### PR TITLE
fix(chat): don't clobber a foreign chat addon's editbox when QUI_Chat is disabled

### DIFF
--- a/QUI_Chat/chat/editbox_basics.lua
+++ b/QUI_Chat/chat/editbox_basics.lua
@@ -392,25 +392,26 @@ function RemoveEditBoxStyle(chatFrame)
     end
     if not editBox then return end
 
-    -- Stock restore: the live disable flip must hand back a fully stock
-    -- editbox (no /reload). Inverse of StyleEditBox's strip + reanchor.
-    -- Anchors per FloatingChatFrame.xml's ChatFrameEditBoxTemplate use:
-    -- TOPLEFT -> chatFrame BOTTOMLEFT (-5,-2), RIGHT -> ScrollBar RIGHT (8,0).
-    if editBox.ClearAllPoints and editBox.SetPoint then
-        editBox:ClearAllPoints()
-        editBox:SetPoint("TOPLEFT", chatFrame, "BOTTOMLEFT", -5, -2)
-        local scrollBar = chatFrame.ScrollBar
-        if scrollBar then
-            editBox:SetPoint("RIGHT", scrollBar, "RIGHT", 8, 0)
-        else
-            editBox:SetPoint("RIGHT", chatFrame, "RIGHT", 8, 0)
-        end
-    end
-
     -- Un-strip the Blizzard chrome StyleEditBox hid/alpha'd, and clear the
     -- styled latch so a re-enable re-strips.
     local ebState = I.editBoxState[editBox]
     if ebState and ebState.styled then
