### PR TITLE
[feat] added ilvl tracking for blizz inspect frame

### DIFF
--- a/options/tabs/character/character.lua
+++ b/options/tabs/character/character.lua
@@ -70,7 +70,7 @@ local function BuildCharacterPaneTab(tabContent)
     inspectHeader:SetPoint("TOPLEFT", PADDING, y)
     y = y - inspectHeader.gap
 
-    local inspectDesc = GUI:CreateLabel(tabContent, "Apply the same overlays and stats panel to the Inspect frame when inspecting other players.", 11, C.textMuted)
+    local inspectDesc = GUI:CreateLabel(tabContent, "Apply overlays to the Inspect frame when inspecting other players. Use Lite Mode only for Blizzard UI for minimal centered iLvL numbers.", 11, C.textMuted)
     inspectDesc:SetPoint("TOPLEFT", PADDING, y)
     inspectDesc:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
     inspectDesc:SetJustifyH("LEFT")
@@ -80,12 +80,109 @@ local function BuildCharacterPaneTab(tabContent)
 
     if char.inspectEnabled == nil then char.inspectEnabled = true end
 
+    -- Initialize lite mode defaults
+    if char.inspectLiteMode == nil then char.inspectLiteMode = false end
+    if char.inspectLiteShowOverall == nil then char.inspectLiteShowOverall = true end
+    if char.inspectLiteShowPerSlot == nil then char.inspectLiteShowPerSlot = true end
+    if char.inspectLiteFontSize == nil then char.inspectLiteFontSize = 15 end
+    if char.inspectLiteOverallFontSize == nil then char.inspectLiteOverallFontSize = 11 end
+    if char.inspectLiteOverallOffsetX == nil then char.inspectLiteOverallOffsetX = 0 end
+    if char.inspectLiteOverallOffsetY == nil then char.inspectLiteOverallOffsetY = -8 end
+
+    -- Store widget refs for lite mode (enabled when inspect overlays OFF)
+    local liteModeWidgets = {}
+
+    -- Refresh callback for lite mode settings
+    local function RefreshInspectLite()
+        local shared = ns.QUI.CharacterShared
+        if shared and shared.ScheduleUpdate then
+            shared.ScheduleUpdate()
+        end
+    end
+
+    -- Helper to update enable states based on inspect overlays toggle
+    local function UpdateLiteModeWidgetStates()
+        local overlaysOn = char.inspectEnabled
+        -- Lite mode widgets: enabled when overlays OFF
+        for _, widget in pairs(liteModeWidgets) do
+            if widget and widget.SetEnabled then
+                widget:SetEnabled(not overlaysOn)
+            end
+        end
+        -- If overlays are enabled, turn off lite mode
+        if overlaysOn and char.inspectLiteMode then
+            char.inspectLiteMode = false
+            if liteModeWidgets.liteToggle and liteModeWidgets.liteToggle.cb then
+                liteModeWidgets.liteToggle.cb:SetChecked(false)
+            end
+        end
+        -- If overlays are disabled, turn on lite mode
+        if not overlaysOn and not char.inspectLiteMode then
+            char.inspectLiteMode = true
+            if liteModeWidgets.liteToggle and liteModeWidgets.liteToggle.cb then
+                liteModeWidgets.liteToggle.cb:SetChecked(true)
+            end
+        end
+    end
+
     local inspectEnabled = GUI:CreateFormCheckbox(tabContent, "Enable Inspect Overlays", "inspectEnabled", char, function()
         print("|cFF56D1FFQUI:|r Inspect overlay change requires /reload to take effect.")
+        UpdateLiteModeWidgetStates()
     end)
     inspectEnabled:SetPoint("TOPLEFT", PADDING, y)
     inspectEnabled:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
     y = y - FORM_ROW
