### PR TITLE
fix(groupframes): missing raid buff reliability

### DIFF
--- a/QUI_GroupFrames/groupframes/groupframes.lua
+++ b/QUI_GroupFrames/groupframes/groupframes.lua
@@ -3927,6 +3927,8 @@ local function CheckUnitRange(unit)
     return true
 end
 
+QUI_GF.CheckUnitRange = CheckUnitRange
+
 local function ApplyRangeAlpha(frame, inRange, outAlpha)
     if frame.SetAlphaFromBoolean then
         frame:SetAlphaFromBoolean(inRange, 1, outAlpha)

--- a/QUI_GroupFrames/groupframes/groupframes_auras.lua
+++ b/QUI_GroupFrames/groupframes/groupframes_auras.lua
@@ -856,6 +856,8 @@ local function ApplyAuraDelta(unit, updateInfo)
                     else
                         debuffsDirty = true
                     end
+                else
+                    _deltaSummary.spellsUncertain = true
                 end
             end
         end
@@ -876,6 +878,9 @@ local function ApplyAuraDelta(unit, updateInfo)
             if rd and RemoveAuraFromBucket(cache, "debuffs", instID) then
                 debuffsDirty = true
                 SummaryAddSpell(rd)
+            end
+            if not rb and not rd then
+                _deltaSummary.spellsUncertain = true
             end
         end
     end
@@ -998,7 +1003,7 @@ local function GetAuraRelevance(auras, specID)
 end
 
 local function DeltaTouchesFrame(rel, dirty)
-    if dirty.helpful and rel.hasMissingRaidBuff then return true end
+    if (dirty.helpful or dirty.spellsUncertain) and rel.hasMissingRaidBuff then return true end
     if rel.hasTracked then
         if dirty.spellsUncertain then return true end
         for sid in pairs(dirty.spells) do
@@ -1075,7 +1080,7 @@ local function RenderFrameElements(frame, cache, dirty)
             local elementDirty = (dirty == nil)
             if not elementDirty then
                 if element.mode == "missingRaidBuff" then
-                    elementDirty = dirty.helpful
+                    elementDirty = dirty.helpful or dirty.spellsUncertain
                 elseif element.mode == "tracked" then
                     if dirty.spellsUncertain then
                         elementDirty = true

--- a/QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua
+++ b/QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua
@@ -22,6 +22,7 @@ local GetNumGroupMembers = GetNumGroupMembers
 local InCombatLockdown = InCombatLockdown
 local GetSpecialization = GetSpecialization
 local GetSpecializationInfo = GetSpecializationInfo
+local C_SpecializationInfo = C_SpecializationInfo
 local IsPlayerSpell = IsPlayerSpell
 local IsSpellKnown = IsSpellKnown
 local CreateFrame = CreateFrame
@@ -280,9 +281,11 @@ local function GetBuffName(buff)
             name = resolved
         end
     end
-    name = name or buff.label
-    nameCache[buff.key] = name
-    return name
+    if name then
+        nameCache[buff.key] = name
+        return name
+    end
+    return buff.label
 end
 
 local function GetBuffIcon(buff)
@@ -298,26 +301,28 @@ local function GetBuffIcon(buff)
         local ok, resolved = pcall(GetSpellTexture, spellID)
         if ok and resolved then icon = resolved end
     end
-    icon = icon or 134400
-    iconCache[spellID] = icon
-    return icon
+    if icon then
+        iconCache[spellID] = icon
+        return icon
+    end
+    return 134400
 end
 
 local function GetSyntheticAura(buff)
     local aura = syntheticAuraCache[buff.key]
-    if aura then return aura end
-
-    aura = {
-        auraInstanceID = "QUI_MissingRaidBuff_" .. buff.key,
-        spellId = buff.iconSpellID or buff.ids[1],
-        name = GetBuffName(buff),
-        icon = GetBuffIcon(buff),
-        duration = 0,
-        expirationTime = 0,
-        isHelpful = true,
-        isHarmful = false,
-    }
-    syntheticAuraCache[buff.key] = aura
+    if not aura then
+        aura = {
+            auraInstanceID = "QUI_MissingRaidBuff_" .. buff.key,
+            spellId = buff.iconSpellID or buff.ids[1],
+            duration = 0,
+            expirationTime = 0,
+            isHelpful = true,
+            isHarmful = false,
+        }
+        syntheticAuraCache[buff.key] = aura
+    end
+    aura.name = GetBuffName(buff)
+    aura.icon = GetBuffIcon(buff)
     return aura
 end
 
