### PR TITLE
Queue Status button blocked by overlay frame on minimap

### DIFF
--- a/modules/ui/minimap.lua
+++ b/modules/ui/minimap.lua
@@ -1034,8 +1034,9 @@ local function RestoreDungeonEye()
         end
     end
 
-    -- Reset scale
+    -- Reset scale and strata
     btn:SetScale(1.0)
+    btn:SetFrameStrata("MEDIUM")
 end
 
 local function UpdateDungeonEyePosition()
@@ -1081,6 +1082,8 @@ local function UpdateDungeonEyePosition()
         -- Apply scale
         local scale = eyeSettings.scale or 1.0
         btn:SetScale(scale)
+        btn:SetFrameStrata("MEDIUM")
+
         -- Do NOT call btn:Show() - let Blizzard control visibility based on queue status
     else
         -- Restore original position


### PR DESCRIPTION
## Problem

The queue status (dungeon eye) button on the minimap was not responding to clicks or showing tooltips on mouseover. Frame inspection revealed an overlay frame (`table` layout) above the `QueueStatusButton` that was intercepting mouse input.

## Solution

Set `QueueStatusButton` to `MEDIUM` frame strata when positioned on the minimap. The blocking overlay frame uses `LOW` strata, so `MEDIUM` ensures the button renders above it and receives mouse events correctly.

## Changes

- **`modules/ui/minimap.lua`**:
  - In `UpdateDungeonEyePosition()`: add `btn:SetFrameStrata("MEDIUM")` when the dungeon eye is enabled
  - In `RestoreDungeonEye()`: reset strata to `MEDIUM` when restoring the button to its original parent (for consistency when the feature is disabled)