+
+    local inspectLiteMode = GUI:CreateFormCheckbox(tabContent, "Enable Inspect iLvL Display", "inspectLiteMode", char, RefreshInspectLite)
+    inspectLiteMode:SetPoint("TOPLEFT", PADDING, y)
+    inspectLiteMode:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.liteToggle = inspectLiteMode
+    y = y - FORM_ROW
+
+    -- Show Overall Average iLvL
+    local liteOverall = GUI:CreateFormCheckbox(tabContent, "Show Overall Average iLvL", "inspectLiteShowOverall", char, RefreshInspectLite)
+    liteOverall:SetPoint("TOPLEFT", PADDING, y)
+    liteOverall:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.showOverall = liteOverall
+    y = y - FORM_ROW
+
+    -- Overall iLvL Font Size
+    local overallFontSize = GUI:CreateFormSlider(tabContent, "Overall iLvL Font Size", 8, 24, 1, "inspectLiteOverallFontSize", char, RefreshInspectLite)
+    overallFontSize:SetPoint("TOPLEFT", PADDING, y)
+    overallFontSize:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.overallFontSize = overallFontSize
+    y = y - FORM_ROW
+
+    -- Overall iLvL X Offset
+    local overallOffsetX = GUI:CreateFormSlider(tabContent, "Overall iLvL X Offset", -100, 100, 1, "inspectLiteOverallOffsetX", char, RefreshInspectLite)
+    overallOffsetX:SetPoint("TOPLEFT", PADDING, y)
+    overallOffsetX:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.overallOffsetX = overallOffsetX
+    y = y - FORM_ROW
+
+    -- Overall iLvL Y Offset
+    local overallOffsetY = GUI:CreateFormSlider(tabContent, "Overall iLvL Y Offset", -100, 100, 1, "inspectLiteOverallOffsetY", char, RefreshInspectLite)
+    overallOffsetY:SetPoint("TOPLEFT", PADDING, y)
+    overallOffsetY:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.overallOffsetY = overallOffsetY
+    y = y - FORM_ROW
+
+    -- Show Per-Slot iLvL
+    local litePerSlot = GUI:CreateFormCheckbox(tabContent, "Show Per-Slot iLvL", "inspectLiteShowPerSlot", char, RefreshInspectLite)
+    litePerSlot:SetPoint("TOPLEFT", PADDING, y)
+    litePerSlot:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.showPerSlot = litePerSlot
+    y = y - FORM_ROW
+
+    -- Per-Slot Font Size
+    local liteFontSize = GUI:CreateFormSlider(tabContent, "Per-Slot Font Size", 8, 24, 1, "inspectLiteFontSize", char, RefreshInspectLite)
+    liteFontSize:SetPoint("TOPLEFT", PADDING, y)
+    liteFontSize:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)
+    liteModeWidgets.perSlotFontSize = liteFontSize
+    y = y - FORM_ROW
+
+    -- Set initial enable/disable states
+    UpdateLiteModeWidgetStates()
 
     y = y - 10
 


### PR DESCRIPTION
Hi, I'm a huge fan of QUI and one of my friends is using it but doesn't like the QUI inspect frame skinning so I've added the iLvL work into my own fork. Since this is the community edition for QUI, I wanted to move away from my own fork and use this one. 

I've added the code that I've added from my own fork into this addon. Please let me know if there are any feedback. Thank you.

Screenshots: 
Blizzard Frame
<img width="349" height="431" alt="Blizz Char Frame" src="https://github.com/user-attachments/assets/f04444fb-2b89-4a1a-a78a-637ca64f98a2" />

Settings in QUI:
<img width="689" height="771" alt="QUI Settings" src="https://github.com/user-attachments/assets/66772510-81a1-4617-872e-f0d4cbe364ff" />

If you enable the skinning via Enable Inspect Overlays, it will disable the blizzard options:
<img width="521" height="397" alt="QUI Settings - Disabled" src="https://github.com/user-attachments/assets/3ec69235-3b3c-4f41-bb51-fe23c6d1de93" />