### PR TITLE
fix: eliminate CompactRaidFrameManager flicker when hiding

### DIFF
--- a/modules/ui/uihider.lua
+++ b/modules/ui/uihider.lua
@@ -38,9 +38,8 @@ local DEFAULTS = {
 local pendingObjectiveTrackerHide = false
 local pendingApplyHideSettings = false
 
--- CompactRaidFrameManager visibility watcher (replaces hooksecurefunc to avoid taint)
-local _crfWatcher = nil
-local _crfWatcherShown = false
+-- CompactRaidFrameManager: tracks whether hooks have been installed
+local _crfHooked = false
 
 -- TAINT SAFETY: Track hook state in a local weak-keyed table, NOT on Blizzard
 -- frames. Writing _QUI_* properties to secure frames taints them in Midnight's
@@ -329,54 +328,73 @@ local function ApplyHideSettings()
     -- secret number tainted by QUI") that can prevent ExitEditMode from completing.
     -- Use SetAlpha(0) + EnableMouse(false) instead to make it invisible without
     -- triggering the compact unit frame update chain.
+    --
+    -- FLICKER FIX: Three hooks replace the old OnUpdate watcher.
+    -- (1) CompactRaidFrameManager_UpdateShown — the global Blizzard calls on
+    --     PLAYER_ENTERING_WORLD, GROUP_ROSTER_UPDATE, etc.
+    -- (2) CompactRaidFrameManager:Show() — catches direct Show() calls that
+    --     bypass UpdateShown (empirically needed for group join).
+    -- (3) CompactRaidFrameManager:SetAlpha() — catches anything that restores
+    --     alpha after hooks 1/2 run (animations, deferred callbacks, etc.).
+    --     The _alphaGuard prevents our own SetAlpha(0) from re-triggering it.
+    -- All hooks run synchronously before rendering, eliminating the flash.
+    -- SetAlpha(0) is used instead of Hide() for taint safety (see above).
     if CompactRaidFrameManager then
         if InCombatLockdown() then
             -- Skip protected operations during combat
         elseif settings.hideRaidFrameManager or (Helpers.GetProfile() and Helpers.GetProfile().quiGroupFrames and Helpers.GetProfile().quiGroupFrames.enabled) then
-            -- Defer to break taint chain (also auto-hide when QUI group frames active)
             C_Timer.After(0, function()
                 if InCombatLockdown() then return end
                 CompactRaidFrameManager:SetAlpha(0)
                 CompactRaidFrameManager:EnableMouse(false)
             end)
-            -- Start OnUpdate watcher to re-hide if Blizzard shows it again
-            -- (replaces hooksecurefunc on Show/SetShown to avoid taint)
-            if not _crfWatcher then
-                _crfWatcher = CreateFrame("Frame", nil, UIParent)
-                _crfWatcherShown = false
-            end
-            _crfWatcher:SetScript("OnUpdate", function()
-                if IsInEditMode() then return end
-                local alpha = CompactRaidFrameManager:GetAlpha()
-                if alpha > 0 and not _crfWatcherShown then
-                    _crfWatcherShown = true
-                    -- Blizzard restored alpha — re-hide if setting is still on
-                    C_Timer.After(0, function()
-                        if IsInEditMode() then _crfWatcherShown = false return end
-                        if InCombatLockdown() then _crfWatcherShown = false return end
+            if not _crfHooked then
+                _crfHooked = true
+
+                local _alphaGuard = false
+
+                local function ApplyCRFHide()
+                    if IsInEditMode() then return end
+                    if InCombatLockdown() then return end
+                    local s = GetSettings()
+                    local quiGFActive = Helpers.GetProfile() and Helpers.GetProfile().quiGroupFrames and Helpers.GetProfile().quiGroupFrames.enabled
+                    if CompactRaidFrameManager and ((s and s.hideRaidFrameManager) or quiGFActive) then
+                        _alphaGuard = true
+                        CompactRaidFrameManager:StopAnimating()
+                        CompactRaidFrameManager:SetAlpha(0)
+                        CompactRaidFrameManager:EnableMouse(false)
+                        _alphaGuard = false
+                    end
+                end
+
+                hooksecurefunc("CompactRaidFrameManager_UpdateShown", function()
+                    ApplyCRFHide()
+                end)
+
+                hooksecurefunc(CompactRaidFrameManager, "Show", function()
+                    ApplyCRFHide()
+                end)
+
+                hooksecurefunc(CompactRaidFrameManager, "SetAlpha", function(self, alpha)
+                    if _alphaGuard then return end
+                    if alpha > 0 and not IsInEditMode() then
                         local s = GetSettings()
                         local quiGFActive = Helpers.GetProfile() and Helpers.GetProfile().quiGroupFrames and Helpers.GetProfile().quiGroupFrames.enabled
                         if (s and s.hideRaidFrameManager) or quiGFActive then
-                            CompactRaidFrameManager:SetAlpha(0)
-                            CompactRaidFrameManager:EnableMouse(false)
+                            _alphaGuard = true
+                            self:StopAnimating()
+                            self:SetAlpha(0)
+                            _alphaGuard = false
                         end
-                        _crfWatcherShown = false
-                    end)
-                elseif alpha == 0 then
-                    _crfWatcherShown = false
-                end
-            end)
+                    end
+                end)
+            end
         else
-            -- Defer to break taint chain from secure context
             C_Timer.After(0, function()
                 if InCombatLockdown() then return end
                 CompactRaidFrameManager:SetAlpha(1)
                 CompactRaidFrameManager:EnableMouse(true)
             end)
-            -- Stop the watcher if it was running
-            if _crfWatcher then
-                _crfWatcher:SetScript("OnUpdate", nil)
-            end
         end
     end
     
@@ -764,22 +782,16 @@ eventFrame:SetScript("OnEvent", function(self, event, addon)
         return
     end
 
-    -- Handle raid permission/role changes - re-hide CompactRaidFrameManager & player frame
+    -- Handle raid permission/role changes - re-evaluate player frame visibility.
+    -- CompactRaidFrameManager re-hide is handled by the hooksecurefunc on
+    -- CompactRaidFrameManager_UpdateShown, which Blizzard calls for this event.
     -- BUG-008: Wrap in C_Timer.After(0) to break taint chain from secure event context
     if event == "GROUP_ROSTER_UPDATE" or event == "PLAYER_ROLES_ASSIGNED" then
-        if settings then
+        if settings and settings.hidePlayerFrameInParty then
             C_Timer.After(0, function()
                 if IsInEditMode() then return end
                 if InCombatLockdown() then return end
-                -- Re-hide CompactRaidFrameManager if needed
-                if settings.hideRaidFrameManager and CompactRaidFrameManager then
-                    CompactRaidFrameManager:SetAlpha(0)
-                    CompactRaidFrameManager:EnableMouse(false)
-                end
-                -- Re-evaluate player frame visibility on group changes
-                if settings.hidePlayerFrameInParty then
-                    ApplyHideSettings()
-                end
+                ApplyHideSettings()
             end)
         end
         return


### PR DESCRIPTION
## Summary

When the "Hide Compact Raid Frame Manager" option is enabled, the frame flickers on group join and other roster/world events — briefly reappearing before being hidden again.

## Root cause

The previous implementation used an `OnUpdate` script that polled `GetAlpha()` every frame, then scheduled a `C_Timer.After(0)` to re-hide the frame. This meant Blizzard's show logic ran, the frame rendered visibly for at least one frame, and the timer fired on the next frame to reset alpha. The per-frame polling also added unnecessary overhead regardless of whether the frame was changing state.

The visibility of `CompactRaidFrameManager` is controlled by `CompactRaidFrameManager_UpdateShown()`, a plain Lua global that Blizzard calls in response to `GROUP_ROSTER_UPDATE`, `PLAYER_ENTERING_WORLD`, `UPDATE_ACTIVE_BATTLEFIELD`, and similar events.

## Changes

- **Hook `CompactRaidFrameManager_UpdateShown`** via `hooksecurefunc` — runs synchronously after Blizzard's visibility logic, in the same execution frame and before rendering, so there is no visible flash
- **Hook `CompactRaidFrameManager.Show`** — covers any direct `Show()` calls outside of `UpdateShown`, and calls `StopAnimating()` immediately after `OnShow` fires to prevent fade-in animations from driving alpha back up
- **Hook `CompactRaidFrameManager.SetAlpha`** with a recursion guard — catches any remaining path that restores alpha, including deferred timers or animation frame callbacks that run after the other two hooks
- Remove the now-redundant manual CRF re-hide from the `GROUP_ROSTER_UPDATE` event handler, since the `UpdateShown` hook handles it
- Replace the two `_crfWatcher`/`_crfWatcherShown` variables with a single `_crfHooked` flag

All hooks respect the existing taint-safety constraint — `Hide()` is never called, only `SetAlpha(0)` and `EnableMouse(false)`. Edit Mode behaviour is unchanged.

## Note on taint safety

The existing code had a comment noting that `hooksecurefunc` on `Show`/`SetShown` was replaced with the `OnUpdate` watcher specifically to avoid taint. Layers 2 and 3 re-introduce frame method hooks on `Show` and `SetAlpha`, which goes against that documented intent. The specific concern is calling `Hide()` from addon context — this fix never does that, only `SetAlpha(0)`, which doesn't touch the unit frame update chain. No taint errors were observed in testing, but flagging this in case there's more context on the original issue.

## Testing

- Hide Compact Raid Frame Manager option enabled, UI reloaded — frame stays hidden
- Joining a group — no flicker, frame stays hidden
- Leaving and rejoining — consistent
- Edit Mode — frame correctly becomes visible for repositioning and re-hides on exit
