### PR TITLE
fix(character): Fix enchantableSlots

### DIFF
--- a/modules/character/character.lua
+++ b/modules/character/character.lua
@@ -245,9 +245,9 @@ local function GetEnchantText(unit, slotId)
 
     -- Not all slots can be enchanted - only check enchantable slots
     local enchantableSlots = {
+        [INVSLOT_HEAD] = true,
+        [INVSLOT_SHOULDER] = true,
         [INVSLOT_CHEST] = true,
-        [INVSLOT_BACK] = true,
-        [INVSLOT_WRIST] = true,
         [INVSLOT_LEGS] = true,
         [INVSLOT_FEET] = true,
         [INVSLOT_FINGER1] = true,


### PR DESCRIPTION
Cloak and Wrist enchants don't exist in Midnight. Head and Shoulder enchants have been added. Modified the enchantableSlots accordingly.