### PR TITLE
fix: extra button bouncing in Edit Mode and anchoring sync

### DIFF
--- a/modules/utility/anchoring.lua
+++ b/modules/utility/anchoring.lua
@@ -1802,6 +1802,11 @@ function QUI_Anchoring:ApplyFrameAnchor(key, settings)
     if not settings.enabled then
         if editDbg then AnchorDebug(format("ApplyFrameAnchor(%s): DISABLED", key)) end
         SetFrameOverride(resolved, false)
+        
+        -- Reposition extra buttons back to their holders when anchoring is disabled
+        if (key == "extraActionButton" or key == "zoneAbility") and _G.QUI_RefreshExtraButtons then
+            _G.QUI_RefreshExtraButtons()
+        end
         return
     end
 


### PR DESCRIPTION
- Fix visible bouncing of Zone Ability and Extra Action Button in Edit Mode by using immediate repositioning instead of deferred C_Timer.After
- Honor Frame Anchoring system when enabled: frame follows anchor position, mover shows locked state (grey, no drag, no nudge buttons)
- Honor holder-based positioning when Frame Anchoring disabled: frame follows holder, mover shows unlocked state (mint, draggable)
- Sync mover position to actual frame position when Frame Anchoring enabled
- Reposition frame back to holder when Frame Anchoring is disabled
- Clean up duplicate/orphaned code in HookExtraButtonPositioning