### PR TITLE
Adds better stack/count handling for CDM icons and extends per-spell CDM glow overrides with a stack threshold option. Also adds Mistweaver Renewing Mist charge tracking to resource bars.

### DIFF
--- a/modules/cooldowns/owned/cdm_composer.lua
+++ b/modules/cooldowns/owned/cdm_composer.lua
@@ -995,6 +995,51 @@ local function ShowOverridePanel(parentRow, containerKey, entry, entryIndex)
     local procCheck = GUI:CreateFormCheckbox(overridePanel, "Proc on Usable", "procOnUsable", proxyDB, OnOverrideChange)
     PlaceWidget(procCheck)
 
+    -- Stack threshold for using the container's configured CDM glow.
+    local stackGlowRow = CreateFrame("Frame", nil, overridePanel)
+    stackGlowRow:SetHeight(FORM_ROW)
+    local stackGlowLabel = stackGlowRow:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    stackGlowLabel:SetPoint("LEFT", 0, 0)
+    stackGlowLabel:SetText("Glow at Stacks")
+    stackGlowLabel:SetTextColor(0.85, 0.85, 0.85, 1)
+
+    local stackGlowHint = stackGlowRow:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    stackGlowHint:SetPoint("LEFT", stackGlowLabel, "RIGHT", 6, 0)
+    stackGlowHint:SetText("(0 = off)")
+    stackGlowHint:SetTextColor(0.45, 0.45, 0.45, 1)
+
+    local stackGlowBox = CreateFrame("EditBox", nil, stackGlowRow, "BackdropTemplate")
+    stackGlowBox:SetSize(48, 20)
+    stackGlowBox:SetPoint("RIGHT", stackGlowRow, "RIGHT", 0, 0)
+    SetSimpleBackdrop(stackGlowBox, 0.1, 0.1, 0.12, 1, 0.3, 0.3, 0.3, 1)
+    stackGlowBox:SetFontObject("GameFontNormalSmall")
+    stackGlowBox:SetTextInsets(4, 4, 0, 0)
+    stackGlowBox:SetAutoFocus(false)
+    stackGlowBox:SetMaxLetters(2)
+    stackGlowBox:SetNumeric(true)
+    stackGlowBox:SetText(tostring(overrides.glowStackThreshold or 0))
+    stackGlowBox:SetScript("OnEnterPressed", function(self)
+        self:ClearFocus()
+        local val = tonumber(self:GetText()) or 0
+        if val < 0 then val = 0 end
+        if val > 99 then val = 99 end
+        self:SetText(tostring(val))
+        if val == 0 then
+            spellData:ClearSpellOverride(containerKey, spellID, "glowStackThreshold")
+        else
+            spellData:SetSpellOverride(containerKey, spellID, "glowStackThreshold", val)
+        end
+        OnOverrideChange()
+    end)
+    stackGlowBox:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    stackGlowBox:SetScript("OnEditFocusGained", function(self)
+        self:SetBackdropBorderColor(ACCENT_R, ACCENT_G, ACCENT_B, 1)
+    end)
+    stackGlowBox:SetScript("OnEditFocusLost", function(self)
+        self:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+    end)
+    PlaceWidget(stackGlowRow)
+
     -- Glow color
     -- For color pickers, we need a real table reference. Use a temp table synced back.
     local glowColorDB = { glowColor = overrides.glowColor or { ACCENT_R, ACCENT_G, ACCENT_B, 1 } }

--- a/modules/cooldowns/owned/cdm_icons.lua
+++ b/modules/cooldowns/owned/cdm_icons.lua
@@ -116,6 +116,8 @@ local blizzTexState = setmetatable({}, { __mode = "k" })
 -- Applications frames are reparented onto our CDM icons and Blizzard
 -- manages SetText/Show/Hide natively — no hook forwarding needed.
 local blizzStackState = setmetatable({}, { __mode = "k" })
+local blizzStackTextHooked = setmetatable({}, { __mode = "k" })
+local SetGlowStackCount
 
 ---------------------------------------------------------------------------
 -- DEBUG: Charge/stack transform debugging.
