### PR TITLE
fix(cdm, anchoring): track parent growth for dynamic anchored frames

### DIFF
--- a/modules/cooldowns/owned/cdm_bars.lua
+++ b/modules/cooldowns/owned/cdm_bars.lua
@@ -1591,11 +1591,9 @@ function CDMBars:LayoutBars(container, settings)
         else
             w, h = barWidth, barHeight
         end
-        if not InCombatLockdown() then
-            container:SetSize(w, h)
-            if _G.QUI_SetCDMViewerBounds then
-                _G.QUI_SetCDMViewerBounds(container, w, h)
-            end
+        pcall(container.SetSize, container, w, h)
+        if _G.QUI_SetCDMViewerBounds then
+            _G.QUI_SetCDMViewerBounds(container, w, h)
         end
         return
     end
@@ -1789,14 +1787,14 @@ function CDMBars:LayoutBars(container, settings)
     local lastW = container._lastBarLayoutW
     local lastH = container._lastBarLayoutH
     if lastW ~= totalW or lastH ~= totalH then
-        if not InCombatLockdown() then
-            container._lastBarLayoutW = totalW
-            container._lastBarLayoutH = totalH
-            container:SetSize(totalW, totalH)
-            -- Write calculated dimensions to viewer state for proxy sizing
-            if _G.QUI_SetCDMViewerBounds then
-                _G.QUI_SetCDMViewerBounds(container, totalW, totalH)
-            end
+        -- Must run in combat too: a bar going active mid-combat would
+        -- otherwise leave the container frozen at the previous height,
+        -- so frames anchored to its growth edge stop tracking.
+        container._lastBarLayoutW = totalW
+        container._lastBarLayoutH = totalH
+        pcall(container.SetSize, container, totalW, totalH)
+        if _G.QUI_SetCDMViewerBounds then
+            _G.QUI_SetCDMViewerBounds(container, totalW, totalH)
         end
     end
 end

--- a/modules/utility/anchoring.lua
+++ b/modules/utility/anchoring.lua
@@ -2221,6 +2221,19 @@ local CASTBAR_ANCHOR_KEYS = {
     totCastbar = true,
 }
 
+-- Frames whose own size mutates at runtime (icons appear/disappear, bars
+-- stack, totems drop/expire).  When one of these is the *child* being
+-- anchored, sizeStable is disabled so the explicit edge relation tracks
+-- the child's own growth.  When one of these is the *parent*, sizeStable
+-- is also disabled so the child tracks the parent's growth edge instead
+-- of being frozen at a CENTER↔CENTER offset baked from the initial size.
+local DYNAMIC_SIZE_ANCHOR_KEYS = {
+    buffBar = true,
+    buffFrame = true,
+    debuffFrame = true,
+    totemBar = true,
+}
+
 local function GetPointOffsetForRect(point, width, height)
     local halfW = (width or 0) * 0.5
     local halfH = (height or 0) * 0.5
@@ -2749,18 +2762,7 @@ function QUI_Anchoring:ApplyFrameAnchor(key, settings)
         -- so they track parent edge movement automatically in combat.
         useSizeStable = false
     end
-    if key == "buffBar" or key == "buffFrame" or key == "debuffFrame" then
-        -- Buff/debuff containers change size dynamically as auras appear/disappear.
-        -- Raw point anchoring keeps the growth edge fixed.
-        useSizeStable = false
-    end
-    if key == "totemBar" then
-        -- Totem bar container resizes dynamically as totems drop/expire
-        -- (1x1 when empty → N icons wide when active). sizeStable caches
-        -- CENTER offsets from the width at apply time, so the frame visibly
-        -- jumps when the size changes later — especially in combat where
-        -- LayoutButtons defers the SetSize until PLAYER_REGEN_ENABLED.
-        -- Raw point anchoring keeps the growth edge fixed instead.
+    if DYNAMIC_SIZE_ANCHOR_KEYS[key] or DYNAMIC_SIZE_ANCHOR_KEYS[settings.parent] then
         useSizeStable = false
     end
 
@@ -2827,7 +2829,8 @@ function QUI_Anchoring:ApplyFrameAnchor(key, settings)
         -- at 1x1 intentionally and grow as icons appear; converting to
         -- CENTER would break the growth-edge anchoring that LayoutIcons
         -- depends on.
-        local skipInflation = key == "buffFrame" or key == "debuffFrame" or key == "buffBar" or key == "totemBar"
+        local skipInflation = DYNAMIC_SIZE_ANCHOR_KEYS[key]
+            or DYNAMIC_SIZE_ANCHOR_KEYS[settings.parent]
         local needsInflation = false
         if not skipInflation and parentFrame and parentFrame ~= UIParent and parentFrame.GetSize then
             local ok, pw, ph = pcall(parentFrame.GetSize, parentFrame)
@@ -3080,7 +3083,8 @@ _G.QUI_ReanchorFramePositionOnly = function(key)
     local offsetX = settings.offsetX or 0
     local offsetY = settings.offsetY or 0
     local useSizeStable = IsSizeStableAnchoringEnabled(settings)
-    if CASTBAR_ANCHOR_KEYS[key] or key == "buffBar" or key == "buffFrame" or key == "debuffFrame" or key == "totemBar" then
+    if CASTBAR_ANCHOR_KEYS[key] or DYNAMIC_SIZE_ANCHOR_KEYS[key]
+        or DYNAMIC_SIZE_ANCHOR_KEYS[settings.parent] then
         useSizeStable = false
     end
 
@@ -3119,7 +3123,8 @@ _G.QUI_AnchorOverlayToParent = function(overlayFrame, key, overlayW, overlayH)
     local offsetX = settings.offsetX or 0
     local offsetY = settings.offsetY or 0
     local useSizeStable = IsSizeStableAnchoringEnabled(settings)
-    if CASTBAR_ANCHOR_KEYS[key] or key == "buffBar" or key == "buffFrame" or key == "debuffFrame" or key == "totemBar" then
+    if CASTBAR_ANCHOR_KEYS[key] or DYNAMIC_SIZE_ANCHOR_KEYS[key]
+        or DYNAMIC_SIZE_ANCHOR_KEYS[settings.parent] then
         useSizeStable = false
     end
 


### PR DESCRIPTION
CDM buff icons anchored to the top of CDM buff bars sat correctly above a single bar but were overrun once a second bar went active in combat.

Two compounding problems:

cdm_bars.lua: LayoutBars guarded container:SetSize() with if not InCombatLockdown(), freezing the trackedBar container at its previous height when a 2nd bar activated mid-combat. The container is a non-protected QUI Frame — SetSize is safe in combat. Replaced the guard with pcall as a defensive net.

anchoring.lua: when a frame is anchored to a parent whose size mutates at runtime (buffBar / buffFrame / debuffFrame / totemBar), sizeStable mode was solving the requested edge relation into a CENTER↔CENTER offset baked from the parent's apply-time size, leaving the child frozen as the parent grew. Existing carve-outs only disabled sizeStable when the child was one of those keys were missing the symmetric "parent is dynamic-size" case. Factored the set into DYNAMIC_SIZE_ANCHOR_KEYS and disable sizeStable + skipInflation when either key or settings.parent is in the set.

Together: bar 2 activates → SetSize fires → trackedBar's TOP edge moves up → buffIcon container follows live via raw BOTTOM→TOP anchor.