### PR TITLE
feat: event-driven aura trackers, timer-based essence regen, health v…

### DIFF
--- a/modules/cooldowns/hud_visibility.lua
+++ b/modules/cooldowns/hud_visibility.lua
@@ -15,6 +15,50 @@ local UpdateCDMVisibility
 local UpdateUnitframesVisibility
 
 ---------------------------------------------------------------------------
+-- HEALTH STATE TRACKER
+-- UnitHealth() always returns secret values from addon code in WoW 12.0+
+-- and COMBAT_LOG_EVENT_UNFILTERED is restricted. Use RegisterStateDriver
+-- with a health macro conditional — evaluated in Blizzard's secure code,
+-- completely bypassing addon taint.
+---------------------------------------------------------------------------
+-- HEALTH STATE DETECTION
+-- ALL health APIs return secret values from addon code in WoW 12.0+.
+-- Secret values can't be compared, even inside pcall.
+--
+-- Solution: UNIT_HEALTH fires when health changes. When health is at 100%
+-- and stable, UNIT_HEALTH stops firing. So:
+-- 1. Every UNIT_HEALTH event → set _healthBelowMax = true (health changing)
+-- 2. Start/reset a short timer on each event
+-- 3. When timer expires (no more events) → health stabilized → assume 100%
+--    (natural regen brings health back to max, then UNIT_HEALTH stops)
+---------------------------------------------------------------------------
+local _healthBelowMax = false
+local _healthStableTimer = nil
+local HEALTH_STABLE_DURATION = 3.0  -- seconds after last health event to assume full
+
+local function UpdateHealthState()
+    -- UNIT_HEALTH fired — health is changing, assume below max
+    local wasBelowMax = _healthBelowMax
+    _healthBelowMax = true
+
+    if not wasBelowMax and UpdateUnitframesVisibility then
+        UpdateUnitframesVisibility()
+    end
+
+    -- Reset the stable timer — when health stops changing, assume full
+    if _healthStableTimer then
+        _healthStableTimer:Cancel()
+    end
+    _healthStableTimer = C_Timer.NewTimer(HEALTH_STABLE_DURATION, function()
+        _healthStableTimer = nil
+        _healthBelowMax = false
+        if UpdateUnitframesVisibility then
+            UpdateUnitframesVisibility()
+        end
+    end)
+end
+
+---------------------------------------------------------------------------
 -- SHARED HELPERS
 ---------------------------------------------------------------------------
 
@@ -407,6 +451,11 @@ local function ShouldUnitframesBeVisible()
     local vis = GetUnitframesVisibilitySettings()
     if not vis then return true end
 
+    -- Health < 100% overrides hide rules (uses UNIT_HEALTH event timing)
+    if vis.showWhenHealthBelow100 and _healthBelowMax then
+        return true
+    end
+
     local ignoreHideRules = vis.dontHideInDungeonsRaids and Helpers.IsPlayerInDungeonOrRaid and Helpers.IsPlayerInDungeonOrRaid()
     if not ignoreHideRules then
         if vis.hideWhenMounted and Helpers.IsPlayerMounted() then return false end
@@ -421,7 +470,6 @@ local function ShouldUnitframesBeVisible()
     if vis.showInGroup and IsPlayerInGroup() then return true end
     if vis.showInInstance and IsPlayerInInstance() then return true end
     if vis.showOnMouseover and UnitframesVisibility.mouseOver then return true end
-    if vis.showWhenHealthBelow100 and Helpers.SafeToNumber(UnitHealth("player"), 1) < Helpers.SafeToNumber(UnitHealthMax("player"), 1) then return true end
 
     return false
 end
