### PR TITLE
Fix cooldown/buff timers broken by secret values in tainted execution

### DIFF
--- a/modules/combat/rotationassist.lua
+++ b/modules/combat/rotationassist.lua
@@ -124,6 +124,25 @@ end
 --------------------------------------------------------------------------------
 
 local function ReadSpellCooldown(spellID)
+    -- 12.0+ DurationObject path (secret-value safe)
+    if C_Spell and C_Spell.GetSpellCooldownDuration then
+        local ok, durationObj = pcall(C_Spell.GetSpellCooldownDuration, spellID)
+        if ok and durationObj then
+            local start, duration, modRate
+            if C_Spell.GetSpellCooldown then
+                local a, b, _, d = C_Spell.GetSpellCooldown(spellID)
+                if type(a) == "table" then
+                    start = a.startTime
+                    duration = a.duration
+                    modRate = a.modRate
+                else
+                    start, duration, modRate = a, b, d
+                end
+            end
+            return start, duration, modRate, durationObj
+        end
+    end
+
     if C_Spell and C_Spell.GetSpellCooldown then
         local a, b, c, d = C_Spell.GetSpellCooldown(spellID)
         if type(a) == "table" then
@@ -131,13 +150,13 @@ local function ReadSpellCooldown(spellID)
             local start = a.startTime or a.start
             local duration = a.duration
             local modRate = a.modRate
-            return start, duration, modRate
+            return start, duration, modRate, nil
         else
             -- 11.x returns tuple: start, duration, enable, modRate
-            return a, b, d
+            return a, b, d, nil
         end
     end
-    return nil, nil, nil
+    return nil, nil, nil, nil
 end
 
 local function IsCooldownActive(start, duration)
@@ -326,11 +345,13 @@ local function UpdateGCDCooldown()
     -- Only show GCD swipe when the icon itself is visible
     if not iconFrame:IsShown() then return end
 
-    local start, duration, modRate = ReadSpellCooldown(GCD_SPELL_ID)
+    local start, duration, modRate, durationObj = ReadSpellCooldown(GCD_SPELL_ID)
 
     if IsCooldownActive(start, duration) then
         iconFrame.cooldown:Show()
-        if modRate then
+        if durationObj and iconFrame.cooldown.SetCooldownFromDurationObject then
+            iconFrame.cooldown:SetCooldownFromDurationObject(durationObj)
+        elseif modRate then
             iconFrame.cooldown:SetCooldown(start, duration, modRate)
         else
             iconFrame.cooldown:SetCooldown(start, duration)

--- a/modules/cooldowns/classic/cdm_custom.lua
+++ b/modules/cooldowns/classic/cdm_custom.lua
@@ -319,24 +319,39 @@ local function UpdateIconCooldown(icon)
         end
     end
 
