### PR TITLE
Refactor keybind management to support character and specialization specific storage

### DIFF
--- a/core/main.lua
+++ b/core/main.lua
@@ -918,8 +918,7 @@ local defaults = {
             enabled = true,           -- Skin GroupLootHistoryFrame
         },
 
-        -- Keybind Overrides (spell/item ID → custom keybind text, shared across viewers)
-        keybindOverrides = {},
+        -- Keybind Overrides (stored per character/spec in db.char.keybindOverrides[specID])
         keybindOverridesEnabledCDM = true,
         keybindOverridesEnabledTrackers = true,
 

--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -72,11 +72,33 @@ local function GetViewerSettings(viewerName)
     return viewers[viewerName]
 end
 
--- Helper: get shared keybind overrides from DB (shared across all viewers)
+-- Helper: get current specialization ID
+local function GetCurrentSpecID()
+    local specIndex = GetSpecialization()
+    if not specIndex then return 0 end
+    local specID = GetSpecializationInfo(specIndex)
+    return specID or 0
+end
+
+-- Helper: get shared keybind overrides from DB (character and spec-specific)
 local function GetSharedOverrides()
     local QUICore = _G.QUI and _G.QUI.QUICore
-    if not QUICore or not QUICore.db or not QUICore.db.profile then return nil end
-    return QUICore.db.profile.keybindOverrides
+    if not QUICore or not QUICore.db or not QUICore.db.char then return nil end
+    
+    local specID = GetCurrentSpecID()
+    if specID == 0 then return nil end
+    
+    -- Initialize char.keybindOverrides if needed
+    if not QUICore.db.char.keybindOverrides then
+        QUICore.db.char.keybindOverrides = {}
+    end
+    
+    -- Initialize spec-specific table if needed
+    if not QUICore.db.char.keybindOverrides[specID] then
+        QUICore.db.char.keybindOverrides[specID] = {}
+    end
+    
+    return QUICore.db.char.keybindOverrides[specID]
 end
 
 -- Helper: get an override keybind, if any, for a given spell/baseSpell (shared across viewers)
@@ -1086,14 +1108,22 @@ local function SetKeybindOverride(spellID, keybindText)
     if not spellID or spellID <= 0 then return end
 
     local QUICore = _G.QUI and _G.QUI.QUICore
-    if not QUICore or not QUICore.db or not QUICore.db.profile then return end
+    if not QUICore or not QUICore.db or not QUICore.db.char then return end
 
-    -- Initialize shared overrides table if needed
-    if not QUICore.db.profile.keybindOverrides then
-        QUICore.db.profile.keybindOverrides = {}
+    local specID = GetCurrentSpecID()
+    if specID == 0 then return end
+
+    -- Initialize char.keybindOverrides if needed
+    if not QUICore.db.char.keybindOverrides then
+        QUICore.db.char.keybindOverrides = {}
+    end
+    
+    -- Initialize spec-specific table if needed
+    if not QUICore.db.char.keybindOverrides[specID] then
+        QUICore.db.char.keybindOverrides[specID] = {}
     end
 
-    local overrides = QUICore.db.profile.keybindOverrides
+    local overrides = QUICore.db.char.keybindOverrides[specID]
 
     if keybindText == nil then
         -- Explicitly remove override (user clicked X)
@@ -1141,14 +1171,22 @@ local function SetKeybindOverrideForItem(itemID, keybindText)
     if not itemID or itemID <= 0 then return end
 
     local QUICore = _G.QUI and _G.QUI.QUICore
-    if not QUICore or not QUICore.db or not QUICore.db.profile then return end
+    if not QUICore or not QUICore.db or not QUICore.db.char then return end
 
-    -- Initialize shared overrides table if needed
-    if not QUICore.db.profile.keybindOverrides then
-        QUICore.db.profile.keybindOverrides = {}
+    local specID = GetCurrentSpecID()
+    if specID == 0 then return end
+
+    -- Initialize char.keybindOverrides if needed
+    if not QUICore.db.char.keybindOverrides then
+        QUICore.db.char.keybindOverrides = {}
+    end
+    
+    -- Initialize spec-specific table if needed
+    if not QUICore.db.char.keybindOverrides[specID] then
+        QUICore.db.char.keybindOverrides[specID] = {}
     end
 
-    local overrides = QUICore.db.profile.keybindOverrides
+    local overrides = QUICore.db.char.keybindOverrides[specID]
     local key = -itemID -- Use negative itemID as key
 
     if keybindText == nil then


### PR DESCRIPTION
# Keybind Overrides: Character and Specialization-Specific Storage

## Summary

This PR changes the keybind override system to store overrides per character and specialization instead of per profile. This makes it much more manageable for players who use multiple characters (alts), as each character and specialization now has its own independent list of overrides.

## Problem

Previously, keybind overrides were stored at the profile level (`db.profile.keybindOverrides`), which meant all characters sharing the same profile would see the same overrides. This was problematic for players who:
- Play multiple characters (alts)
- Use different keybinds for different characters
- Want different overrides for different specializations

## Solution

Overrides are now stored per character and specialization in `db.char.keybindOverrides[specID]`:
- Each character has its own override storage
- Each specialization within a character has its own override list
- The UI displays which character and specialization the overrides belong to
- The list automatically refreshes when the player changes specializations

## Changes

### Core Changes

1. **Database Structure** (`core/main.lua`)
   - Removed `keybindOverrides` initialization from profile defaults
   - Overrides are now stored in `db.char.keybindOverrides[specID]` (created on-demand)

2. **Keybind Module** (`modules/utility/keybinds.lua`)
   - Added `GetCurrentSpecID()` helper function to get the current specialization ID
   - Modified `GetSharedOverrides()` to read from `db.char.keybindOverrides[specID]`
   - Updated `SetKeybindOverride()` to save to character/spec-specific storage
   - Updated `SetKeybindOverrideForItem()` to save to character/spec-specific storage

3. **Options UI** (`options/tabs/utility/keybinds.lua`)
   - Added `UpdateSpecInfo()` function to refresh specialization information
   - Added `GetCurrentSpecOverrides()` helper to get current spec's override table
   - Updated all database references from `db.profile.keybindOverrides` to `db.char.keybindOverrides[specID]`
   - Added header display showing "Overrides for [Character Name], [Spec Name] spec"
   - Added `PLAYER_SPECIALIZATION_CHANGED` event listener to auto-refresh the list on spec change
   - Fixed item info retrieval to use correct `C_Item.GetItemInfo` return values (multiple values, not object)

### Technical Details

- **Storage Key Format**: 
  - Spells: Positive spellID (e.g., `12345`)
  - Items: Negative itemID (e.g., `-67890`)
  
- **Specialization Detection**: Uses `GetSpecialization()` and `GetSpecializationInfo()` to get current spec ID and name

- **Event Handling**: Uses persistent event listener frame that updates callback per tab build

- **UI Refresh**: When specialization changes:
  1. Spec info is updated (`UpdateSpecInfo()`)
  2. Header text is refreshed with new spec name
  3. Override list is reloaded from new spec's storage

## Migration

No migration needed - existing profile-level overrides will simply not be accessible. Users will need to recreate their overrides per character/spec, but this is intentional as the old system was not suitable for multi-character usage.
