### PR TITLE
fix(profile-io): cover orphaned settings dropped by selective export

### DIFF
--- a/core/profile_io.lua
+++ b/core/profile_io.lua
@@ -472,9 +472,16 @@ local PROFILE_THEME_GENERAL_KEYS = {
     "defaultHealthOpacity",
     "defaultBgOpacity",
     "applyGlobalFontToBlizzard",
+    "overrideSCTFont",
 }
 
 local PROFILE_QOL_GENERAL_KEYS = {
+    "uiScale",
+    "allowReloadInCombat",
+    "autoInsertKey",
+    "consumableMacros",
+    "consumablePersistent",
+    "craftingOrderExpansionFilter",
     "sellJunk",
     "autoRepair",
     "autoRoleAccept",
@@ -532,6 +539,8 @@ local PROFILE_SKINNING_GENERAL_KEYS = {
     "skinKeystoneFrame",
     "skinGameMenu",
     "addQUIButton",
+    "addEditModeButton",
+    "objectiveTrackerClickThrough",
     "gameMenuFontSize",
     "gameMenuDim",
     "skinPowerBarAlt",
@@ -790,7 +799,7 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Theme / Fonts / Colors",
         description = "Shared fonts, textures, dark mode, and addon-wide color settings.",
         recommended = false,
-        topLevelKeys = { "addonAccentColor", "powerColors" },
+        topLevelKeys = { "addonAccentColor", "powerColors", "themePreset" },
         generalKeys = PROFILE_THEME_GENERAL_KEYS,
     },
     {
@@ -798,7 +807,7 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Layout / Positions",
         description = "Mover positions, HUD anchors, frame placement, and tracked element offsets.",
         recommended = false,
-        topLevelKeys = { "frameAnchoring", "dandersFrames", "abilityTimeline" },
+        topLevelKeys = { "frameAnchoring", "dandersFrames", "abilityTimeline", "blizzardMover" },
         paths = PROFILE_LAYOUT_PATHS,
     },
     {
@@ -881,6 +890,10 @@ local PROFILE_IMPORT_CATEGORIES = {
             "customGlow",
             "buffBorders",
             "keybindOverridesEnabledCDM",
+            "powerBar",
+            "secondaryPowerBar",
+            "powerColors",
+            "cooldownHighlighter",
         },
         children = {
             { id = "cdmEssential", label = "Essential", description = "Essential cooldown rows and essential viewer settings.", paths = { "ncdm.essential" } },
@@ -917,7 +930,7 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Action Bars",
         description = "Action bar styling, fade rules, and per-bar behavior.",
         recommended = true,
-        topLevelKeys = { "actionBars" },
+        topLevelKeys = { "actionBars", "actionBarsVisibility" },
         children = {
             {
                 id = "actionBarsMaster",
@@ -972,13 +985,13 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Minimap / Datatexts",
         description = "Minimap, datatext panel, and extra datatext settings.",
         recommended = true,
-        topLevelKeys = { "minimap", "datatext", "quiDatatexts" },
+        topLevelKeys = { "minimap", "minimapButton", "datatext", "quiDatatexts" },
         children = {
             {
                 id = "minimapSubtab",
                 label = "Minimap",
                 description = "Minimap frame and minimap utility settings.",
-                topLevelKeys = { "minimap" },
+                topLevelKeys = { "minimap", "minimapButton" },
             },
             {
                 id = "datatextSubtab",
@@ -993,11 +1006,7 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Custom CDM Bars",
         description = "Custom CDM bar settings and individual imported bars.",
         recommended = true,
-        topLevelKeys = { "customTrackersVisibility", "keybindOverridesEnabledTrackers" },
-        paths = {
-            "customTrackers.bars",
-            "customTrackers.keybinds",
-        },
+        topLevelKeys = { "customTrackers", "customTrackersVisibility", "keybindOverridesEnabledTrackers" },
         children = {
             {
                 id = "customTrackersShared",
@@ -1023,6 +1032,7 @@ local PROFILE_IMPORT_CATEGORIES = {
             "combatTimer",
             "xpTracker",
             "totemBar",
+            "preyTracker",
         },
     },
     {
@@ -1030,14 +1040,14 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Chat",
         description = "Chat frame skinning, formatting, and utility options.",
         recommended = true,
-        topLevelKeys = { "chat" },
+        topLevelKeys = { "chat", "chatVisibility" },
     },
     {
         id = "qol",
         label = "QoL / Automation",
         description = "Automation helpers, popup blocker, consumables, and utility toggles.",
         recommended = true,
-        topLevelKeys = { "uiHider" },
+        topLevelKeys = { "uiHider", "configPanelWidth", "configPanelAlpha", "configPanelScale" },
         generalKeys = PROFILE_QOL_GENERAL_KEYS,
     },
     {


### PR DESCRIPTION
Selective export with Select-All silently dropped 17 profile fields because they weren't listed in any category's topLevelKeys, generalKeys, or paths. Resource-bar custom color/height, UI scale, and the options panel size were the most visible casualties.

Adds the missing keys to the appropriate categories so a Select-All export now round-trips every user-configurable field. Also folds powerBar/secondaryPowerBar/powerColors into the cdm parent so parent-only selection includes them (previously only the cdmClassResourceBar child covered them, and Select-All filters child IDs out when their parent is also selected).

Verified by enumerating every db.profile key from defaults.lua and diffing against the union of every category's coverage lists — zero unintended orphans remain.


(cherry picked from commit bc0f41367f4d9864ef34fca3ed939ad983833e21)