### PR TITLE
Fix mail icon not showing on minimap by default

### DIFF
--- a/core/main.lua
+++ b/core/main.lua
@@ -2744,7 +2744,7 @@ local defaults = {
             
             -- Button Visibility
             showZoomButtons = false,
-            showMail = false,
+            showMail = true,
             showCraftingOrder = false,
             showAddonCompartment = false,
             showDifficulty = false,


### PR DESCRIPTION
## Summary
- The default value for `showMail` was `false`, causing the new mail indicator to be hidden on the minimap for all users who haven't explicitly enabled it
- Changed the default to `true` so the mail icon is visible out of the box

Fixes #202