### PR TITLE
fix: prevent Edit Mode taint from anchoring to hidden system frames

### DIFF
--- a/modules/utility/anchoring.lua
+++ b/modules/utility/anchoring.lua
@@ -1505,6 +1505,20 @@ function QUI_Anchoring:ApplyFrameAnchor(key, settings)
     end
 
     local parentFrame = ResolveParentFrame(settings.parent)
+
+    -- Skip repositioning when the parent is a hidden Blizzard Edit Mode system
+    -- frame (e.g. StanceBar anchored to PetActionBar when there is no pet).
+    -- Anchoring a secure frame to a hidden secure frame via SetPoint from addon
+    -- code taints the anchor chain; when Edit Mode reads it in the secure context
+    -- the taint propagates and causes "secret number tainted by QUI" errors.
+    -- Leave the frame at Blizzard's default position instead.
+    if parentFrame and parentFrame ~= UIParent then
+        local parentIsBlizzSystem = parentFrame.system ~= nil or parentFrame.systemIndex ~= nil
+        if parentIsBlizzSystem and parentFrame.IsShown and not parentFrame:IsShown() then
+            return
+        end
+    end
+    
     local point = settings.point or "CENTER"
     local relative = settings.relative or "CENTER"
     local offsetX = settings.offsetX or 0


### PR DESCRIPTION
## Summary
- Skip repositioning when a frame's anchor parent is a hidden Blizzard Edit Mode system frame (e.g. StanceBar anchored to PetActionBar when there is no pet)
- Anchoring a secure frame to a hidden secure frame via SetPoint from addon context taints the anchor chain, causing "secret number tainted by QUI" errors when Edit Mode reads it in the secure context
- The frame is left at Blizzard's default position instead, avoiding the taint propagation entirely

## Test plan
- [ ] On a Druid (no pet), anchor StanceBar to PetActionBar in QUI settings
- [ ] Enter Edit Mode — verify no taint errors appear
- [ ] Verify StanceBar is visible at its default position
- [ ] On a class with a pet, verify anchoring still works normally