@@ -1088,11 +1090,27 @@ local function HookBlizzStackText(icon, blizzChild)
     local chargeFrame = blizzChild.ChargeCount
     local appFrame = blizzChild.Applications
 
+    local function HookNativeStackFontString(fs)
+        if not fs or blizzStackTextHooked[fs] then return end
+        blizzStackTextHooked[fs] = true
+        hooksecurefunc(fs, "SetText", function(self, text)
+            local state = blizzStackState[blizzChild]
+            if state and state.icon and SetGlowStackCount then
+                SetGlowStackCount(state.icon, text)
+            end
+        end)
+        hooksecurefunc(fs, "Hide", function()
+            local state = blizzStackState[blizzChild]
+            if state and state.icon and SetGlowStackCount then
+                SetGlowStackCount(state.icon, nil)
+            end
+        end)
+    end
+
     -- Reparent and style Blizzard's native ChargeCount and Applications
     -- frames onto our CDM icon.  Blizzard manages SetText/Show/Hide
-    -- natively — no hooks needed for stack text forwarding.  This avoids
-    -- all secret-value comparison issues: Blizzard's C-side code handles
-    -- zero detection, visibility toggling, and clearing internally.
+    -- natively; the small FontString hooks below only mirror the numeric
+    -- value into icon state so stack-threshold glow rules can evaluate it.
     --
     -- For non-charged entries (Spirit Bomb / Soul Fragments): the native
     -- ChargeCount.Current and Applications.Applications FontStrings
@@ -1119,6 +1137,7 @@ local function HookBlizzStackText(icon, blizzChild)
         if not (entry and entry.hasCharges) then
             chargeFrame:Show()
         end
+        HookNativeStackFontString(chargeFrame.Current)
     end
 
     -- Same for Applications.
@@ -1129,6 +1148,7 @@ local function HookBlizzStackText(icon, blizzChild)
             pcall(appFrame.SetParent, appFrame, textOverlay)
             pcall(appFrame.SetFrameLevel, appFrame, lvl)
         end
