### PR TITLE
Fix remaining CDM taint: defer hooksecurefunc work to next frame

### DIFF
--- a/modules/cooldowns/cdm_viewer.lua
+++ b/modules/cooldowns/cdm_viewer.lua
@@ -147,8 +147,10 @@ local function StripBlizzardOverlay(icon)
                 region:SetTexture("")
                 region:Hide()
                 hooksecurefunc(region, "Show", function(self)
-                    if InCombatLockdown() then return end
-                    self:Hide()
+                    C_Timer.After(0, function()
+                        if InCombatLockdown() then return end
+                        self:Hide()
+                    end)
                 end)
             end
         end
@@ -165,9 +167,11 @@ local function PreventAtlasBorder(texture)
     -- Hook future SetAtlas calls to block border re-application
     if texture.SetAtlas then
         hooksecurefunc(texture, "SetAtlas", function(self)
-            if InCombatLockdown() then return end
-            if self.SetTexture then self:SetTexture(nil) end
-            if self.SetAlpha then self:SetAlpha(0) end
+            C_Timer.After(0, function()
+                if InCombatLockdown() then return end
+                if self.SetTexture then self:SetTexture(nil) end
+                if self.SetAlpha then self:SetAlpha(0) end
+            end)
         end)
     end
     -- Clear current state
@@ -322,8 +326,10 @@ local function SkinIcon(icon, size, aspectRatioCrop, zoom, borderSize, borderCol
             if not icon.CooldownFlash._ncdmHooked then
                 icon.CooldownFlash._ncdmHooked = true
                 hooksecurefunc(icon.CooldownFlash, "Show", function(self)
-                    if InCombatLockdown() then return end
-                    self:SetAlpha(0)
+                    C_Timer.After(0, function()
+                        if InCombatLockdown() then return end
+                        self:SetAlpha(0)
+                    end)
                 end)
             end
         end

--- a/modules/cooldowns/effects.lua
+++ b/modules/cooldowns/effects.lua
@@ -36,9 +36,11 @@ local function HideCooldownEffects(child)
                 -- Hook Show to prevent it from showing
                 if frame.Show then
                     hooksecurefunc(frame, "Show", function(self)
-                        if InCombatLockdown() then return end
-                        self:Hide()
-                        self:SetAlpha(0)
+                        C_Timer.After(0, function()
+                            if InCombatLockdown() then return end
+                            self:Hide()
+                            self:SetAlpha(0)
+                        end)
                     end)
                 end
                 

--- a/modules/cooldowns/glows.lua
+++ b/modules/cooldowns/glows.lua
@@ -114,8 +114,11 @@ local function SuppressBlizzardGlow(icon)
             if not alert._QUI_NoShow then
                 alert._QUI_NoShow = true
                 hooksecurefunc(alert, "Show", function(self)
-                    self:Hide()
-                    self:SetAlpha(0)
+                    C_Timer.After(0, function()
+                        if InCombatLockdown() then return end
+                        self:Hide()
+                        self:SetAlpha(0)
+                    end)
                 end)
             end
         end
@@ -128,8 +131,11 @@ local function SuppressBlizzardGlow(icon)
             if not icon.OverlayGlow._QUI_NoShow then
                 icon.OverlayGlow._QUI_NoShow = true
                 hooksecurefunc(icon.OverlayGlow, "Show", function(self)
-                    self:Hide()
-                    self:SetAlpha(0)
+                    C_Timer.After(0, function()
+                        if InCombatLockdown() then return end
+                        self:Hide()
+                        self:SetAlpha(0)
+                    end)
                 end)
             end
         end


### PR DESCRIPTION
## Summary
- Fixes 6 remaining `hooksecurefunc` hooks that still ran synchronous UI work (`Hide`, `SetTexture`, `SetAlpha`) inside Blizzard's CooldownViewer execution context
- The v2.36 fix correctly deferred `OnSizeChanged`, but the `SetAtlas` hook on border textures and `Show` hooks on overlays/glows still taint the call stack during `UNIT_AURA` processing
- Wraps all synchronous hook bodies in `C_Timer.After(0, ...)` to break out of Blizzard's execution context, preventing taint propagation

## Hooks Fixed

| File | Hook Target | Was doing synchronously |
|------|------------|------------------------|
| `cdm_viewer.lua` | `region:Show()` (overlay) | `self:Hide()` |
| `cdm_viewer.lua` | `texture:SetAtlas()` (borders) | `SetTexture(nil)`, `SetAlpha(0)` |
| `cdm_viewer.lua` | `CooldownFlash:Show()` | `SetAlpha(0)` |
| `effects.lua` | Effect frames `Show()` | `self:Hide()`, `SetAlpha(0)` |
| `glows.lua` | `SpellActivationAlert:Show()` | `self:Hide()`, `SetAlpha(0)` |
| `glows.lua` | `OverlayGlow:Show()` | `self:Hide()`, `SetAlpha(0)` |

## Root Cause
`hooksecurefunc` handlers share the caller's execution context. When Blizzard's `OnUnitAura` -> `NeedsAddedAuraUpdate` -> `UpdateLinkedSpell` path triggers `SetAtlas` on a border texture (or `Show` on an overlay), QUI's synchronous calls taint the entire call stack, causing `spellID` values to become "secret number values tainted by QUI".

Fixes #190