@@ -478,21 +483,31 @@ function MRB:UnitHasMyBuff(unit, ids)
     return false
 end
 
-local function UnitInKnownRange(unit)
-    if unit == "player" then return true end
+function MRB._rangeProbe(unit)
+    local GF = ns.QUI_GroupFrames
+    if GF and GF.CheckUnitRange then
+        local ok, inRange = pcall(GF.CheckUnitRange, unit)
+        if not ok or IsSecretValue(inRange) then return false end
+        return inRange ~= false
+    end
     if UnitInRange then
         local ok, inRange, checked = pcall(UnitInRange, unit)
-        if ok then
-            if IsSecretValue(inRange) or IsSecretValue(checked) then
-            elseif checked and inRange == false then
-                return false
-            end
-        end
+        if not ok then return false end
+        -- @secret-policy: reject-secret-value
+        if IsSecretValue(inRange) then return false end
+        -- @secret-policy: reject-secret-value
+        if IsSecretValue(checked) then return false end
+        if checked and inRange == false then return false end
     end
     return true
 end
 
-local function UnitEligible(unit)
+local function UnitInKnownRange(unit)
+    if MRB._isPlayerUnitProbe(unit) then return true end
+    return MRB._rangeProbe(unit) == true
+end
+
+local function UnitEligible(unit, skipRange)
     if not unit or not SafeBoolean(UnitExists, unit, false) then return false end
     if SafeBoolean(UnitIsDeadOrGhost, unit, true) then return false end
     if SafeBoolean(UnitIsConnected, unit, false) == false then return false end
@@ -501,18 +516,21 @@ local function UnitEligible(unit)
         local ok, canAssist = pcall(UnitCanAssist, "player", unit)
         if not ok or IsSecretValue(canAssist) or not canAssist then return false end
     end
-    if not UnitInKnownRange(unit) then return false end
+    if not skipRange and not UnitInKnownRange(unit) then return false end
     return true
 end
 
-function MRB._eligibleProbe(unit) return UnitEligible(unit) end
+function MRB._eligibleProbe(unit, skipRange) return UnitEligible(unit, skipRange) end
 
 function MRB._specProbe()
-    if not GetSpecialization then return nil end
-    local idx = GetSpecialization()
+    local getSpec = (C_SpecializationInfo and C_SpecializationInfo.GetSpecialization)
+        or GetSpecialization
+    local getSpecInfo = (C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo)
+        or GetSpecializationInfo
+    if not getSpec or not getSpecInfo then return nil end
+    local idx = getSpec()
     if not idx then return nil end
-    local specID = GetSpecializationInfo and GetSpecializationInfo(idx) or nil
-    return specID
+    return (getSpecInfo(idx))
 end
 
 function MRB._groupUnitsProbe()
@@ -576,7 +594,7 @@ function MRB:AnyEligibleAllyHasMyBuff(ids)
     local sawUnknown = false
     for i = 1, #units do
         local unit = units[i]
-        if MRB._eligibleProbe(unit) then
+        if MRB._eligibleProbe(unit, true) then
             local has = MRB:UnitHasMyBuff(unit, ids)
             if has == true then
                 return true

