### PR TITLE
fix: propagate non-arrow keyboard input during Edit Mode

### DIFF
--- a/core/main.lua
+++ b/core/main.lua
@@ -3789,6 +3789,7 @@ end
 
 EditModeKeyHandler:SetScript("OnKeyDown", function(self, key)
     if not QUICore.EditModeSelection or not QUICore.EditModeSelection.selectedType then
+        self:SetPropagateKeyboardInput(true)
         return
     end
 

--- a/modules/frames/castbar.lua
+++ b/modules/frames/castbar.lua
@@ -3678,14 +3678,24 @@ local function ShowCastbarEditOverlay(unitKey)
     -- Enable keyboard for arrow key nudging
     castbar:EnableKeyboard(true)
     castbar:SetScript("OnKeyDown", function(self, key)
-        if not EditModeState.active then return end
+        if not EditModeState.active then
+            self:SetPropagateKeyboardInput(true)
+            return
+        end
 
         local deltaX, deltaY = 0, 0
         if key == "LEFT" then deltaX = -1
         elseif key == "RIGHT" then deltaX = 1
         elseif key == "UP" then deltaY = 1
         elseif key == "DOWN" then deltaY = -1
-        else return end  -- Ignore other keys
+        else
+            -- Non-arrow keys: propagate to game (WASD, hotkeys, Escape, etc.)
+            self:SetPropagateKeyboardInput(true)
+            return
+        end
+
+        -- Consume arrow keys so they nudge instead of moving the camera
+        self:SetPropagateKeyboardInput(false)
 
         -- Use global selection system - nudge the SELECTED element, not this castbar
         if QUICore and QUICore.EditModeSelection and QUICore.EditModeSelection.selectedType then

--- a/modules/frames/resourcebars.lua
+++ b/modules/frames/resourcebars.lua
@@ -858,14 +858,24 @@ function QUICore:EnablePowerBarEditMode()
             -- Enable keyboard for arrow key nudging
             bar:EnableKeyboard(true)
             bar:SetScript("OnKeyDown", function(self, key)
-                if not PowerBarEditMode.active then return end
+                if not PowerBarEditMode.active then
+                    self:SetPropagateKeyboardInput(true)
+                    return
+                end
 
                 local deltaX, deltaY = 0, 0
                 if key == "LEFT" then deltaX = -1
                 elseif key == "RIGHT" then deltaX = 1
                 elseif key == "UP" then deltaY = 1
                 elseif key == "DOWN" then deltaY = -1
-                else return end  -- Ignore other keys
+                else
+                    -- Non-arrow keys: propagate to game (WASD, hotkeys, Escape, etc.)
+                    self:SetPropagateKeyboardInput(true)
+                    return
+                end
+
+                -- Consume arrow keys so they nudge instead of moving the camera
+                self:SetPropagateKeyboardInput(false)
 
                 -- Use global selection system - nudge the SELECTED element, not this bar
                 if QUICore and QUICore.EditModeSelection and QUICore.EditModeSelection.selectedType then

--- a/modules/frames/unitframe_editmode.lua
+++ b/modules/frames/unitframe_editmode.lua
@@ -401,14 +401,24 @@ function QUI_UF:EnableEditMode()
             frame:EnableKeyboard(true)
         end
         frame:SetScript("OnKeyDown", function(self, key)
-            if not QUI_UF.editModeActive then return end
+            if not QUI_UF.editModeActive then
+                self:SetPropagateKeyboardInput(true)
+                return
+            end
 
             local deltaX, deltaY = 0, 0
             if key == "LEFT" then deltaX = -1
             elseif key == "RIGHT" then deltaX = 1
             elseif key == "UP" then deltaY = 1
             elseif key == "DOWN" then deltaY = -1
-            else return end  -- Ignore other keys
+            else
+                -- Non-arrow keys: propagate to game (WASD, hotkeys, Escape, etc.)
+                self:SetPropagateKeyboardInput(true)
+                return
+            end
+
+            -- Consume arrow keys so they nudge instead of moving the camera
+            self:SetPropagateKeyboardInput(false)
 
             -- Use global selection system - nudge the SELECTED element, not this frame
             local core = GetCore()


### PR DESCRIPTION
OnKeyDown handlers on unit frames, castbars, and resource bars were consuming ALL keyboard input (WASD, hotkeys, Escape, etc.) because SetPropagateKeyboardInput(true) was never called for non-arrow keys. Only arrow keys should be consumed for nudging; everything else must pass through to the game.


(cherry picked from commit 6600d6a4b17fb1efdd278f05900eb37ae8aa0cae)