### PR TITLE
Essential Cooldown Bar displays HoT duration instead of spell cooldown for aura-based spells

### DIFF
--- a/modules/cooldowns/owned/cdm_icons.lua
+++ b/modules/cooldowns/owned/cdm_icons.lua
@@ -1412,7 +1412,7 @@ local function UpdateIconCooldown(icon)
             end
         end
 
-        icon._auraActive = isActiveAura
+        icon._auraActive = isActiveAura and entry.viewerType == "buff"
         RefreshIconGCDState(icon)
 
         if icon.Cooldown then


### PR DESCRIPTION
When a spell tracked on the Essential Cooldown bar is also a HoT (such as Wild Growth), the cooldown icon incorrectly displays the aura's remaining duration rather than the spell's actual cooldown. In the attached screenshots, you can see that after casting Wild Growth, the Essential cooldown icon shows 7 seconds (matching the HoT duration on the raid frames) instead of the 10 second spell cooldown. This is misleading — it appears the spell is ready to cast when the timer hits 0, but in reality the cooldown hasn't expired yet.

<img width="484" height="466" alt="wildgrowth-hot-tracked" src="https://github.com/user-attachments/assets/25ef8bbf-f77e-4f4f-be2c-8449fd0a556c" />
<img width="763" height="752" alt="wildgrowth-hot-untracked" src="https://github.com/user-attachments/assets/af75987f-248c-435d-a5cb-7ea2250f06bd" />

The issue is in UpdateIconCooldown() in cdm_icons.lua. Blizzard sets cooldownUseAuraDisplayTime = true on HoT spells like Wild Growth, which causes isActiveAura to be true regardless of viewer type. This prioritizes C_UnitAuras.GetAuraDuration (the HoT duration) over the actual spell cooldown. The fix gates the aura duration path with entry.viewerType == "buff" so that only Buff viewer icons use aura duration — Essential and Utility cooldown icons will always display the spell cooldown, which is the information players need to know when the ability is available again.