--- a/tests/helpers/pcall_site_inventory.lua
+++ b/tests/helpers/pcall_site_inventory.lua
@@ -44,7 +44,7 @@ return {
     "QUI_Debug/ui_smoke.lua::5",
     "QUI_GroupFrames/groupframes/groupframes.lua::8",
     "QUI_GroupFrames/groupframes/groupframes_aura_render.lua::6",
-    "QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua::24",
+    "QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua::25",
     "QUI_GroupFrames/groupframes/groupframes_targeted_spells.lua::8",
     "QUI_GroupFrames/groupframes/raidbuffs.lua::9",
     "QUI_GroupFrames/groupframes/settings/click_cast_content.lua::6",

--- a/tests/unit/groupframes_missing_raid_buffs_range_test.lua
+++ b/tests/unit/groupframes_missing_raid_buffs_range_test.lua
@@ -1,0 +1,163 @@
+-- tests/unit/groupframes_missing_raid_buffs_range_test.lua
+-- Run: lua tests/unit/groupframes_missing_raid_buffs_range_test.lua
+-- Validates the missing-raid-buff range gate (_rangeProbe): prefers the
+-- group-frame range engine, fails CLOSED on secret/unknown range, falls
+-- back to UnitInRange; plus the C_SpecializationInfo spec probe preference
+-- and the synthetic-aura name/icon cache self-heal.
+
+-- =========================================================================
+-- Minimal WoW global stubs (set BEFORE loadfile so locals capture them)
+-- =========================================================================
+
+_G.CreateFrame = function()
+    return setmetatable({}, { __index = function() return function() end end })
+end
+
+_G.wipe = function(t)
+    for k in pairs(t) do t[k] = nil end
+    return t
+end
+
+-- Test-controlled UnitInRange fallback (captured as a dispatcher at load).
+local unitInRangeResult = { true, true }
+_G.UnitInRange = function() return unitInRangeResult[1], unitInRangeResult[2] end
+
+_G.UnitExists        = function() return true  end
+_G.UnitIsDeadOrGhost = function() return false end
+_G.UnitIsConnected   = function() return true  end
+_G.UnitIsPlayer      = function() return true  end
+_G.UnitCanAssist     = function() return true  end
+_G.UnitIsUnit        = function(u, other) return u == other end
+_G.UnitClass         = function() return "Priest", "PRIEST" end
+_G.IsInRaid          = function() return false end
+_G.IsInGroup         = function() return true  end
+_G.GetNumGroupMembers = function() return 2 end
+_G.InCombatLockdown  = function() return false end
+_G.GetTime           = function() return 0 end
+_G.C_Timer = { After = function() end }
+
+-- Spell name/icon lookups: start UNRESOLVED (early-login simulation).
+local spellDataLoaded = false
+_G.C_Spell = {
+    GetSpellName = function(id)
+        if spellDataLoaded then return "Machtwort: Seelenstaerke" end
+        return nil
+    end,
+    GetSpellTexture = function(id)
+        if spellDataLoaded then return 135987 end
+        return nil
+    end,
+}
+_G.C_UnitAuras = {
+    GetPlayerAuraBySpellID = function() return nil end,
+    GetUnitAuraBySpellID   = function() return nil end,
+}
+_G.AuraUtil = {}
+
+-- Spec API: both the deprecated globals and the C_ namespace exist; the
+-- namespace must win.
+_G.GetSpecialization = function() return 1 end
+_G.GetSpecializationInfo = function() return 111 end
+_G.C_SpecializationInfo = {
+    GetSpecialization = function() return 2 end,
+    GetSpecializationInfo = function(idx)
+        assert(idx == 2, "spec index must come from C_SpecializationInfo")
+        return 222, "SpecName"
+    end,
+}
+
+local ns = {}
+ns.Helpers = {
+    IsSecretValue = function(v) return v == "SECRET" end,
+}
+
+assert(loadfile("QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua"))(
+    "QUI_GroupFrames", ns)
+local MRB = ns.QUI_GroupFrameMissingRaidBuffs
+
+local failures = 0
+local function check(label, cond)
+    if cond then
+        print("  ok  " .. label)
+    else
+        failures = failures + 1
+        print("  FAIL " .. label)
+    end
+end
+
+-- =========================================================================
+-- 1. _rangeProbe with the group-frame range engine
+-- =========================================================================
+local rangeResult = true
+ns.QUI_GroupFrames = {
+    CheckUnitRange = function(unit)
+        if rangeResult == "THROW" then error("boom") end
+        return rangeResult
+    end,
+}
+
+rangeResult = true
+check("engine in-range -> probe true", MRB._rangeProbe("party1") == true)
+rangeResult = false
+check("engine out-of-range -> probe false", MRB._rangeProbe("party1") == false)
+rangeResult = "SECRET"
+check("engine secret range -> probe false (fail closed)", MRB._rangeProbe("party1") == false)
+rangeResult = "THROW"
+check("engine error -> probe false (fail closed)", MRB._rangeProbe("party1") == false)
+
+-- =========================================================================
+-- 2. _rangeProbe UnitInRange fallback (no engine available)
+-- =========================================================================
+ns.QUI_GroupFrames = nil
+
+unitInRangeResult = { true, true }
+check("fallback (true, checked) -> probe true", MRB._rangeProbe("party1") == true)
+unitInRangeResult = { false, true }
+check("fallback (false, checked) -> probe false", MRB._rangeProbe("party1") == false)
+unitInRangeResult = { true, false }
+check("fallback unchecked -> probe true (range unknowable, keep icon)", MRB._rangeProbe("party1") == true)
+unitInRangeResult = { "SECRET", "SECRET" }
+check("fallback secret -> probe false (fail closed)", MRB._rangeProbe("party1") == false)
+
+-- =========================================================================
+-- 3. BuildMatches honors the range gate
+-- =========================================================================
+local element = { classDetection = true, maxIcons = 1 }
+
+unitInRangeResult = { true, true }
+local matches = MRB:BuildMatches("party1", element, {})
+check("in-range unit missing Fortitude -> 1 match", #matches == 1)
+check("match is the stamina synthetic aura", matches[1] and matches[1].spellId == 21562)
+
+unitInRangeResult = { false, true }
+matches = MRB:BuildMatches("party1", element, {})
+check("out-of-range unit -> suppressed", #matches == 0)
+
+unitInRangeResult = { "SECRET", "SECRET" }
+matches = MRB:BuildMatches("party1", element, {})
+check("secret-range unit -> suppressed (fail closed)", #matches == 0)
+
+matches = MRB:BuildMatches("player", element, {})
+check("player token exempt from range gate", #matches == 1)
+
+-- =========================================================================
+-- 4. Synthetic aura name/icon self-heal (no permanent fallback caching)
+-- =========================================================================
+unitInRangeResult = { true, true }
+matches = MRB:BuildMatches("party1", element, {})
+check("pre-spell-data: label fallback used", matches[1].name == "Power Word: Fortitude")
+check("pre-spell-data: question-mark icon fallback", matches[1].icon == 134400)
+
+spellDataLoaded = true
+matches = MRB:BuildMatches("party1", element, {})
+check("post-spell-data: localized name self-heals", matches[1].name == "Machtwort: Seelenstaerke")
+check("post-spell-data: real icon self-heals", matches[1].icon == 135987)
+
+-- =========================================================================
+-- 5. _specProbe prefers C_SpecializationInfo over deprecated globals
+-- =========================================================================
+check("spec probe returns C_SpecializationInfo specID", MRB._specProbe() == 222)
+
+print(string.format("\n%d failure(s)", failures))
+if failures > 0 then os.exit(1) end
+print("OK: groupframes_missing_raid_buffs_range_test")


### PR DESCRIPTION
Cherry-picks `0875f7aa` "fix(groupframes): missing raid buff reliability" from `feature/QUI-PTR` onto `beta`. Fast-forward from `ab6ac639`.

Three deliberate deviations from the upstream diff:

- **Prose comments dropped** (34 lines). All three merge conflicts were comment-vs-code collisions — `beta` has the stripped `QUI_GroupFrames` tree, the source branch still carries the prose. Upstream's code taken verbatim. The new test file keeps its comments, since `tests/unit/**` was never stripped.
- **`_rangeProbe`'s `UnitInRange` guard restructured.** Upstream's `if not ok or IsSecretValue(inRange) or IsSecretValue(checked)` credits neither value in the strict taint analyzer, so the following `if checked and inRange == false` tripped `<comparison>` and `<truthiness>`. Beta's baseline is 0 strict findings, so this was a real regression on gate 2. Split into per-statement probes with two named `reject-secret-value` policies. Semantics unchanged; the range probe still fails closed on an unreadable value.
- **`pcall_site_inventory.lua` bumped** 24 → 25 for the new checked-result probe.

`bash tools/test.sh` → 9/9 green (797 unit tests, taint strict, luacheck, profiles, both staleness gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