+    -- 12.0+ secret-safe path: use DurationObject for spell cooldowns
+    local function ApplySpellCooldownSafe(spellID, startTime, duration)
+        if not startTime or not duration then
+            cooldown:Clear()
+            return
+        end
+
+        if not IsSecretValue(duration) and type(duration) == "number" and duration <= 0 then
+            cooldown:Clear()
+            return
+        end
+
+        -- Try DurationObject path when values are secret (12.0+)
+        if (IsSecretValue(startTime) or IsSecretValue(duration))
+           and spellID and C_Spell.GetSpellCooldownDuration
+           and cooldown.SetCooldownFromDurationObject then
+            local dOk, dObj = pcall(C_Spell.GetSpellCooldownDuration, spellID)
+            if dOk and dObj then
+                pcall(cooldown.SetCooldownFromDurationObject, cooldown, dObj)
+                return
+            end
+        end
+
+        local ok = pcall(cooldown.SetCooldown, cooldown, startTime, duration)
+        if not ok then
+            cooldown:Clear()
+        end
+    end
+
     pcall(function()
         if entry.type == "spell" then
             local startTime, duration = GetBestSpellCooldown(entry.id)
-            if not startTime or not duration then
-                cooldown:Clear()
-                return
-            end
-
-            -- Avoid comparing secret values; let CooldownFrame process them.
-            if not IsSecretValue(duration) and type(duration) == "number" and duration <= 0 then
-                cooldown:Clear()
-                return
-            end
-
-            local ok = pcall(cooldown.SetCooldown, cooldown, startTime, duration)
-            if not ok then
-                cooldown:Clear()
-            end
+            ApplySpellCooldownSafe(entry.id, startTime, duration)
         elseif entry.type == "item" then
             local startTime, duration, enable = C_Item.GetItemCooldown(entry.id)
             ApplyCooldown(startTime, duration, enable)

--- a/modules/cooldowns/owned/cdm_icons.lua
+++ b/modules/cooldowns/owned/cdm_icons.lua
@@ -338,7 +338,44 @@ local function MirrorBlizzCooldown(icon, blizzChild)
             -- Mirror to addon-owned CD
             local cd = targetIcon.Cooldown
             if cd then
-                pcall(cd.SetCooldown, cd, start, duration)
+                local ok = pcall(cd.SetCooldown, cd, start, duration)
+                -- 12.0+ secret values: SetCooldown fails from tainted (addon)
+                -- context.  Fall back to secret-safe APIs.
+                if not ok then
+                    local entry = targetIcon._spellEntry
+                    local sid = entry and (entry.overrideSpellID or entry.spellID or entry.id)
+                    local recovered = false
+
+                    -- Path 1: Buff/aura icons → C_UnitAuras.GetAuraDuration
+                    if not recovered and sid and entry.viewerType == "buff"
+                       and cd.SetCooldownFromDurationObject
+                       and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID
+                       and C_UnitAuras.GetAuraDuration then
+                        local aOk, auraData = pcall(C_UnitAuras.GetPlayerAuraBySpellID, sid)
+                        if aOk and auraData and auraData.auraInstanceID then
+                            local dOk, dObj = pcall(C_UnitAuras.GetAuraDuration, "player", auraData.auraInstanceID)
+                            if dOk and dObj then
+                                pcall(cd.SetCooldownFromDurationObject, cd, dObj)
+                                recovered = true
+                            end
+                        end
+                        -- Fallback: SetCooldownFromExpirationTime (accepts secret args)
+                        if not recovered and cd.SetCooldownFromExpirationTime
+                           and aOk and auraData and auraData.expirationTime and auraData.duration then
+                            pcall(cd.SetCooldownFromExpirationTime, cd, auraData.expirationTime, auraData.duration)
+                            recovered = true
+                        end
+                    end
+
+                    -- Path 2: Spell cooldown icons → C_Spell.GetSpellCooldownDuration
+                    if not recovered and sid
+                       and cd.SetCooldownFromDurationObject and C_Spell.GetSpellCooldownDuration then
+                        local dOk, dObj = pcall(C_Spell.GetSpellCooldownDuration, sid)
+                        if dOk and dObj then
+                            pcall(cd.SetCooldownFromDurationObject, cd, dObj)
+                        end
+                    end
+                end
             end
 
             -- Track GCD state for swipe classification (matches CMC pattern).
@@ -370,11 +407,40 @@ local function MirrorBlizzCooldown(icon, blizzChild)
     if addonCD then
         -- Mirror current cooldown duration via GetCooldownTimes (C-side, secret-safe)
         local ok, startMs, durMs = pcall(blizzCD.GetCooldownTimes, blizzCD)
+        local syncDone = false
         if ok and startMs and durMs then
             local start = SafeToNumber(startMs)
             local dur = SafeToNumber(durMs)
             if start and dur and start > 0 and dur > 0 then
-                pcall(addonCD.SetCooldown, addonCD, start / 1000, dur / 1000)
+                local setOk = pcall(addonCD.SetCooldown, addonCD, start / 1000, dur / 1000)
+                syncDone = setOk
+            end
+        end
+        -- 12.0+ fallback: if values were secret or SetCooldown failed, try DurationObject
+        if not syncDone and addonCD.SetCooldownFromDurationObject then
+            local entry = icon._spellEntry
+            local sid = entry and (entry.overrideSpellID or entry.spellID or entry.id)
+            if sid then
+                -- Buff/aura → C_UnitAuras.GetAuraDuration
+                if entry.viewerType == "buff"
+                   and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID
+                   and C_UnitAuras.GetAuraDuration then
+                    local aOk, auraData = pcall(C_UnitAuras.GetPlayerAuraBySpellID, sid)
+                    if aOk and auraData and auraData.auraInstanceID then
+                        local dOk, dObj = pcall(C_UnitAuras.GetAuraDuration, "player", auraData.auraInstanceID)
+                        if dOk and dObj then
+                            pcall(addonCD.SetCooldownFromDurationObject, addonCD, dObj)
+                            syncDone = true
+                        end
+                    end
+                end
+                -- Spell cooldown → C_Spell.GetSpellCooldownDuration
+                if not syncDone and C_Spell.GetSpellCooldownDuration then
+                    local dOk, dObj = pcall(C_Spell.GetSpellCooldownDuration, sid)
+                    if dOk and dObj then
+                        pcall(addonCD.SetCooldownFromDurationObject, addonCD, dObj)
+                    end
+                end
             end
         end
         -- Mirror reverse state (aura timers show reversed swipe)
@@ -1217,6 +1283,8 @@ local function UpdateIconCooldown(icon)
     else
         -- Custom entry: use addon-created CD with our cooldown resolution
         local startTime, duration
+        local durationObj  -- 12.0+ opaque handle for secret-safe cooldown display
+        local resolvedSpellID  -- track the spell ID for DurationObject lookup
         if entry.type == "macro" then
             local resolvedID, resolvedType = ResolveMacro(entry)
             if resolvedID then
@@ -1224,6 +1292,7 @@ local function UpdateIconCooldown(icon)
                     startTime, duration = GetItemCooldown(resolvedID)
                 else
                     startTime, duration = GetBestSpellCooldown(resolvedID)
+                    resolvedSpellID = resolvedID
                 end
             end
             -- Update icon texture dynamically (resolved spell may change each tick)
@@ -1240,7 +1309,8 @@ local function UpdateIconCooldown(icon)
         elseif entry.type == "item" then
             startTime, duration = GetItemCooldown(entry.id)
         else
-            startTime, duration = GetBestSpellCooldown(entry.overrideSpellID or entry.spellID or entry.id)
+            resolvedSpellID = entry.overrideSpellID or entry.spellID or entry.id
+            startTime, duration = GetBestSpellCooldown(resolvedSpellID)
 
             -- Sync texture for spell overrides (e.g., Judgment → Hammer of Wrath).
             -- Custom spell entries don't have _blizzChild to mirror, so check the
@@ -1253,6 +1323,16 @@ local function UpdateIconCooldown(icon)
                     if newTex then
                         icon.Icon:SetTexture(newTex)
                     end
+                end
+            end
+        end
+
+        -- 12.0+ secret-safe path: get DurationObject for spells when values are secret
+        if resolvedSpellID and C_Spell.GetSpellCooldownDuration then
+            if IsSecretValue(startTime) or IsSecretValue(duration) then
+                local ok, obj = pcall(C_Spell.GetSpellCooldownDuration, resolvedSpellID)
+                if ok and obj then
+                    durationObj = obj
                 end
             end
         end
@@ -1270,7 +1350,10 @@ local function UpdateIconCooldown(icon)
         end
 
         if icon.Cooldown then
-            if startTime and duration then
+            if durationObj and icon.Cooldown.SetCooldownFromDurationObject then
+                -- Secret-safe: use opaque DurationObject (12.0+)
+                pcall(icon.Cooldown.SetCooldownFromDurationObject, icon.Cooldown, durationObj)
+            elseif startTime and duration then
                 pcall(icon.Cooldown.SetCooldown, icon.Cooldown, startTime, duration)
             else
                 icon.Cooldown:Clear()

--- a/modules/qol/reticle.lua
+++ b/modules/qol/reticle.lua
@@ -135,8 +135,31 @@ end
 
 ---------------------------------------------------------------------------
 -- Read spell cooldown (handles both 11.x and 12.0+ API formats)
+-- Returns: start, duration, modRate, durationObject
+-- durationObject is an opaque handle for SetCooldownFromDurationObject (12.0+)
 ---------------------------------------------------------------------------
 local function ReadSpellCooldown(spellID)
+    -- 12.0+ DurationObject path (secret-value safe)
+    if C_Spell and C_Spell.GetSpellCooldownDuration then
+        local ok, durationObj = pcall(C_Spell.GetSpellCooldownDuration, spellID)
+        if ok and durationObj then
+            -- Also get the cooldown info for IsCooldownActive checks
+            local start, duration, modRate
+            if C_Spell.GetSpellCooldown then
+                local a, b, _, d = C_Spell.GetSpellCooldown(spellID)
+                if type(a) == "table" then
+                    local t = a
+                    start = t.startTime
+                    duration = t.duration
+                    modRate = t.modRate
+                else
+                    start, duration, modRate = a, b, d
+                end
+            end
+            return start, duration, modRate, durationObj
+        end
+    end
+
     if C_Spell and C_Spell.GetSpellCooldown then
         local a, b, c, d = C_Spell.GetSpellCooldown(spellID)
         if type(a) == "table" then
@@ -145,18 +168,34 @@ local function ReadSpellCooldown(spellID)
             local start = t.startTime or t.start
             local duration = t.duration
             local modRate = t.modRate
-            return start, duration, modRate
+            return start, duration, modRate, nil
         else
             -- 11.x returns tuple: start, duration, enable, modRate
-            return a, b, d
+            return a, b, d, nil
         end
     end
     -- Fallback for older API
     if GetSpellCooldown then
         local s, d = GetSpellCooldown(spellID)
-        return s, d, nil
+        return s, d, nil, nil
     end
-    return nil, nil, nil
+    return nil, nil, nil, nil
+end
+
+---------------------------------------------------------------------------
+-- Apply cooldown to a Cooldown frame (secret-value safe)
+-- Prefers SetCooldownFromDurationObject when available (12.0+)
+---------------------------------------------------------------------------
+local function ApplyCooldown(cooldownFrame, start, duration, modRate, durationObj)
+    if durationObj and cooldownFrame.SetCooldownFromDurationObject then
+        cooldownFrame:SetCooldownFromDurationObject(durationObj)
+        return
+    end
+    if modRate then
+        cooldownFrame:SetCooldown(start, duration, modRate)
+    else
+        cooldownFrame:SetCooldown(start, duration)
+    end
 end
 
 ---------------------------------------------------------------------------
@@ -276,15 +315,11 @@ local function UpdateGCDCooldown()
         return
     end
 
-    local start, duration, modRate = ReadSpellCooldown(GCD_SPELL_ID)
+    local start, duration, modRate, durationObj = ReadSpellCooldown(GCD_SPELL_ID)
 
     if IsCooldownActive(start, duration) then
         gcdCooldown:Show()
-        if modRate then
-            gcdCooldown:SetCooldown(start, duration, modRate)
-        else
-            gcdCooldown:SetCooldown(start, duration)
-        end
+        ApplyCooldown(gcdCooldown, start, duration, modRate, durationObj)
     else
         gcdCooldown:Hide()
     end
@@ -472,15 +507,11 @@ eventFrame:SetScript("OnEvent", function(self, event, unit, _, spellID)
 
         -- Check cooldown of cast spell, fall back to GCD spell
         if spellID then
-            local start, duration, modRate = ReadSpellCooldown(spellID)
+            local start, duration, modRate, durationObj = ReadSpellCooldown(spellID)
             if IsCooldownActive(start, duration) then
                 if gcdCooldown then
                     gcdCooldown:Show()
-                    if modRate then
-                        gcdCooldown:SetCooldown(start, duration, modRate)
-                    else
-                        gcdCooldown:SetCooldown(start, duration)
-                    end
+                    ApplyCooldown(gcdCooldown, start, duration, modRate, durationObj)
                     UpdateRingAppearance()
                 end
             else

--- a/modules/qol/skyriding.lua
+++ b/modules/qol/skyriding.lua
@@ -922,10 +922,22 @@ local function UpdateAbilityIcon()
     abilityIcon:ClearAllPoints()
     abilityIcon:SetPoint("LEFT", skyridingFrame, "RIGHT", 2, yOffset)
 
-    -- Get cooldown info
+    -- Get cooldown info (secret-safe: use DurationObject in 12.0+)
     local cooldownInfo = C_Spell.GetSpellCooldown(WHIRLING_SURGE_SPELL_ID)
-    if cooldownInfo and cooldownInfo.duration and not IsSecretValue(cooldownInfo.duration) and cooldownInfo.duration > 0 then
-        abilityIconCooldown:SetCooldown(cooldownInfo.startTime, cooldownInfo.duration)
+    if cooldownInfo and cooldownInfo.duration then
+        if IsSecretValue(cooldownInfo.duration) then
+            -- 12.0+ secret value path
+            if C_Spell.GetSpellCooldownDuration and abilityIconCooldown.SetCooldownFromDurationObject then
+                local ok, dObj = pcall(C_Spell.GetSpellCooldownDuration, WHIRLING_SURGE_SPELL_ID)
+                if ok and dObj then
+                    abilityIconCooldown:SetCooldownFromDurationObject(dObj)
+                end
+            end
+        elseif cooldownInfo.duration > 0 then
+            abilityIconCooldown:SetCooldown(cooldownInfo.startTime, cooldownInfo.duration)
+        else
+            abilityIconCooldown:Clear()
+        end
     else
         abilityIconCooldown:Clear()
     end

--- a/modules/trackers/customtrackers.lua
+++ b/modules/trackers/customtrackers.lua
@@ -91,7 +91,20 @@ local _eventUpdateThrottle = 0.1  -- Minimum interval between event-driven DoUpd
 local _lastEventUpdate = 0
 
 -- Performance: hoisted pcall wrapper functions (avoids anonymous closure allocation per call)
-local function SafeSetCooldown(cd, start, dur) cd:SetCooldown(start, dur) end
+-- 12.0+ secret-safe cooldown setter: tries DurationObject path for spells
+-- when start/dur are secret, falls back to SetCooldown.
+-- spellID is optional — pass nil for non-spell entries.
+local function SafeSetCooldownSecure(cd, start, dur, spellID)
+    if spellID and (IsSecretValue(start) or IsSecretValue(dur))
+       and C_Spell.GetSpellCooldownDuration and cd.SetCooldownFromDurationObject then
+        local ok, dObj = pcall(C_Spell.GetSpellCooldownDuration, spellID)
+        if ok and dObj then
+            cd:SetCooldownFromDurationObject(dObj)
+            return
+        end
+    end
+    cd:SetCooldown(start, dur)
+end
 local function SafeSetReverse(cd, val) cd:SetReverse(val) end
 local function SafeSetSwipeColor(cd, r, g, b, a) cd:SetSwipeColor(r, g, b, a) end
 local function SafeSetDrawSwipe(cd, val) cd:SetDrawSwipe(val) end
@@ -1783,10 +1796,11 @@ function CustomTrackers:StartCooldownPolling(bar)
                 -- not buff duration (trinkets/pots have meaningful cooldowns users want to track;
                 -- active glow still indicates the buff is active)
                 local isItemEntry = entry.type == "slot" or entry.type == "item"
+                local entrySpellID = entry.type == "spell" and entry.id or nil
                 if isActive and activeStartTime and activeDuration and activeDuration > 0 and not showOnlyOnCooldown and not isItemEntry then
                     -- Active state: show buff/cast duration (reverse fill)
                     pcall(SafeSetReverse, icon.cooldown, true)
-                    pcall(SafeSetCooldown, icon.cooldown, activeStartTime, activeDuration)
+                    pcall(SafeSetCooldownSecure, icon.cooldown, activeStartTime, activeDuration, entrySpellID)
                     isOnCD = false  -- Active overrides cooldown state
                 else
                     -- Normal cooldown display
@@ -1798,7 +1812,7 @@ function CustomTrackers:StartCooldownPolling(bar)
                         -- For charge spells: use charge cooldown values
                         if chargeStartTime and chargeDuration then
                             -- Set cooldown first (pcall for secret value safety)
-                            pcall(SafeSetCooldown, icon.cooldown, chargeStartTime, chargeDuration)
+                            pcall(SafeSetCooldownSecure, icon.cooldown, chargeStartTime, chargeDuration, entrySpellID)
                             -- Check if cooldown is active AFTER setting it
                             rechargeActive = IsCooldownFrameActive(icon.cooldown)
                         else
@@ -1831,14 +1845,14 @@ function CustomTrackers:StartCooldownPolling(bar)
                         -- Main cooldown is only active when ALL charges are depleted
                         -- Clear first to ensure clean state (SetCooldown(0,0) doesn't clear previous state)
                         icon.cooldown:Clear()
-                        pcall(SafeSetCooldown, icon.cooldown, startTime, duration)
+                        pcall(SafeSetCooldownSecure, icon.cooldown, startTime, duration, entrySpellID)
                         -- Check if the frame shows this cooldown as active
                         -- IsCooldownFrameActive uses IsVisible() which handles secret values internally
                         mainCDActive = IsCooldownFrameActive(icon.cooldown)
 
                         -- Now restore charge cooldown values for display
                         if chargeStartTime and chargeDuration then
-                            pcall(SafeSetCooldown, icon.cooldown, chargeStartTime, chargeDuration)
+                            pcall(SafeSetCooldownSecure, icon.cooldown, chargeStartTime, chargeDuration, entrySpellID)
                         end
 
                         -- Exclude GCD from triggering desaturation
@@ -1903,7 +1917,7 @@ function CustomTrackers:StartCooldownPolling(bar)
                     else
                         -- Normal spell/item cooldown
                         if startTime and duration then
-                            pcall(SafeSetCooldown, icon.cooldown, startTime, duration)
+                            pcall(SafeSetCooldownSecure, icon.cooldown, startTime, duration, entrySpellID)
                         end
 
                         pcall(SafeSetDrawSwipe, icon.cooldown, false)


### PR DESCRIPTION
## Summary

- `Cooldown:SetCooldown(start, duration)` rejects secret values when called from addon (tainted) execution context, breaking all cooldown and buff timer displays in combat.
- `hooksecurefunc` callbacks run in tainted context — when Blizzard's secure CDM calls `SetCooldown` with secret values on the hidden viewer, the mirror hook cannot forward them to addon-owned CooldownFrames.
- Added fallback paths using secret-safe APIs: `C_Spell.GetSpellCooldownDuration()` → `SetCooldownFromDurationObject()` for spell cooldowns, and `C_UnitAuras.GetAuraDuration()` → `SetCooldownFromDurationObject()` for buff/aura icons, with `SetCooldownFromExpirationTime()` as a secondary fallback.

## Files changed

| File | What changed |
|------|-------------|
| `modules/cooldowns/owned/cdm_icons.lua` | `SetCooldown` mirror hook falls back to DurationObject on failure; buff icons use `C_UnitAuras.GetAuraDuration`; initial sync handles secret values; custom entry path gets DurationObject when values are secret |
| `modules/cooldowns/classic/cdm_custom.lua` | New `ApplySpellCooldownSafe` tries `GetSpellCooldownDuration` → `SetCooldownFromDurationObject` before falling back to `SetCooldown` |
| `modules/trackers/customtrackers.lua` | Replaced `SafeSetCooldown` with `SafeSetCooldownSecure` that tries DurationObject path for spell entries |
| `modules/qol/reticle.lua` | `ReadSpellCooldown` returns DurationObject as 4th value; new `ApplyCooldown` helper prefers `SetCooldownFromDurationObject` |
| `modules/combat/rotationassist.lua` | Same pattern as reticle — `ReadSpellCooldown` returns DurationObject, call site prefers it |
| `modules/qol/skyriding.lua` | Added secret value branch using `GetSpellCooldownDuration` + `SetCooldownFromDurationObject` |