+        HookNativeStackFontString(appFrame.Applications)
     end
 
     -- Style the native FontStrings (font/color/position applied in
@@ -1934,6 +1954,70 @@ local function GetChildIconTexture(child)
     return nil
 end
 
+local function GetDisplayTextFromCountAPI(sid, maxCharges, countAPI)
+    if not countAPI then return nil end
+
+    local okDisplay, displayCount = pcall(countAPI, sid)
+    if not okDisplay or displayCount == nil then return nil end
+
+    if maxCharges and maxCharges > 1 then
+        return displayCount, displayCount
+    end
+
+    local truncOk, truncText = pcall(C_StringUtil.TruncateWhenZero, displayCount)
+    local displayText = truncOk and truncText or displayCount
+    local hasText = displayText ~= nil
+    if hasText then
+        local etOk, etEq = pcall(function() return displayText == "" end)
+        if etOk and etEq then hasText = false end
+    end
+    return hasText and displayText or nil, hasText and displayCount or nil
+end
+
+local function GetSpellDisplayCountText(entry, runtimeSid, cachedChargeInfo)
+    if not entry or entry.type ~= "spell"
+        or not ((C_Spell and (C_Spell.GetSpellDisplayCount or C_Spell.GetSpellCastCount)) or GetSpellCount) then
+        return nil
+    end
+
+    local candidates = {
+        runtimeSid,
+        entry.overrideSpellID,
+        entry.spellID,
+        entry.id,
+    }
+    for _, sid in ipairs(candidates) do
+        if sid then
+            local maxCharges = cachedChargeInfo and SafeToNumber(cachedChargeInfo.maxCharges, nil)
+            if not maxCharges and C_Spell and C_Spell.GetSpellCharges then
+                local okCharges, ci = pcall(C_Spell.GetSpellCharges, sid)
+                maxCharges = okCharges and ci and SafeToNumber(ci.maxCharges, nil)
+            end
+
+            local displayText, rawCount = GetDisplayTextFromCountAPI(sid, maxCharges, C_Spell and C_Spell.GetSpellDisplayCount)
+            if displayText == nil then
+                displayText, rawCount = GetDisplayTextFromCountAPI(sid, maxCharges, C_Spell and C_Spell.GetSpellCastCount)
+            end
+            if displayText == nil then
+                displayText, rawCount = GetDisplayTextFromCountAPI(sid, maxCharges, GetSpellCount)
+            end
+            if displayText ~= nil then return displayText, rawCount end
+        end
+    end
+
+    return nil
+end
+
+SetGlowStackCount = function(icon, count)
+    if not icon then return end
+    local numeric = SafeToNumber(count, nil)
+    if icon._glowStackCount == numeric then return end
+    icon._glowStackCount = numeric
+    if ns._OwnedGlows and ns._OwnedGlows.SyncGlowForIcon then
+        ns._OwnedGlows.SyncGlowForIcon(icon)
+    end
+end
+
 local function UpdateIconCooldown(icon)
     if not icon or not icon._spellEntry then return end
     local entry = icon._spellEntry
@@ -2009,23 +2093,31 @@ local function UpdateIconCooldown(icon)
                         -- combat — only use it as a fallback when hooks aren't
                         -- actively driving stack text for this icon.
                         local _auraHookActive = (not r.isTotemInstance) and IsHookStackActive(entry, icon)
-                        if not _auraHookActive then
-                            if r.isTotemInstance then
-                                icon.StackText:SetText("")
-                                icon.StackText:Hide()
-                            elseif r.stacks then
-                                -- Charged abilities: "0" is meaningful (all
-                                -- charges depleted). Only truncate zero for
-                                -- non-charged resource stacks.
-                                if entry.hasCharges then
-                                    pcall(icon.StackText.SetText, icon.StackText, r.stacks)
-                                else
-                                    pcall(icon.StackText.SetText, icon.StackText, C_StringUtil.TruncateWhenZero(r.stacks))
-                                end
+                        if r.isTotemInstance then
+                            icon.StackText:SetText("")
+                            icon.StackText:Hide()
+                            SetGlowStackCount(icon, nil)
+                        elseif r.stacks and not _auraHookActive then
+                            -- Charged abilities: "0" is meaningful (all
+                            -- charges depleted). Only truncate zero for
+                            -- non-charged resource stacks.
+                            if entry.hasCharges then
+                                pcall(icon.StackText.SetText, icon.StackText, r.stacks)
+                            else
+                                pcall(icon.StackText.SetText, icon.StackText, C_StringUtil.TruncateWhenZero(r.stacks))
+                            end
+                            icon.StackText:Show()
+                            SetGlowStackCount(icon, r.stacks)
+                        elseif not r.stacks then
+                            local displayText, rawCount = GetSpellDisplayCountText(entry, _runtimeSid, nil)
+                            if displayText ~= nil then
+                                pcall(icon.StackText.SetText, icon.StackText, displayText)
                                 icon.StackText:Show()
-                            elseif not InCombatLockdown() then
+                                SetGlowStackCount(icon, rawCount)
+                            elseif not _auraHookActive and not InCombatLockdown() then
                                 icon.StackText:SetText("")
                                 icon.StackText:Hide()
+                                SetGlowStackCount(icon, nil)
                             end
                         end
 
@@ -2085,6 +2177,7 @@ local function UpdateIconCooldown(icon)
                         if r.isTotemInstance or not IsHookStackActive(entry, icon) then
                             icon.StackText:SetText("")
                             icon.StackText:Hide()
+                            SetGlowStackCount(icon, nil)
                         end
                         return  -- Aura path complete
                     end
@@ -2138,6 +2231,7 @@ local function UpdateIconCooldown(icon)
             -- Hide stack text for trinkets
             icon.StackText:SetText("")
             icon.StackText:Hide()
+            SetGlowStackCount(icon, nil)
         elseif entry.type == "item" then
             startTime, duration, durObj = GetItemCooldown(entry.id)
             -- Show item count as stack text (includeUses=true for charge items)
@@ -2146,9 +2240,11 @@ local function UpdateIconCooldown(icon)
                 if ok and count and count > 0 then
                     icon.StackText:SetText(tostring(count))
                     icon.StackText:Show()
+                    SetGlowStackCount(icon, count)
                 else
                     icon.StackText:SetText("0")
                     icon.StackText:Show()
+                    SetGlowStackCount(icon, 0)
                 end
             end
         else
@@ -2194,6 +2290,7 @@ local function UpdateIconCooldown(icon)
                             _ncTotemTexture = r.totemIcon or icon._totemIconCache
                             icon.StackText:SetText("")
                             icon.StackText:Hide()
+                            SetGlowStackCount(icon, nil)
                         else
                             icon._isTotemInstance = nil
                         end
@@ -2355,6 +2452,7 @@ local function UpdateIconCooldown(icon)
                             _chargedTotemTexture = r.totemIcon or icon._totemIconCache
                             icon.StackText:SetText("")
                             icon.StackText:Hide()
+                            SetGlowStackCount(icon, nil)
                         else
                             icon._isTotemInstance = nil
                         end
@@ -2693,26 +2791,37 @@ local function UpdateIconCooldown(icon)
             if ccc ~= nil then
                 pcall(icon.StackText.SetText, icon.StackText, ccc)
                 icon.StackText:Show()
+                SetGlowStackCount(icon, ccc)
                 _chargeCountForwarded = true
             end
         elseif ci and ci.maxCharges then
             ChargeDebug(entry.name, "FWD path CLEAR: baseSid=", baseSid,
-                "maxCharges=", ci.maxCharges, "(<=1, clearing stacks)",
+                "maxCharges=", ci.maxCharges, "(<=1, yielding to display-count fallback)",
                 "overrideSpellID=", entry.overrideSpellID)
-            icon.StackText:SetText("")
-            _chargeCountForwarded = true
         end
     end
 
-    -- Charged entries where the FWD path couldn't find charges:
-    -- Blizzard's native ChargeCount.Current (reparented onto our icon)
-    -- displays the correct value natively — no fallback forwarding needed.
-
-    if _hookActive or _chargeCountForwarded then
-        ChargeDebug(entry.name, "SKIP API path: hookActive=", _hookActive,
-            "chargeCountForwarded=", _chargeCountForwarded)
+    -- Some abilities expose their count via GetSpellDisplayCount without
+    -- reporting as multi-charge spells (Mana Tea is one such case).  Run this
+    -- before the hook-active skip so a reparented-but-empty Blizzard stack
+    -- frame cannot suppress the API count.
+    local _displayCountForwarded = false
+    if not _chargeCountForwarded then
+        local displayText, rawCount = GetSpellDisplayCountText(entry, _runtimeSid, _cachedChargeInfo)
+        if displayText ~= nil then
+            pcall(icon.StackText.SetText, icon.StackText, displayText)
+            icon.StackText:Show()
+            SetGlowStackCount(icon, rawCount)
+            _displayCountForwarded = true
+        end
     end
-    if not _hookActive and not _chargeCountForwarded then
+
+    if _hookActive or _chargeCountForwarded or _displayCountForwarded then
+        ChargeDebug(entry.name, "SKIP API path: hookActive=", _hookActive,
+            "chargeCountForwarded=", _chargeCountForwarded,
+            "displayCountForwarded=", _displayCountForwarded)
+    end
+    if not _hookActive and not _chargeCountForwarded and not _displayCountForwarded then
         if entry.type == "item" then
             -- Item stack text was already set above in the cooldown section;
             -- nothing to do here — just prevent the else clause from clearing it.
@@ -2759,6 +2868,7 @@ local function UpdateIconCooldown(icon)
                     -- Always show charge count — "0" is meaningful
                     pcall(icon.StackText.SetText, icon.StackText, stackVal)
                     icon.StackText:Show()
+                    SetGlowStackCount(icon, stackVal)
                 else
                     local truncOk, truncText = pcall(C_StringUtil.TruncateWhenZero, stackVal)
                     local displayText = truncOk and truncText or stackVal
@@ -2770,14 +2880,17 @@ local function UpdateIconCooldown(icon)
                     if hasText then
                         pcall(icon.StackText.SetText, icon.StackText, displayText)
                         icon.StackText:Show()
+                        SetGlowStackCount(icon, stackVal)
                     else
                         icon.StackText:SetText("")
                         icon.StackText:Hide()
+                        SetGlowStackCount(icon, nil)
                     end
                 end
             elseif not InCombatLockdown() then
                 icon.StackText:SetText("")
                 icon.StackText:Hide()
+                SetGlowStackCount(icon, nil)
             end
         else
             -- Harvested entries and other types: hooks drive stack text.
@@ -2787,6 +2900,7 @@ local function UpdateIconCooldown(icon)
 
                 icon.StackText:SetText("")
                 icon.StackText:Hide()
+                SetGlowStackCount(icon, nil)
             end
         end
     end
@@ -2958,6 +3072,7 @@ function CDMIcons:AcquireIcon(parent, spellEntry)
         end
         icon.StackText:SetText("")
         icon.StackText:Hide()
+        SetGlowStackCount(icon, nil)
         -- Update click-to-cast secure attributes for recycled icons
         if spellEntry.viewerType ~= "buff" then
             UpdateIconSecureAttributes(icon, spellEntry, spellEntry.viewerType)
@@ -3024,6 +3139,8 @@ function CDMIcons:ReleaseIcon(icon)
         icon.Cooldown:Clear()
     end
     icon.StackText:SetText("")
+    icon.StackText:Hide()
+    SetGlowStackCount(icon, nil)
     icon.Border:Hide()
 
     -- Clear click-to-cast secure button

--- a/modules/cooldowns/owned/glows.lua
+++ b/modules/cooldowns/owned/glows.lua
@@ -669,6 +669,15 @@ local function IsOverlayed(spellID)
     return overlayedSpells[spellID] or false
 end
 
+local function IsStackThresholdMet(icon, spellOvr)
+    if not icon or not spellOvr then return false end
+    local threshold = Helpers.SafeToNumber(spellOvr.glowStackThreshold, nil)
+    if not threshold or threshold <= 0 then return false end
+
+    local count = Helpers.SafeToNumber(icon._glowStackCount, nil)
+    return count and count >= threshold
+end
+
 local function EvaluateGlowForIcon(icon, includeHidden)
     if not icon or not icon._spellEntry then
         return false, nil
@@ -682,6 +691,8 @@ local function EvaluateGlowForIcon(icon, includeHidden)
     local shouldGlow
     if spellOvr and spellOvr.glowEnabled == false then
         shouldGlow = false
+    elseif IsStackThresholdMet(icon, spellOvr) then
+        shouldGlow = true
     elseif spellOvr and spellOvr.glowEnabled == true then
         shouldGlow = true
     else

--- a/modules/frames/resourcebars.lua
+++ b/modules/frames/resourcebars.lua
@@ -233,6 +233,7 @@ Enum.PowerType.MaelstromWeapon = 100
 Enum.PowerType.VengSoulFragments = 101
 Enum.PowerType.Whirlwind = 102       -- Fury Warrior Improved Whirlwind stacks
 Enum.PowerType.TipOfTheSpear = 103   -- Survival Hunter Tip of the Spear stacks
+Enum.PowerType.RenewingMistCharges = 104 -- Mistweaver Monk Renewing Mist charges
 
 ---------------------------------------------------------------------------
 -- WHIRLWIND STACK TRACKER (event-driven)
@@ -511,6 +512,44 @@ end
 
 local VDH_SOUL_FRAGMENTS_POWER = (Enum.PowerType and type(Enum.PowerType.SoulFragments) == "number") and Enum.PowerType.SoulFragments or nil
 
+-- Renewing Mist charge spell IDs.  115151 is the player-facing Mistweaver
+-- spell on most builds; 448430 is included as a build/PTR fallback because
+-- Blizzard spell records can shift between releases.
+local RENEWING_MIST_SPELL_IDS = { 115151, 448430 }
+
+local function GetSpellChargesCompat(spellID)
+    -- Dragonflight+/modern API: returns a table.  Some older clients/wrappers
+    -- still return multiple values, so support both forms.
+    if C_Spell and C_Spell.GetSpellCharges then
+        local a, b, c, d, e = C_Spell.GetSpellCharges(spellID)
+        if type(a) == "table" then
+            return a.currentCharges or 0,
+                   a.maxCharges or 0,
+                   a.cooldownStartTime or a.cooldownStart or a.startTime or 0,
+                   a.cooldownDuration or a.duration or 0,
+                   a.chargeModRate or 1
+        end
+        return a, b, c, d, e
+    end
+
+    -- Legacy global fallback.
+    if type(GetSpellCharges) == "function" then
+        return GetSpellCharges(spellID)
+    end
+
+    return nil, nil, nil, nil, nil
+end
+
+local function GetRenewingMistCharges()
+    for _, spellID in ipairs(RENEWING_MIST_SPELL_IDS) do
+        local current, max = GetSpellChargesCompat(spellID)
+        if max and max > 0 then
+            return max, current or 0
+        end
+    end
+    return nil, 0
+end
+
 local tocVersion = select(4, GetBuildInfo())
 local HAS_UNIT_POWER_PERCENT = type(UnitPowerPercent) == "function"
 
@@ -552,6 +591,7 @@ local tickedPowerTypes = {
     [Enum.PowerType.VengSoulFragments] = true,
     [Enum.PowerType.Whirlwind] = true,
     [Enum.PowerType.TipOfTheSpear] = true,
+    [Enum.PowerType.RenewingMistCharges] = true,
 }
 if VDH_SOUL_FRAGMENTS_POWER then
     tickedPowerTypes[VDH_SOUL_FRAGMENTS_POWER] = true
@@ -596,6 +636,7 @@ local instantFeedbackTypes = {
     [Enum.PowerType.VengSoulFragments] = true,
     [Enum.PowerType.Whirlwind] = true,
     [Enum.PowerType.TipOfTheSpear] = true,
+    [Enum.PowerType.RenewingMistCharges] = true,
 }
 if VDH_SOUL_FRAGMENTS_POWER then
     instantFeedbackTypes[VDH_SOUL_FRAGMENTS_POWER] = true
@@ -1413,6 +1454,7 @@ local function GetSecondaryResource()
         ["MONK"]        = {
             [268]  = "STAGGER", -- Brewmaster
             [269]  = Enum.PowerType.Chi, -- Windwalker
+            [270]  = Enum.PowerType.RenewingMistCharges, -- Mistweaver Renewing Mist charges
         },
         ["PALADIN"]     = Enum.PowerType.HolyPower,
         ["PRIEST"]      = {
@@ -1525,6 +1567,8 @@ local function GetResourceColor(resource)
             customColor = pc.whirlwind
         elseif resource == Enum.PowerType.TipOfTheSpear then
             customColor = pc.tipOfTheSpear
+        elseif resource == Enum.PowerType.RenewingMistCharges then
+            customColor = pc.renewingMistCharges or pc.renewingMist or pc.chi or pc.mana
         elseif resource == Enum.PowerType.LunarPower then
             customColor = pc.lunarPower
         elseif resource == Enum.PowerType.HolyPower then
@@ -1676,6 +1720,15 @@ local function GetSecondaryResourceValue(resource)
         -- Manual tracker (UNIT_SPELLCAST_SUCCEEDED) is reliable during combat;
         -- C_UnitAuras.GetPlayerAuraBySpellID(260286) returns stale/secret data.
         local max, current = TipOfTheSpearTracker:GetStacks()
+        if not max then return nil, nil, nil, nil end
+        return max, current, current, "number"
+    end
+
+    if resource == Enum.PowerType.RenewingMistCharges then
+        -- Mistweaver Monk Renewing Mist spell charges.
+        -- Uses the spell charge API instead of aura count so this tracks
+        -- available charges on the button, not active HoT applications.
+        local max, current = GetRenewingMistCharges()
         if not max then return nil, nil, nil, nil end
         return max, current, current, "number"
     end
@@ -4173,6 +4226,12 @@ function QUICore:OnUnitAura(_, unit)
     end
 end
 
+function QUICore:OnSpellChargeUpdate()
+    if GetSecondaryResource() == Enum.PowerType.RenewingMistCharges then
+        self:UpdateSecondaryPowerBar()
+    end
+end
+
 function QUICore:OnUnitPowerPointCharge(_, unit)
     if unit and unit ~= "player" then return end
     if GetSecondaryResource() == Enum.PowerType.ComboPoints then
@@ -4266,6 +4325,9 @@ local function InitializeResourceBars(self)
     powerEventFrame:RegisterUnitEvent("UNIT_MAXPOWER", "player")
     powerEventFrame:RegisterUnitEvent("UNIT_AURA", "player")  -- Aura-based resources (Maelstrom Weapon stacks)
     powerEventFrame:RegisterEvent("UNIT_POWER_POINT_CHARGE")  -- Charged combo points
+    powerEventFrame:RegisterEvent("SPELL_UPDATE_CHARGES")  -- Spell-charge resources (Renewing Mist)
+    powerEventFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN") -- Recharge timer completion fallback
+    powerEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player") -- Immediate charge updates on cast
     powerEventFrame:RegisterEvent("RUNE_POWER_UPDATE")  -- DK rune updates (no unit filter available)
     powerEventFrame:SetScript("OnEvent", function(_, event, unit, ...)
         if event == "RUNE_POWER_UPDATE" then
@@ -4274,6 +4336,18 @@ local function InitializeResourceBars(self)
             self:OnUnitAura(event, unit, ...)
         elseif event == "UNIT_POWER_POINT_CHARGE" then
             self:OnUnitPowerPointCharge(event, unit, ...)
+        elseif event == "SPELL_UPDATE_CHARGES" or event == "SPELL_UPDATE_COOLDOWN" then
+            self:OnSpellChargeUpdate(event)
+        elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+            local _, spellID = ...
+            if unit == "player" then
+                for _, renewingMistSpellID in ipairs(RENEWING_MIST_SPELL_IDS) do
+                    if spellID == renewingMistSpellID then
+                        self:OnSpellChargeUpdate(event)
+                        break
+                    end
+                end
+            end
         else
             self:OnUnitPower(event, unit, ...)
         end


### PR DESCRIPTION
## Changes

- Added fallback stack/count display for CDM icons using spell count APIs:
  - `C_Spell.GetSpellDisplayCount`
  - `C_Spell.GetSpellCastCount`
  - `GetSpellCount`
- Fixes cases like Mana Tea where the visible count is not exposed as a normal multi-charge spell via `GetSpellCharges`.
- Added per-spell `Glow at Stacks` setting in the CDM Spell Manager.
  - `0` disables the threshold.
  - When the displayed stack/count is greater than or equal to the configured value, the icon uses the existing CDM glow settings.
- Tracks icon stack/count state for both addon-driven stack text and Blizzard-native reparented stack/application text.
- Added Mistweaver Renewing Mist charge support to `resourcebars.lua`.
  - Adds a custom `RenewingMistCharges` resource type.
  - Tracks Renewing Mist charges through spell charge APIs.
  - Updates on charge, cooldown, and successful cast events.
  - Uses Renewing Mist-specific coloring fallback.

## Testing

- Verified Mana Tea stack/count text now displays on CDM icons.
- Verified stack-threshold glow can trigger using the existing CDM glow configuration.
- Ran `git diff --check` for touched CDM files.