### PR TITLE
fix: custom entries UpdateIconCooldown state mgmt

### DIFF
--- a/modules/cooldowns/owned/cdm_icons.lua
+++ b/modules/cooldowns/owned/cdm_icons.lua
@@ -2585,6 +2585,7 @@ local function UpdateIconCooldown(icon)
             local itemID = GetInventoryItemID("player", slotID)
             if itemID then
                 startTime, duration, durObj = GetSlotCooldown(slotID)
+                apiIsActive = (startTime ~= nil and duration ~= nil)
                 -- Update texture in case trinket was swapped
                 if icon.Icon then
                     local ok, tex = pcall(C_Item.GetItemIconByID, itemID)
@@ -2593,12 +2594,15 @@ local function UpdateIconCooldown(icon)
                         icon._lastTexture = tex
                     end
                 end
+            else
+                apiIsActive = false
             end
             -- Hide stack text for trinkets
             icon.StackText:SetText("")
             icon.StackText:Hide()
         elseif entry.type == "item" then
             startTime, duration, durObj = GetItemCooldown(entry.id)
+            apiIsActive = (startTime ~= nil and duration ~= nil)
             -- Show item count as stack text (includeUses=true for charge items)
             if C_Item and C_Item.GetItemCount then
                 local ok, count = pcall(C_Item.GetItemCount, entry.id, false, true)
@@ -2928,6 +2932,7 @@ local function UpdateIconCooldown(icon)
             and not _chargeCountForwarded
             and icon._durObjHookSync
             and apiIsActive ~= false
+            and entry._blizzChild
             and (_batchTime - icon._durObjHookSync) < 10
 
 


### PR DESCRIPTION
 ## Summary

Had issues with tracking of custom entries, especially trinkets not syncing cds properly

  ## Problem

  Custom trinket entries for me would seemingly randomly stop tracking CDs for me

  Two state management gaps in `UpdateIconCooldown` caused the issue:

  1. **`mirrorActive` false positive:** After a successful `SetCooldown`, `_durObjHookSync` was set, activating a
  10-second throttle designed for Blizzard-backed entries with DurationObject mirror hooks. Custom entries have no
  mirror hook, so during these windows neither the re-apply nor the clear path could execute - cooldown state changes
  (expiration, new use, reset) were invisible.

  2. **`apiIsActive` never set:** Without `apiIsActive`, `cooldownInactive` could never become `true`, so
  `icon.Cooldown:Clear()` never fired when the cooldown ended. Stale internal flags (`_showingRealCooldownSwipe`,
  `_durObjHookSync`, `_hasCooldownActive`) accumulated across uses, compounding the first issue.

  ## Fix

  - Added `entry._blizzChild` guard to `mirrorActive` so only entries with an actual mirror hook are throttled.
  - Derived `apiIsActive` from `GetSlotCooldown`/`GetItemCooldown` results for trinket, slot, and item entries, enabling
   proper cooldown clearing and desaturation.

Testing ingame for me it works as expected