### PR TITLE
fix(profile-io): include layoutMode and options panel collapsible sta…

### DIFF
--- a/core/profile_io.lua
+++ b/core/profile_io.lua
@@ -807,7 +807,7 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "Layout / Positions",
         description = "Mover positions, HUD anchors, frame placement, and tracked element offsets.",
         recommended = false,
-        topLevelKeys = { "frameAnchoring", "dandersFrames", "abilityTimeline", "blizzardMover" },
+        topLevelKeys = { "frameAnchoring", "dandersFrames", "abilityTimeline", "blizzardMover", "layoutMode" },
         paths = PROFILE_LAYOUT_PATHS,
     },
     {
@@ -1047,7 +1047,7 @@ local PROFILE_IMPORT_CATEGORIES = {
         label = "QoL / Automation",
         description = "Automation helpers, popup blocker, consumables, and utility toggles.",
         recommended = true,
-        topLevelKeys = { "uiHider", "configPanelWidth", "configPanelAlpha", "configPanelScale" },
+        topLevelKeys = { "uiHider", "configPanelWidth", "configPanelAlpha", "configPanelScale", "optionsPanelCollapsibleStates" },
         generalKeys = PROFILE_QOL_GENERAL_KEYS,
     },
     {


### PR DESCRIPTION
…te in selective export

Two more lazy-created profile keys absent from defaults.lua but present at runtime. Both represent real user preferences that should travel with selective exports:

- db.layoutMode  — hidden mover handles, snap, side panel position/side (created in modules/utility/layoutmode*.lua); now in the layout category
- db.optionsPanelCollapsibleStates — which options-panel sections the user has collapsed (created in options/shared.lua); now in the qol category alongside configPanelWidth/Alpha/Scale

Surfaced by diffing a real Select-All export against a full export and finding 22 missing top-level keys, of which these were the only two worth including (the rest were AceDB internals, per-machine fpsBackup, or migrated-away legacy fields).


(cherry picked from commit f82ac058554e97c7e0ac076fb6702dd5207c1af4)