### PR TITLE
Optimize OnUpdate handling across multiple modules to reduce CPU usage

### DIFF
--- a/core/main.lua
+++ b/core/main.lua
@@ -186,13 +186,14 @@ function QUICore.SafeSetBackdrop(frame, backdropInfo, borderColor)
                     QUICore.__pendingBackdrops[pf] = nil
                 end
 
-                -- Stop OnUpdate if no more pending
+                -- Stop OnUpdate if no more pending (SetScript nil to avoid per-frame CPU cost)
                 local hasAny = false
                 for _ in pairs(QUICore.__pendingBackdrops or {}) do
                     hasAny = true
                     break
                 end
                 if not hasAny then
+                    self:SetScript("OnUpdate", nil)
                     self:Hide()
                 end
             end)

--- a/modules/cooldowns/cdm_viewer.lua
+++ b/modules/cooldowns/cdm_viewer.lua
@@ -1408,8 +1408,11 @@ local function HookViewer(viewerName, trackerKey)
 
     -- Step 1 & 3: OnShow hook - enable polling and single deferred layout
     viewer:HookScript("OnShow", function(self)
-        -- Enable polling when viewer becomes visible
+        -- Enable polling when viewer becomes visible (restore handler if we cleared it on Hide)
         if self.__ncdmUpdateFrame then
+            if self.__ncdmUpdateHandler then
+                self.__ncdmUpdateFrame:SetScript("OnUpdate", self.__ncdmUpdateHandler)
+            end
             self.__ncdmUpdateFrame:Show()
         end
         -- Single deferred layout
@@ -1424,9 +1427,10 @@ local function HookViewer(viewerName, trackerKey)
         end)
     end)
 
-    -- Step 1: OnHide hook - disable polling to save CPU
+    -- Step 1: OnHide hook - disable polling to save CPU (SetScript nil stops OnUpdate entirely)
     viewer:HookScript("OnHide", function(self)
         if self.__ncdmUpdateFrame then
+            self.__ncdmUpdateFrame:SetScript("OnUpdate", nil)
             self.__ncdmUpdateFrame:Hide()
         end
     end)
@@ -1540,6 +1544,7 @@ local function HookViewer(viewerName, trackerKey)
             LayoutViewer(viewerName, trackerKey)
         end
     end)
+    viewer.__ncdmUpdateHandler = updateFrame:GetScript("OnUpdate")
 
     -- Step 1: Initially show update frame only if viewer is visible
     if viewer:IsShown() then

--- a/modules/frames/actionbars.lua
+++ b/modules/frames/actionbars.lua
@@ -1614,10 +1614,13 @@ local function StartBarFade(barKey, targetAlpha)
             end
 
             if not anyFading then
+                self:SetScript("OnUpdate", nil)
                 self:Hide()
             end
         end)
+        ActionBars.fadeFrameUpdate = ActionBars.fadeFrame:GetScript("OnUpdate")
     end
+    ActionBars.fadeFrame:SetScript("OnUpdate", ActionBars.fadeFrameUpdate)
     ActionBars.fadeFrame:Show()
 end
 


### PR DESCRIPTION
## Changes by Module

### 1. `modules/cooldowns/swipe.lua`

**Issue:** A dedicated frame used `SetScript("OnUpdate", ...)` which fired every frame (~60–120 times/second). Its logic (throttled to 0.12s) only did meaningful work occasionally, but the handler was still invoked every frame.

**Change:** Replaced `OnUpdate` with `C_Timer.NewTicker(0.12, fn)`.

- **Before:** Per-frame execution for the entire session.
- **After:** ~8 invocations per second via ticker.
- **Impact:** Significant reduction in CPU usage for cooldown swipe updates.

### 2. `core/main.lua` – Backdrop Update Frame

**Issue:** When the pending backdrops queue became empty, the update frame was only hidden with `Hide()`. The `OnUpdate` script remained attached, so it could keep running.

**Change:** When there are no more pending backdrops, `SetScript("OnUpdate", nil)` is called before `Hide()`.

- **Effect:** The handler is fully removed when no longer needed, stopping any further CPU cost.

### 3. `modules/cooldowns/cdm_viewer.lua` – Update Frame Polling

**Issue:** On viewer hide, `__ncdmUpdateFrame` was only hidden. The `OnUpdate` script stayed active, potentially continuing to run.

**Change:**

- **OnHide:** Call `SetScript("OnUpdate", nil)` before `Hide()` to fully stop the handler.
- **OnShow:** Restore the handler with `SetScript("OnUpdate", self.__ncdmUpdateHandler)` when the viewer is shown again.
- Store the handler in `viewer.__ncdmUpdateHandler` during setup so it can be reattached.

- **Effect:** No polling when the CDM viewer is hidden.

### 4. `modules/frames/actionbars.lua` – Fade Frame

**Issue:** When no bars were fading, only `Hide()` was called. The fade frame’s `OnUpdate` script was never cleared.

**Change:**

- When `anyFading` becomes false: call `SetScript("OnUpdate", nil)` before `Hide()`.
- Store the handler in `ActionBars.fadeFrameUpdate` so it can be reattached.
- On each new fade: set the script again with `SetScript("OnUpdate", ActionBars.fadeFrameUpdate)` before showing the frame.

- **Effect:** No OnUpdate execution when no action bar fade is in progress.