@@ -611,7 +659,13 @@ visibilityEventFrame:SetScript("OnEvent", function(self, event, ...)
         if unit ~= "player" then return end
     end
 
+    -- Health events — update health state before visibility check
+    if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
+        UpdateHealthState()
+    end
+
     if event == "PLAYER_LOGIN" or event == "PLAYER_ENTERING_WORLD" then
+        UpdateHealthState()
         -- Schedule delayed setup so CDM/UF frames have time to initialize.
         -- PLAYER_LOGIN only fires on first login, NOT on /reload — so we
         -- must also schedule on PLAYER_ENTERING_WORLD to cover reloads.
@@ -620,6 +674,7 @@ visibilityEventFrame:SetScript("OnEvent", function(self, event, ...)
         end
         _pendingSetupTimer = C_Timer.NewTimer(2.0, function()
             _pendingSetupTimer = nil
+            UpdateHealthState()  -- Player healthBar should exist by now
             SetupCDMMouseoverDetector()
             SetupUnitframesMouseoverDetector()
             UpdateCDMVisibility()

--- a/modules/cooldowns/owned/cdm_containers.lua
+++ b/modules/cooldowns/owned/cdm_containers.lua
@@ -621,6 +621,9 @@ local function LayoutContainer(trackerKey)
         vs.cdmProxyYOffset = (actualTop + actualBot) / 2
     end
 
+    -- Save raw content width before min-width inflation (used by resource bars)
+    local rawContentWidth = maxRowWidth
+
     -- HUD min-width floor
     local minWidthEnabled, minWidth = GetHUDMinWidth()
     local applyHUDMinWidth = minWidthEnabled and IsHUDAnchoredToCDM()
@@ -699,6 +702,7 @@ local function LayoutContainer(trackerKey)
 
     -- Store dimensions in viewer state
     vs.cdmIconWidth = maxRowWidth
+    vs.cdmRawContentWidth = rawContentWidth
     vs.cdmTotalHeight = proxyTotalHeight
 
     -- Persist for next reload
@@ -909,6 +913,7 @@ local function GetViewerState(viewer)
         _stateSnapshots[viewer] = snap
     end
     snap.iconWidth              = vs.cdmIconWidth
+    snap.rawContentWidth        = vs.cdmRawContentWidth
     snap.totalHeight            = vs.cdmTotalHeight
     snap.row1Width              = vs.cdmRow1Width
     snap.bottomRowWidth         = vs.cdmBottomRowWidth

--- a/modules/frames/resourcebars.lua
+++ b/modules/frames/resourcebars.lua
@@ -172,6 +172,270 @@ Enum.PowerType.MaelstromWeapon = 100
 Enum.PowerType.VengSoulFragments = 101
 Enum.PowerType.Whirlwind = 102       -- Fury Warrior Improved Whirlwind stacks
 Enum.PowerType.TipOfTheSpear = 103   -- Survival Hunter Tip of the Spear stacks
+
+---------------------------------------------------------------------------
+-- WHIRLWIND STACK TRACKER (event-driven)
+--
+-- C_UnitAuras.GetPlayerAuraBySpellID(85739) is unreliable during combat.
+-- Track stacks manually via UNIT_SPELLCAST_SUCCEEDED: generators set to max,
+-- spenders decrement.
+---------------------------------------------------------------------------
+local WhirlwindTracker = {}
+do
+    local IW_MAX_STACKS = 4
+    local IW_DURATION   = 20
+    local IMPROVED_WW_TALENT = 12950
+
+    -- Generators: set stacks to max
+    local GENERATORS = {
+        [190411] = true,  -- Whirlwind
+        [6343]   = true,  -- Thunder Clap
+        [435222] = true,  -- Thunder Blast
+    }
+    -- Thunder Clap/Blast require Crashing Thunder talent
+    local CRASHING_THUNDER_TALENT = 436707
+
+    -- Spenders: consume one stack
+    local SPENDERS = {
+        [23881]  = true,  -- Bloodthirst
+        [85288]  = true,  -- Raging Blow
+        [280735] = true,  -- Execute
+        [202168] = true,  -- Impending Victory
+        [184367] = true,  -- Rampage
+        [335096] = true,  -- Bloodbath
+        [335097] = true,  -- Crushing Blow
+        [5308]   = true,  -- Execute (base)
+    }
+    -- Unhinged: BT/Bloodbath don't consume during Bladestorm
+    local UNHINGED_TALENT = 386628
+
+    local stacks    = 0
+    local expiresAt = nil
+    local seenGUID  = {}
+    local pendingToken = 0
+
+    function WhirlwindTracker:GetStacks()
+        -- Expire stale stacks
+        if expiresAt and GetTime() >= expiresAt then
+            stacks = 0
+            expiresAt = nil
+        end
+        -- Check talent
+        if not C_SpellBook or not C_SpellBook.IsSpellKnown(IMPROVED_WW_TALENT) then
+            return nil, 0  -- talent not learned
+        end
+        return IW_MAX_STACKS, stacks
+    end
+
+    function WhirlwindTracker:Reset()
+        stacks = 0
+        expiresAt = nil
+        seenGUID = {}
+        pendingToken = pendingToken + 1
+    end
+
+    function WhirlwindTracker:OnSpellCast(spellID, castGUID)
+        if castGUID and seenGUID[castGUID] then return end
+        if castGUID then seenGUID[castGUID] = true end
+
+        -- Generator
+        if GENERATORS[spellID] then
+            -- Thunder Clap/Blast need Crashing Thunder talent
+            if (spellID == 6343 or spellID == 435222) then
+                if not C_SpellBook.IsSpellKnown(CRASHING_THUNDER_TALENT) then
+                    return
+                end
+            end
+            -- Delayed grant (matches game behavior)
+            pendingToken = pendingToken + 1
+            local myToken = pendingToken
+            C_Timer.After(0.15, function()
+                if myToken ~= pendingToken then return end
+                stacks = IW_MAX_STACKS
+                expiresAt = GetTime() + IW_DURATION
+                -- Force immediate resource bar update
+                if QUICore and QUICore.UpdateSecondaryPowerBar then
+                    QUICore:UpdateSecondaryPowerBar()
+                end
+            end)
+            return
+        end
+
+        -- Spender
+        if SPENDERS[spellID] then
+            -- Unhinged: BT/Bloodbath don't consume during Bladestorm
+            if (spellID == 23881 or spellID == 335096) then
+                if C_SpellBook.IsSpellKnown(UNHINGED_TALENT) then
+                    local ok, usable = pcall(C_Spell.IsSpellUsable, 446035)
+                    if ok and not usable then return end
+                end
+            end
+            if stacks > 0 then
+                stacks = stacks - 1
+                if stacks == 0 then expiresAt = nil end
+                -- Force immediate resource bar update
+                if QUICore and QUICore.UpdateSecondaryPowerBar then
+                    QUICore:UpdateSecondaryPowerBar()
+                end
+            end
+            return
+        end
+    end
+
+    -- Event frame: only active for Fury Warriors
+    local wwFrame = CreateFrame("Frame")
+    wwFrame:RegisterEvent("PLAYER_LOGIN")
+    wwFrame:SetScript("OnEvent", function(self, event, ...)
+        if event == "PLAYER_LOGIN" or event == "ACTIVE_PLAYER_SPECIALIZATION_CHANGED"
+            or event == "PLAYER_SPECIALIZATION_CHANGED" then
+            local _, class = UnitClass("player")
+            local spec = GetSpecialization()
+            -- Fury = spec 2
+            if class == "WARRIOR" and spec == 2 then
+                self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+                self:RegisterEvent("PLAYER_DEAD")
+                self:RegisterEvent("PLAYER_REGEN_ENABLED")
+            else
+                self:UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+                self:UnregisterEvent("PLAYER_DEAD")
+                self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+                WhirlwindTracker:Reset()
+            end
+        elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+            local unit, castGUID, spellID = ...
+            if unit == "player" then
+                WhirlwindTracker:OnSpellCast(spellID, castGUID)
+            end
+        elseif event == "PLAYER_DEAD" then
+            WhirlwindTracker:Reset()
+        elseif event == "PLAYER_REGEN_ENABLED" then
+            -- Combat ended: clear pending token to prevent stale delayed grants,
+            -- and clear GUID cache to prevent memory growth.
+            pendingToken = pendingToken + 1
+            seenGUID = {}
+        end
+    end)
+    wwFrame:RegisterEvent("ACTIVE_PLAYER_SPECIALIZATION_CHANGED")
+    wwFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+end
+
+---------------------------------------------------------------------------
+-- TIP OF THE SPEAR STACK TRACKER (event-driven)
+--
+-- Same pattern as Whirlwind: aura API unreliable during combat.
+-- Kill Command grants 1 stack (2 with Primal Surge), spenders consume 1.
+---------------------------------------------------------------------------
+local TipOfTheSpearTracker = {}
+do
+    local TIP_MAX_STACKS = 3
+    local TIP_DURATION   = 10
+    local TIP_TALENT     = 260285
+
+    -- Generators
+    local KILL_COMMAND    = 259489
+    local TAKEDOWN        = 1250646
+    local PRIMAL_SURGE    = 1272154  -- talent: Kill Command grants 2 stacks
+    local TWIN_FANG       = 1272139  -- talent: Takedown grants 2 stacks
+
+    -- Spenders: consume one stack
+    local SPENDERS = {
+        [186270]  = true,  -- Raptor Strike
+        [1262293] = true,  -- Raptor Swipe
+        [1261193] = true,  -- Boomstick
+        [1253859] = true,  -- Takedown
+        [259495]  = true,  -- Wildfire Bomb
+        [193265]  = true,  -- Hatchet Toss
+        [1264949] = true,  -- Chakram
+        [1262343] = true,  -- Ranged Raptor Swipe
+        [265189]  = true,  -- Ranged Raptor Strike
+        [1251592] = true,  -- Flamefang Pitch
+    }
+
+    local stacks    = 0
+    local expiresAt = nil
+
+    function TipOfTheSpearTracker:GetStacks()
+        if expiresAt and GetTime() >= expiresAt then
+            stacks = 0
+            expiresAt = nil
+        end
+        if not C_SpellBook or not C_SpellBook.IsSpellKnown(TIP_TALENT) then
+            return nil, 0
+        end
+        return TIP_MAX_STACKS, stacks
+    end
+
+    function TipOfTheSpearTracker:Reset()
+        stacks = 0
+        expiresAt = nil
+    end
+
+    function TipOfTheSpearTracker:OnSpellCast(spellID)
+        if not C_SpellBook.IsSpellKnown(TIP_TALENT) then return end
+
+        -- Kill Command: +1 (or +2 with Primal Surge)
+        if spellID == KILL_COMMAND then
+            local gain = C_SpellBook.IsSpellKnown(PRIMAL_SURGE) and 2 or 1
+            stacks = math.min(TIP_MAX_STACKS, stacks + gain)
+            expiresAt = GetTime() + TIP_DURATION
+            if QUICore and QUICore.UpdateSecondaryPowerBar then
+                QUICore:UpdateSecondaryPowerBar()
+            end
+            return
+        end
+
+        -- Takedown: +2 with Twin Fang talent
+        if spellID == TAKEDOWN and C_SpellBook.IsSpellKnown(TWIN_FANG) then
+            stacks = math.min(TIP_MAX_STACKS, stacks + 2)
+            expiresAt = GetTime() + TIP_DURATION
+            if QUICore and QUICore.UpdateSecondaryPowerBar then
+                QUICore:UpdateSecondaryPowerBar()
+            end
+            return
+        end
+
+        -- Spender: consume one stack
+        if SPENDERS[spellID] then
+            if stacks > 0 then
+                stacks = stacks - 1
+                if stacks == 0 then expiresAt = nil end
+                if QUICore and QUICore.UpdateSecondaryPowerBar then
+                    QUICore:UpdateSecondaryPowerBar()
+                end
+            end
+            return
+        end
+    end
+
+    local tipFrame = CreateFrame("Frame")
+    tipFrame:RegisterEvent("PLAYER_LOGIN")
+    tipFrame:SetScript("OnEvent", function(self, event, ...)
+        if event == "PLAYER_LOGIN" or event == "ACTIVE_PLAYER_SPECIALIZATION_CHANGED"
+            or event == "PLAYER_SPECIALIZATION_CHANGED" then
+            local _, class = UnitClass("player")
+            local spec = GetSpecialization()
+            -- Survival = spec 3
+            if class == "HUNTER" and spec == 3 then
+                self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+                self:RegisterEvent("PLAYER_DEAD")
+            else
+                self:UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+                self:UnregisterEvent("PLAYER_DEAD")
+                TipOfTheSpearTracker:Reset()
+            end
+        elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+            local unit, _, spellID = ...
+            if unit == "player" then
+                TipOfTheSpearTracker:OnSpellCast(spellID)
+            end
+        elseif event == "PLAYER_DEAD" then
+            TipOfTheSpearTracker:Reset()
+        end
+    end)
+    tipFrame:RegisterEvent("ACTIVE_PLAYER_SPECIALIZATION_CHANGED")
+    tipFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+end
+
 local VDH_SOUL_FRAGMENTS_POWER = (Enum.PowerType and type(Enum.PowerType.SoulFragments) == "number") and Enum.PowerType.SoulFragments or nil
 
 local tocVersion = select(4, GetBuildInfo())
@@ -229,9 +493,12 @@ local fragmentedPowerTypes = {
 local runeUpdateElapsed = 0
 local runeUpdateRunning = false
 
--- Smooth essence regen timer state
+-- Essence regen timer state (timer-based extrapolation)
 local essenceUpdateElapsed = 0
 local essenceUpdateRunning = false
+local essenceNextTick = nil      -- GetTime() when next essence will be ready
+local essenceLastCount = nil     -- last integer essence count (detect gains)
+local essenceTickDuration = nil  -- seconds per essence regen tick
 
 -- Rune text format cache: only call string.format when the truncated value changes
 local _lastRuneRounded = {}    -- [runeIndex] = last math.floor(remaining * 10) value
@@ -662,17 +929,21 @@ local function GetSecondaryResourceValue(resource)
     end
 
     if resource == Enum.PowerType.Whirlwind then
-        -- Fury Warrior Improved Whirlwind stacks (aura-based, spell ID 85739)
-        local aura = C_UnitAuras.GetPlayerAuraBySpellID(85739)
-        local current = aura and aura.applications or 0
-        return 4, current, current, "number"
+        -- Fury Warrior Improved Whirlwind stacks.
+        -- Manual tracker (UNIT_SPELLCAST_SUCCEEDED) is reliable during combat;
+        -- C_UnitAuras.GetPlayerAuraBySpellID(85739) returns stale/secret data.
+        local max, current = WhirlwindTracker:GetStacks()
+        if not max then return nil, nil, nil, nil end
+        return max, current, current, "number"
     end
 
     if resource == Enum.PowerType.TipOfTheSpear then
-        -- Survival Hunter Tip of the Spear stacks (aura-based, spell ID 260286)
-        local aura = C_UnitAuras.GetPlayerAuraBySpellID(260286)
-        local current = aura and aura.applications or 0
-        return 3, current, current, "number"
+        -- Survival Hunter Tip of the Spear stacks.
+        -- Manual tracker (UNIT_SPELLCAST_SUCCEEDED) is reliable during combat;
+        -- C_UnitAuras.GetPlayerAuraBySpellID(260286) returns stale/secret data.
+        local max, current = TipOfTheSpearTracker:GetStacks()
+        if not max then return nil, nil, nil, nil end
+        return max, current, current, "number"
     end
 
     if resource == Enum.PowerType.Runes then
@@ -2246,19 +2517,47 @@ function QUICore:UpdateFragmentedPowerDisplay(bar, resource, isVertical)
         end
 
     elseif resource == Enum.PowerType.Essence then
-        -- Evoker Essence with regen prediction on the recharging segment
+        -- Evoker Essence with timer-based regen extrapolation on the recharging segment
         local current = UnitPower("player", Enum.PowerType.Essence) or 0
+        local now = GetTime()
 
-        -- Get fractional essence via the modified (true) parameter
-        local fractionalPower = UnitPower("player", Enum.PowerType.Essence, true) or 0
-        local fractionalMax = UnitPowerMax("player", Enum.PowerType.Essence, true) or 1
-        if fractionalMax <= 0 then fractionalMax = 1 end
-        -- Fractional per-essence = fractionalMax / maxPower
-        local perEssence = fractionalMax / maxPower
+        -- Calculate tick duration from regen rate (cache outside combat, may be secret in combat)
+        if not InCombatLockdown() then
+            local regenRate = GetPowerRegenForPowerType(Enum.PowerType.Essence)
+            if regenRate and not Helpers.IsSecretValue(regenRate) and regenRate > 0 then
+                essenceTickDuration = 1 / regenRate
+            end
+        end
+        if not essenceTickDuration or essenceTickDuration <= 0 then
+            essenceTickDuration = 5  -- fallback (default 0.2 regen = 5s per essence)
+        end
+
+        -- Detect essence gain — reset timer for next tick
+        if essenceLastCount and current > essenceLastCount then
+            if current < maxPower then
+                essenceNextTick = now + essenceTickDuration
+            else
+                essenceNextTick = nil
+            end
+        end
+
+        -- If missing essence and no timer, start one
+        if current < maxPower and not essenceNextTick then
+            essenceNextTick = now + essenceTickDuration
+        end
+
+        -- If full essence, clear timer
+        if current >= maxPower then
+            essenceNextTick = nil
+        end
+
+        essenceLastCount = current
+
+        -- Calculate partial fill from timer extrapolation
         local partialFill = 0
-        if current < maxPower and perEssence > 0 then
-            local remainder = fractionalPower - (current * perEssence)
-            partialFill = math.max(0, math.min(1, remainder / perEssence))
+        if essenceNextTick and essenceTickDuration > 0 then
+            local remaining = math.max(0, essenceNextTick - now)
+            partialFill = math.max(0, math.min(1, 1 - (remaining / essenceTickDuration)))
         end
 
         for pos = 1, maxPower do
@@ -2281,7 +2580,7 @@ function QUICore:UpdateFragmentedPowerDisplay(bar, resource, isVertical)
                     essenceFrame:SetValue(1)
                     essenceFrame:SetStatusBarColor(color.r, color.g, color.b)
                 elseif pos == current + 1 then
-                    -- Recharging segment — partial fill
+                    -- Recharging segment — partial fill via timer extrapolation
                     essenceFrame:SetValue(partialFill)
                     essenceFrame:SetStatusBarColor(color.r * 0.5, color.g * 0.5, color.b * 0.5)
                 else
@@ -2411,6 +2710,7 @@ local function EssenceTimerOnUpdate(bar, delta)
     if current >= maxPower then
         bar:SetScript("OnUpdate", nil)
         essenceUpdateRunning = false
+        essenceNextTick = nil
         -- Set all visible segments to full
         for i = 1, maxPower do
             local essenceFrame = bar.FragmentedPowerBars and bar.FragmentedPowerBars[i]
@@ -2421,20 +2721,29 @@ local function EssenceTimerOnUpdate(bar, delta)
         return
     end
 
-    -- Get fractional fill for the recharging segment
-    local fractionalPower = UnitPower("player", Enum.PowerType.Essence, true) or 0
-    local fractionalMax = UnitPowerMax("player", Enum.PowerType.Essence, true) or 1
-    if fractionalMax <= 0 then fractionalMax = 1 end
-    local perEssence = fractionalMax / maxPower
-    local partialFill = 0
-    if perEssence > 0 then
-        local remainder = fractionalPower - (current * perEssence)
-        partialFill = math.max(0, math.min(1, remainder / perEssence))
+    -- Detect essence gain — reset timer for next tick
+    if essenceLastCount and current > essenceLastCount then
+        if current < maxPower then
+            essenceNextTick = GetTime() + (essenceTickDuration or 5)
+        else
+            essenceNextTick = nil
+        end
+    end
+    essenceLastCount = current
+
+    -- If missing essence and no timer, start one
+    if current < maxPower and not essenceNextTick then
+        essenceNextTick = GetTime() + (essenceTickDuration or 5)
     end
 
-    -- Update the recharging segment (current + 1)
+    -- Update the recharging segment (current + 1) via timer extrapolation
     local rechargingIdx = current + 1
-    if rechargingIdx <= maxPower then
+    if rechargingIdx <= maxPower and essenceNextTick and essenceTickDuration and essenceTickDuration > 0 then
+        local now = GetTime()
+        local remaining = math.max(0, essenceNextTick - now)
+        local partialFill = 1 - (remaining / essenceTickDuration)
+        partialFill = math.max(0, math.min(1, partialFill))
+
         local essenceFrame = bar.FragmentedPowerBars and bar.FragmentedPowerBars[rechargingIdx]
         if essenceFrame and essenceFrame:IsShown() then
             essenceFrame:SetValue(partialFill)

--- a/modules/utility/anchoring.lua
+++ b/modules/utility/anchoring.lua
@@ -1347,8 +1347,8 @@ local ANCHOR_PROXY_SOURCES = {
     cdmUtility     = { resolver = function() return _G.QUI_GetCDMViewerFrame and _G.QUI_GetCDMViewerFrame("utility") end,   cdm = true },
     buffIcon       = { resolver = function() return _G.QUI_GetCDMViewerFrame and _G.QUI_GetCDMViewerFrame("buffIcon") end,  cdm = true },
     buffBar        = { resolver = function() return _G.QUI_GetCDMViewerFrame and _G.QUI_GetCDMViewerFrame("buffBar") end,   cdm = true },
-    primaryPower   = { resolver = function() return QUICore and QUICore.powerBar end },
-    secondaryPower = { resolver = function() return QUICore and QUICore.secondaryPowerBar end },
+    primaryPower   = { resolver = function() return QUICore and QUICore.powerBar end, hudMinWidth = true },
+    secondaryPower = { resolver = function() return QUICore and QUICore.secondaryPowerBar end, hudMinWidth = true },
 }
 local cdmAnchorProxies = {}
 local cdmAnchorProxyPendingAfterCombat = {}
@@ -1397,6 +1397,24 @@ local function CDMSizeResolver(source)
     if scale <= 0 then scale = 1 end
     local minWidthEnabled, minWidth = GetHUDMinWidthSettings()
     if minWidthEnabled and IsHUDAnchoredToCDM() then
+        local visualW = width * scale
+        if visualW < minWidth then
+            width = minWidth / scale
+        end
+    end
+    return width, height
+end
+
+-- Resource bar proxy size resolver: mirrors real frame size but enforces
+-- the HUD min-width floor so frames anchored to resource bars still see
+-- the minimum width (even though the resource bar itself is raw content width).
+local function HUDMinWidthSizeResolver(source)
+    local width = source:GetWidth() or 0
+    local height = source:GetHeight() or 0
+    local minWidthEnabled, minWidth = GetHUDMinWidthSettings()
+    if minWidthEnabled and IsHUDAnchoredToCDM() then
+        local scale = source:GetScale() or 1
+        if scale <= 0 then scale = 1 end
         local visualW = width * scale
         if visualW < minWidth then
             width = minWidth / scale
@@ -1463,7 +1481,9 @@ local function GetCDMAnchorProxy(parentKey)
             -- CDM + HUD proxy frames are addon-owned and safe to resize/anchor in combat.
             -- Keeping them live avoids stale bounds when CDM reflows during combat.
             combatFreeze = false,
-            sizeResolver = sourceInfo.cdm and CDMSizeResolver or nil,
+            sizeResolver = sourceInfo.cdm and CDMSizeResolver
+                or sourceInfo.hudMinWidth and HUDMinWidthSizeResolver
+                or nil,
             anchorResolver = sourceInfo.cdm and CDMAnchorResolver or nil,
         })
         if not proxy then
@@ -1559,6 +1579,7 @@ local function UpdateCDMAnchorProxies()
             GetCDMAnchorProxy(key)
         end
     end
+
 end
 
 -- Fallback anchor targets for when a resolved frame is unavailable (nil or hidden).
@@ -1938,6 +1959,41 @@ local function ApplyAutoSizing(frame, settings, parentFrame, key)
     if settings.autoWidth and parentFrame and parentFrame ~= UIParent then
         local ok, parentWidth = pcall(function() return parentFrame:GetWidth() end)
         if ok and parentWidth and parentWidth > 0 then
+            -- Resource bars should use raw CDM content width, bypassing the
+            -- min-width floor that CDMSizeResolver applies to the proxy.
+            -- The min-width setting is meant for player/target only.
+            local isResourceBar = (key == "primaryPower" or key == "secondaryPower")
+            if isResourceBar then
+                local parentKey = settings.parent
+                if parentKey == "essential" then parentKey = "cdmEssential"
+                elseif parentKey == "utility" then parentKey = "cdmUtility" end
+                if parentKey and CDM_LOGICAL_SIZE_KEYS[parentKey] then
+                    -- Parent is a CDM viewer — read raw content width from viewer state
+                    local source = ANCHOR_PROXY_SOURCES[parentKey]
+                    if source then
+                        local sourceFrame = source.resolver()
+                        if sourceFrame then
+                            local vs = _G.QUI_GetCDMViewerState and _G.QUI_GetCDMViewerState(sourceFrame)
+                            local rawWidth = vs and vs.rawContentWidth
+                            if rawWidth and rawWidth > 0 then
+                                parentWidth = rawWidth
+                            end
+                        end
+                    end
+                elseif parentKey and ANCHOR_PROXY_SOURCES[parentKey]
+                    and ANCHOR_PROXY_SOURCES[parentKey].hudMinWidth then
+                    -- Parent is another resource bar whose proxy has min-width
+                    -- inflation. Read the actual frame width instead.
+                    local source = ANCHOR_PROXY_SOURCES[parentKey]
+                    local sourceFrame = source.resolver()
+                    if sourceFrame then
+                        local frameOk, frameWidth = pcall(function() return sourceFrame:GetWidth() end)
+                        if frameOk and frameWidth and frameWidth > 0 then
+                            parentWidth = frameWidth
+                        end
+                    end
+                end
+            end
             local adjustedWidth = parentWidth + (settings.widthAdjust or 0)
             if adjustedWidth > 0 then
                 pcall(function() frame:SetWidth(adjustedWidth) end)

--- a/options/tabs/ui/hud_visibility.lua
+++ b/options/tabs/ui/hud_visibility.lua
@@ -275,9 +275,9 @@ local function BuildHUDVisibilityTab(tabContent)
         end
     end
 
-    local ufAlwaysCheck = GUI:CreateFormCheckbox(tabContent, "Show Always", "showAlways", ufVis, function()
-        RefreshUnitframesVisibility()
+    local ufAlwaysCheck = GUI:CreateFormCheckbox(tabContent, "Show Always", "showAlways", ufVis, function(val)
         UpdateUFConditionState()
+        RefreshUnitframesVisibility()
     end)
     ufAlwaysCheck:SetPoint("TOPLEFT", PADDING, y)
     ufAlwaysCheck:SetPoint("RIGHT", tabContent, "RIGHT", -PADDING, 0)


### PR DESCRIPTION
…isibility, resource bar sizing

Replace unreliable C_UnitAuras combat reads with manual UNIT_SPELLCAST_SUCCEEDED trackers for Whirlwind and Tip of the Spear stacks. Switch Evoker Essence regen animation from fractional UnitPower (returns secret values) to timer-based extrapolation using cached regen rate. Add UNIT_HEALTH event-based health state detection for showWhenHealthBelow100 visibility rule. Store raw content width in CDM viewer state so resource bars use actual content width instead of min-width-inflated proxy width. Add HUD min-width size resolver for resource bar anchor proxies.


(cherry picked from commit cb57ed37528385a6d7c0c27062382ec762f95b2c)