+        -- Stock restore: the live disable flip must hand back a fully stock
+        -- editbox (no /reload). Inverse of StyleEditBox's strip + reanchor.
+        -- Anchors per FloatingChatFrame.xml's ChatFrameEditBoxTemplate use:
+        -- TOPLEFT -> chatFrame BOTTOMLEFT (-5,-2), RIGHT -> ScrollBar RIGHT (8,0).
+        -- Only runs when QUI actually styled the editbox — otherwise another
+        -- addon's anchoring would be clobbered on every disabled Apply().
+        if editBox.ClearAllPoints and editBox.SetPoint then
+            editBox:ClearAllPoints()
+            editBox:SetPoint("TOPLEFT", chatFrame, "BOTTOMLEFT", -5, -2)
+            local scrollBar = chatFrame.ScrollBar
+            if scrollBar then
+                editBox:SetPoint("RIGHT", scrollBar, "RIGHT", 8, 0)
+            else
+                editBox:SetPoint("RIGHT", chatFrame, "RIGHT", 8, 0)
+            end
+        end
         ebState.styled = false
         -- Hand the QUI chat font back to the stock chat font, on the input AND
         -- each channel-prefix child. RestoreStockEditBoxFont uses SetFont (never

--- a/QUI_Chat/chat/editbox_basics.lua
+++ b/QUI_Chat/chat/editbox_basics.lua
@@ -378,70 +378,75 @@ end
 ---------------------------------------------------------------------------
 function RemoveEditBoxStyle(chatFrame)
     if not chatFrame then return end
-    -- Hide backdrop stored in local table
+    local frameName = chatFrame.GetName and chatFrame:GetName()
+    local editBox = chatFrame.editBox or (frameName and _G[frameName .. "EditBox"])
+    if not editBox then return end
+
+    -- Nothing to undo if QUI never styled this editbox: bail before touching the
+    -- backdrop, mouse, alpha, anchors, or font so a foreign chat addon's editbox
+    -- is left exactly as it was. Single gate (vs. per-block guards) keeps "did we
+    -- style this?" in one place; clearing the latch makes a repeat teardown a
+    -- no-op too.
+    local ebState = I.editBoxState[editBox]
+    if not (ebState and ebState.styled) then return end
+    ebState.styled = false
+
+    -- Hide the glass backdrop (only ever created by StyleEditBox).
     if I.editBoxBackdrops[chatFrame] then
         I.editBoxBackdrops[chatFrame]:Hide()
     end
-    -- Restore mouse on the editBox — top mode disables it while unfocused so
-    -- clicks fall through to the tabs, and that state must not survive teardown.
-    local frameName = chatFrame.GetName and chatFrame:GetName()
-    local editBox = chatFrame.editBox or (frameName and _G[frameName .. "EditBox"])
-    if editBox and editBox.EnableMouse then
+
+    -- Restore mouse + visibility on the editBox — top mode disables the mouse
+    -- while unfocused so clicks fall through to the tabs, and that state must not
+    -- survive teardown.
+    if editBox.EnableMouse then
         editBox:EnableMouse(true)
         SetEditBoxVisualShown(editBox, true)
     end
-    if not editBox then return end
 
-    -- Un-strip the Blizzard chrome StyleEditBox hid/alpha'd, and clear the
-    -- styled latch so a re-enable re-strips.
-    local ebState = I.editBoxState[editBox]
-    if ebState and ebState.styled then
-        -- Stock restore: the live disable flip must hand back a fully stock
-        -- editbox (no /reload). Inverse of StyleEditBox's strip + reanchor.
-        -- Anchors per FloatingChatFrame.xml's ChatFrameEditBoxTemplate use:
-        -- TOPLEFT -> chatFrame BOTTOMLEFT (-5,-2), RIGHT -> ScrollBar RIGHT (8,0).
-        -- Only runs when QUI actually styled the editbox — otherwise another
-        -- addon's anchoring would be clobbered on every disabled Apply().
-        if editBox.ClearAllPoints and editBox.SetPoint then
-            editBox:ClearAllPoints()
-            editBox:SetPoint("TOPLEFT", chatFrame, "BOTTOMLEFT", -5, -2)
-            local scrollBar = chatFrame.ScrollBar
-            if scrollBar then
-                editBox:SetPoint("RIGHT", scrollBar, "RIGHT", 8, 0)
-            else
-                editBox:SetPoint("RIGHT", chatFrame, "RIGHT", 8, 0)
-            end
+    -- Stock restore: the live disable flip must hand back a fully stock editbox
+    -- (no /reload). Inverse of StyleEditBox's strip + reanchor. Anchors per
+    -- FloatingChatFrame.xml's ChatFrameEditBoxTemplate use:
+    -- TOPLEFT -> chatFrame BOTTOMLEFT (-5,-2), RIGHT -> ScrollBar RIGHT (8,0).
+    if editBox.ClearAllPoints and editBox.SetPoint then
+        editBox:ClearAllPoints()
+        editBox:SetPoint("TOPLEFT", chatFrame, "BOTTOMLEFT", -5, -2)
+        local scrollBar = chatFrame.ScrollBar
+        if scrollBar then
+            editBox:SetPoint("RIGHT", scrollBar, "RIGHT", 8, 0)
+        else
+            editBox:SetPoint("RIGHT", chatFrame, "RIGHT", 8, 0)
         end
-        ebState.styled = false
-        -- Hand the QUI chat font back to the stock chat font, on the input AND
-        -- each channel-prefix child. RestoreStockEditBoxFont uses SetFont (never
-        -- SetFontObject) so a captured self-referential font object can't
-        -- stack-overflow the client — see its comment.
-        RestoreStockEditBoxFont(editBox)
-        for _, key in ipairs(EDITBOX_HEADER_KEYS) do
-            RestoreStockEditBoxFont(editBox[key])
+    end
+
+    -- Hand the QUI chat font back to the stock chat font, on the input AND each
+    -- channel-prefix child. RestoreStockEditBoxFont uses SetFont (never
+    -- SetFontObject) so a captured self-referential font object can't
+    -- stack-overflow the client — see its comment.
+    RestoreStockEditBoxFont(editBox)
+    for _, key in ipairs(EDITBOX_HEADER_KEYS) do
+        RestoreStockEditBoxFont(editBox[key])
+    end
+    for _, suffix in ipairs(EDITBOX_CHILD_SUFFIXES) do
+        local child = frameName and _G[frameName .. "EditBox" .. suffix]
+        if child and child.Show then
+            child:Show()
         end
-        for _, suffix in ipairs(EDITBOX_CHILD_SUFFIXES) do
-            local child = frameName and _G[frameName .. "EditBox" .. suffix]
-            if child and child.Show then
-                child:Show()
-            end
+    end
+    if editBox.focusLeft then editBox.focusLeft:SetAlpha(1) end
+    if editBox.focusMid then editBox.focusMid:SetAlpha(1) end
+    if editBox.focusRight then editBox.focusRight:SetAlpha(1) end
+    for _, name in ipairs(EDITBOX_TEXTURES) do
+        local tex = editBox[name]
+        if tex and tex.Show then
+            tex:Show()
         end
-        if editBox.focusLeft then editBox.focusLeft:SetAlpha(1) end
-        if editBox.focusMid then editBox.focusMid:SetAlpha(1) end
-        if editBox.focusRight then editBox.focusRight:SetAlpha(1) end
-        for _, name in ipairs(EDITBOX_TEXTURES) do
-            local tex = editBox[name]
-            if tex and tex.Show then
-                tex:Show()
-            end
-        end
-        if editBox.GetRegions then
-            local regions = { editBox:GetRegions() }
-            for _, region in ipairs(regions) do
-                if region and region.GetObjectType and region:GetObjectType() == "Texture" then
-                    region:SetAlpha(1)
-                end
+    end
+    if editBox.GetRegions then
+        local regions = { editBox:GetRegions() }
+        for _, region in ipairs(regions) do
+            if region and region.GetObjectType and region:GetObjectType() == "Texture" then
+                region:SetAlpha(1)
             end
         end
     end


### PR DESCRIPTION
## Summary
When QUI_Chat is loaded but the chat module is disabled (`chat.enabled = false`), QUI_Chat still mutated `ChatFrame1EditBox` on every `DisplayFallback.Apply()` (fires at `ADDON_LOADED`, `PLAYER_LOGIN`, and every settings refresh). For users running a **separate chat addon**, this clobbered that addon's editbox — repositioning it and forcing its mouse/alpha state. Disabling QUI_Chat entirely was the only workaround.

Root cause is in `RemoveEditBoxStyle` (`QUI_Chat/chat/editbox_basics.lua`), which ran its restore logic unconditionally instead of only when QUI had actually styled the editbox.

## Changes
- **Anchor reset** (`ClearAllPoints`/`SetPoint`) moved inside the `ebState.styled` guard, so stock anchors are only re-applied when QUI styled the editbox.
- **Mouse + visibility restore** (`EnableMouse(true)` + `SetAlpha(1)`) sat in the prologue, *before* the guard, so it fired even for an editbox QUI never touched. `RemoveEditBoxStyle` is refactored to a single early return: when `ebState.styled` is false it touches nothing (backdrop, mouse, alpha, anchors, font). Clearing the latch up front also makes a repeat teardown idempotent.

Net effect: with the chat module disabled, `RemoveEditBoxStyle` is a complete no-op for an editbox QUI never styled, leaving a foreign chat addon's editbox exactly as it was.

## Testing
- Existing unit tests (`chat_editbox_top_focus_test`, `chat_editbox_font_test`, `chat_editbox_restore_safe_font_test`, `chat_editbox_takeover_rewire_test`) all `StyleEditBox` before `RemoveEditBoxStyle`, so styled-path behavior is unchanged. Verified locally with Lua 5.1.
- Verified in-game (retail) with the chat module disabled across multiple chat setups — **Chattynator**, the **native Blizzard chat**, and **QUI's own chat** — confirming the active chat's editbox keeps its position and mouse/alpha state.