### PR TITLE
Feature/keybind text overrides

### DIFF
--- a/core/main.lua
+++ b/core/main.lua
@@ -879,6 +879,11 @@ local defaults = {
             enabled = true,           -- Skin GroupLootHistoryFrame
         },
 
+        -- Keybind Overrides (spell/item ID → custom keybind text, shared across viewers)
+        keybindOverrides = {},
+        keybindOverridesEnabledCDM = true,
+        keybindOverridesEnabledTrackers = true,
+
         -- FPS Settings Backup (stores user's CVars before applying Quazii's settings)
         fpsBackup = nil,
 

--- a/modules/trackers/customtrackers.lua
+++ b/modules/trackers/customtrackers.lua
@@ -1132,18 +1132,26 @@ local function ApplyKeybindToTrackerIcon(icon)
         return
     end
 
+    -- Check tracker overrides toggle
+    local trackersOverridesEnabled = true
+    if db then
+        trackersOverridesEnabled = db.keybindOverridesEnabledTrackers ~= false
+    end
+
+    -- Use centralized API for overrides
+    local overrides = trackersOverridesEnabled and QUIKeybinds.GetOverrides and QUIKeybinds.GetOverrides() or nil
+
     if entry.type == "spell" and entry.id then
         -- Step 1: Check for user override (highest priority)
-        local overrides = db and db.keybindOverrides
         if overrides and overrides[entry.id] and overrides[entry.id] ~= "" then
             keybind = overrides[entry.id]
         end
-        
+
         -- Step 2: Try auto-detected cache by spell ID
         if not keybind then
             keybind = QUIKeybinds.GetKeybindForSpell(entry.id)
         end
-        
+
         -- Step 3: Try spell name fallback (for macros)
         if not keybind and QUIKeybinds.GetKeybindForSpellName then
             local spellInfo = C_Spell.GetSpellInfo(entry.id)
@@ -1154,19 +1162,18 @@ local function ApplyKeybindToTrackerIcon(icon)
     elseif entry.type == "item" and entry.id then
         -- Step 1: Check for user override (highest priority)
         -- Items use negative itemID as key to avoid conflicts with spellIDs
-        local overrides = db and db.keybindOverrides
         if overrides then
             local overrideKey = -entry.id
             if overrides[overrideKey] and overrides[overrideKey] ~= "" then
                 keybind = overrides[overrideKey]
             end
         end
-        
+
         -- Step 2: Try auto-detected cache by item ID
         if not keybind then
             keybind = QUIKeybinds.GetKeybindForItem(entry.id)
         end
-        
+
         -- Step 3: Try item name fallback (for macros)
         if not keybind and QUIKeybinds.GetKeybindForItemName then
             local itemName = C_Item.GetItemInfo(entry.id)


### PR DESCRIPTION
# Add manual keybind override for CDM spells and Custom Tracker items

## Problem
Auto-detection of keybinds for spells and items in macros can be expensive and complex, sometimes resulting in missing or incorrect keybind displays on Cooldown Manager (CDM) icons and Custom Tracker bars. This is particularly problematic when spells/items are used through macros, as the detection logic needs to parse macro bodies and match names, which can fail in various edge cases.

## Solution
This PR adds a manual override system that allows users to explicitly set the keybind text for any spell (CDM) or item/spell (Custom Trackers). Users can:

1. **Drag and drop spells** from their spellbook into a dedicated drop zone
2. **Drag and drop items** from their bags into the same drop zone
3. **Manually enter keybind text** for each spell/item they want to override
4. **View all overridden entries** in a list with icons, names, and IDs (distinguishing between spells and items)
5. **Edit or remove overrides** individually

The override system takes priority over auto-detection, ensuring that user-defined keybinds are always displayed correctly.

## Implementation Details

### Database Structure
- Added `db.profile.keybindOverrides` table:
  - Spells: `[spellID] = "keybind text"` (positive keys)
  - Items: `[-itemID] = "keybind text"` (negative keys to avoid conflicts)
- Overrides are shared across all CDM viewers (Essential and Utility) and Custom Tracker bars

### Keybind Resolution Priority

**For CDM Spells:**
1. **User override** (by spellID/baseSpellID) - highest priority
2. Auto-detected cache by spell ID/base spell
3. Auto-detected cache by spell name (macro fallback)

**For Custom Tracker Spells:**
1. **User override** (by spellID) - highest priority
2. Auto-detected cache by spell ID
3. Auto-detected cache by spell name (macro fallback)

**For Custom Tracker Items:**
1. **User override** (by itemID, stored as negative key) - highest priority
2. Auto-detected cache by item ID
3. Auto-detected cache by item name (macro fallback)

### UI Features
- Drag-and-drop zone for adding spells and items
- List view showing:
  - Spell/item icon (24x24)
  - Entry type, name and ID (e.g., "Spell: Fireball (133)" or "Item: Health Potion (5512)")
  - Editable keybind text input
  - Save button per entry
  - Remove button (X) per entry
- Real-time list refresh when entries are added/removed
- Items are displayed first, then spells (sorted by ID within each type)

### API
- `QUI.Keybinds.SetOverride(viewerName, spellID, keybindText)` - Set or clear spell override
- `QUI.Keybinds.SetOverrideForItem(itemID, keybindText)` - Set or clear item override
- `QUI.Keybinds.GetOverrideForItem(itemID)` - Get item override
- `QUI.Keybinds.ClearAllOverrides(viewerName)` - Clear all overrides (spells and items)
- Global functions: 
  - `_G.QUI_SetKeybindOverride` (spells)
  - `_G.QUI_SetKeybindOverrideForItem` (items)
  - `_G.QUI_ClearAllKeybindOverrides`

## Files Changed
- `modules/utility/keybinds.lua` - Core override logic and API (spells and items)
- `modules/trackers/customtrackers.lua` - Apply override logic to Custom Tracker icons
- `options/tabs/utility/keybinds.lua` - UI for managing overrides (spells and items)
- `core/main.lua` - Database initialization (implicit, via profile defaults)

## Testing
- [x] Drag spells from spellbook to drop zone
- [x] Drag items from bags to drop zone
- [x] Edit keybind text for existing overrides
- [x] Remove individual overrides
- [x] Verify overrides take priority over auto-detection
- [x] Verify overrides persist across reloads
- [x] Verify spell overrides work on both Essential and Utility CDM viewers
- [x] Verify item/spell overrides work on Custom Tracker bars
