### PR TITLE
docs: bring beta up to main (README and docs site corrections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,35 +33,13 @@ QUI is a modular World of Warcraft UI suite for Midnight 12.1+. It combines comb
 
 Log in and open `/qui` (or `/qui`) to get started.
 
-## Coming from QUI
+## Upgrading from 4.x
 
-QUI stores its settings separately from QUI, under `QUIDB`. There are two ways to bring your QUI configuration across.
+Install over the top. There is nothing to move by hand: 5.0 uses the same addon folders and the same saved variables as 4.x (`QUIDB` and `QUI_StorageDB`), so your profiles, layouts and keybinds are already where the addon looks for them.
 
-**Both ways need QUI disabled or uninstalled on the character you log in with.** Addon enable state is per character, so untick QUI in the AddOns list at character select — or delete the `QUI` folder entirely. QUI refuses to import anything while QUI is still loaded, and tells you so in chat if you try.
+On first login QUI brings each profile up to the current settings schema, taking a backup of that profile before it changes anything. `/qui migration status` prints the schema version and lists the available backup slots, and `/qui migration restore` rolls back to one if something looks wrong.
 
-### Copy your saved variables file (recommended)
-
-This works even if you have already uninstalled QUI, because the game keeps a saved variables file after the addon folder is gone. Close WoW first, then find your account's saved variables folder:
-
-```text
-World of Warcraft\_retail_\WTF\Account\<YOUR ACCOUNT>\SavedVariables\
-```
-
-It holds one file per addon. QUI's is `QUI.lua`. QUI's is `QUI.lua`, which only appears once you have played with QUI installed and logged out at least once. Look in the folder and check whether `QUI.lua` is there — that answers which of the two recipes below you want.
-
-**Recipe 1 — there is no `QUI.lua`.** Copy `QUI.lua`, leave the original where it is, and rename the copy to `QUI.lua`.
-
-**Recipe 2 — `QUI.lua` is already there.** Do not replace it. That file *is* your QUI settings, and overwriting it deletes them. Make a backup copy of it first. Then open `QUI.lua` and `QUI.lua` in a plain text editor, copy everything out of `QUI.lua`, paste it at the **end** of `QUI.lua`, and save. Your QUI profiles are then added alongside the ones you already have instead of replacing them, and you pick the one you want under Options → Profiles.
-
-Either way, start the game afterwards with QUI disabled. QUI reads your QUI settings on the next login and tells you in chat when it has. If it instead says the settings look incomplete, the copy or paste was truncated — restore your backup and try again.
-
-### Or import a profile string
-
-If you can still run QUI, export a profile string from it first. Then disable or uninstall QUI, log in with QUI, and paste the string under Options → Import & Export Strings. QUI reads QUI's `QUI1:` strings natively.
-
-Neither way writes to `QUI.lua`, so QUI's own saved variables stay intact and you can keep the addon folder around until you are sure you no longer need it — just leave it disabled.
-
-Slash commands changed: `/qui` is now `/qui` (or `/qui`), and the rest of the `/qui*` family is now `/qui*` — for example `/quibags` is now `/quibags`.
+Back up your `WTF` folder first if you are installing an alpha or beta build.
 
 ## Documentation
 
@@ -71,7 +49,7 @@ Slash commands changed: `/qui` is now `/qui` (or `/qui`), and the rest of the `/
 
 ## Credits
 
-QUI is a derivative work of QUI. The original addon was created by **Quazii**, and QUI Community Edition was expanded and maintained by **Zol**, **LiQiuDGG**, and **Mondo**. This fork would not exist without their work.
+QUI began as an addon created by **Quazii**, and was expanded and maintained as QUI Community Edition by **Zol**, **LiQiuDGG**, and **Mondo**. It would not exist without their work.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-[![GitHub release](https://img.shields.io/github/v/release/torresdrew/QUI)](https://github.com/torresdrew/QUI/releases)
+[![GitHub release](https://img.shields.io/github/v/release/zol-wow/QUI)](https://github.com/zol-wow/QUI/releases)
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
 
 # QUI
 
 QUI is a modular World of Warcraft UI suite for Midnight 12.1+. It combines combat HUD tools, layout editing, action bars, unit and group frames, chat, minimap controls, data panels, a native damage meter, profile tools, and quality-of-life helpers under one settings experience.
-
-QUI is a fork of [QUI Community Edition](https://github.com/zol-wow/QUI), continued independently by Drew. See [Credits](#credits).
 
 ## Highlights
 
@@ -24,7 +22,7 @@ QUI is a fork of [QUI Community Edition](https://github.com/zol-wow/QUI), contin
 
 ## Installation
 
-1. Download the latest release zip from [GitHub Releases](https://github.com/torresdrew/QUI/releases).
+1. Download the latest release zip from [GitHub Releases](https://github.com/zol-wow/QUI/releases).
 2. Extract the zip.
 3. Copy every top-level `QUI*` folder from the zip into:
    ```text
@@ -67,15 +65,13 @@ Slash commands changed: `/qui` is now `/qui` (or `/qui`), and the rest of the `/
 
 ## Documentation
 
-- User guide: https://torresdrew.github.io/QUI/
-- Releases: https://github.com/torresdrew/QUI/releases
-- Issues: https://github.com/torresdrew/QUI/issues
+- User guide: https://zol-wow.github.io/QUI/
+- Releases: https://github.com/zol-wow/QUI/releases
+- Issues: https://github.com/zol-wow/QUI/issues
 
 ## Credits
 
 QUI is a derivative work of QUI. The original addon was created by **Quazii**, and QUI Community Edition was expanded and maintained by **Zol**, **LiQiuDGG**, and **Mondo**. This fork would not exist without their work.
-
-Upstream project: https://github.com/zol-wow/QUI
 
 ## License
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: QUI Documentation
-description: "Friendly setup guides and feature walkthroughs for QUI, a customizable World of Warcraft UI addon for Midnight (12.0+)."
+description: "Friendly setup guides and feature walkthroughs for QUI, a customizable World of Warcraft UI addon for Midnight (12.1+)."
 url: "https://zol-wow.github.io"
 baseurl: "/QUI"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,48 +8,46 @@ nav_order: 5
 
 This page summarizes the user-facing changes since the last mainline release. For every beta entry and technical fix, see the full [CHANGELOG.md](https://github.com/zol-wow/QUI/blob/main/CHANGELOG.md).
 
-## Current Beta: v4.0.0-beta56 - 2026-06-16
+## Current Release: 5.0.0
 
-QUI 4 is a major beta update over v3.5.11. The biggest change is that QUI now ships as a modular suite: a core addon plus feature folders you can manage from `/qui` > **Module Addons**. The most recent betas add full interface localization, per-frame unit-frame border colors, a Volume datatext control panel, and a large round of Group Frames, Layout Mode, and Bags refinements.
+{: .warning }
+**WoW 12.1 only.** This build targets patch 12.1 (interface 120100) and will not load on the 12.0.x client.
+
+QUI 5.0 rebuilds nameplates as their own addon, puts nameplates, group frames and unit frames on one shared aura engine, and cuts the suite from 22 addon folders to 11. It is also the release that adapts to 12.1's stricter rules about what an addon may read.
 
 {: .important }
 Back up your `WTF` folder before installing beta builds. Manual installs must copy every `QUI*` folder from the release zip into `Interface\AddOns\`.
 
-## Latest Updates (beta44–beta56)
+## What's New in 5.0
 
-These are the user-facing changes since beta43. None of these betas require a profile migration past beta47, and your settings carry over.
+### Nameplates
 
-### Localization (beta56)
+- **Nameplates are their own addon**, with a setup wizard and a settings preview that renders a real plate 1:1 and follows whatever you are editing.
+- **Every plate type gets its own config** — pets and minions, friendly units, bosses and elites, minor and trivial units, enemy players and enemy NPCs — picked from a dropdown with a Copy From control.
+- **Target indicators** (arrow, brackets, glow line), class power pips on the target plate, execute-threshold health colouring, and threat colour mapping.
+- **A Visibility tab** with an enemy-plate master toggle, friendly NPCs exposed, and Minions nesting Guardians, Pets and Totems. `Show In Instances` is a never / name-only / always choice.
+- **Name-only is a real render mode** — QUI draws the name and hides the bar and aura containers rather than restyling Blizzard's text.
 
-- **QUI's interface is now translated into 11 languages** — English plus German, Spanish (Spain & Mexico), French, Italian, Korean, Portuguese (Brazil), Russian, and Simplified & Traditional Chinese. The language follows your WoW client automatically; English clients see no change.
-- **CJK font rendering** picks a font fallback for Korean and Chinese automatically, so those glyphs display correctly. (Options search stays English for now.) See [Localization](features/localization).
+### Auras
 
-### Unit & Group Frames
+- **One aura engine drives nameplates, group frames and unit frames**, so an element configured on one behaves the same on the others.
+- **Pandemic glow** flashes an icon as its aura enters the refresh window, driven by the game's own pandemic region rather than a timer QUI approximates.
+- **Dispel borders and stealable buffs come from the game.** An aura element can be set to `Debuffs + Stealable Buffs` or `All Auras`.
 
-- **Per-frame Unit Frame border color (beta52).** Each frame (player, target, pet, focus, target-of-target, boss) can pick its own border color — Inherit, Theme, Class, or Custom — instead of all frames sharing one skin border.
-- **Group Frames unified aura model (beta47).** Buff/debuff auras, pinned auras, and indicators now share one Auras model with a reworked live preview and a faster in-combat render path.
-- **Group Frames fixes.** Power-bar space is reclaimed when power bars are off; dispel/defensive indicators no longer stay lit after the aura ends; bottom-anchored defensive indicators no longer overlap the power bar.
+### Speed and size
 
-### Info Bar & Datatexts
+- **The suite is 11 addon folders instead of 22.** Locales ship packed, so only the language in use is ever compiled, and login memory drops by roughly 2.3 MB.
+- **Settings search is 2.5–3x faster.** One English index ships instead of ten translated copies; typing the English term still finds the translated row on non-English clients.
+- **The options panel opens instantly**, building on the first frame after login, and moving between settings tabs reuses the page it already built.
 
-- **Volume datatext control panel (beta44).** Left-click opens a themed popup with Master/SFX/Music/Ambience/Dialog sliders and a Mute-all toggle. Audio settings moved to middle-click.
-- **Travel widget label & tooltip and a per-widget "Hide Text" (icon-only) toggle (beta51).**
-- **Shift-drag to reorder datatexts (beta47),** including the Volume widget (beta56 fix).
+### Localization
 
-### Bags, Alts & Chat
+- **Every non-English locale is actually translated now.** Nine of the ten had been falling back to English for roughly 900 strings each.
 
-- **Bags: "Pack to bottom" sort (beta46)** and reagent-bag sorting parity (beta47).
-- **Alts: right-click to untrack** currency and reputation rows (beta46).
-- **Chat: saved-tab right-click Filter/Tab Settings menus (beta45),** Blizzard whisper pop-out routing, and stable sender class colors (beta55).
+### Adapting to 12.1
 
-### Layout Mode
-
-- **Opens collapsed (beta54)** with the toolbar and frames drawer tucked away.
-- **Anchored windows and castbars** position correctly in Layout Mode, and resizing an anchored window keeps its anchor pinned (beta42–54).
-
-### Setup & Profiles
-
-- **New profiles seed from QUI's shipped defaults automatically (beta47);** the old first-run welcome popup is gone. Profiles older than schema v31 (pre-3.5.11) are backed up, reset, and reseeded at login; 3.5.11+ profiles migrate unchanged.
+- **Atonement tracking no longer reads the combat log** — 12.1 closed combat log events to addons, so the counter watches auras directly.
+- **The Brez counter lost its resurrection list** for the same reason. The charge count, recharge timer and per-pull tally are unaffected.
 
 ## Major Additions
 
@@ -58,7 +56,7 @@ These are the user-facing changes since beta43. None of these betas require a pr
 - QUI is now split into feature addon folders.
 - The **Module Addons** page controls whole modules such as Chat, Bags, Info Bar, Alts, Group Frames, Damage Meter, Datatexts, Minimap, and Quality of Life.
 - Several large beta modules are off by default so existing setups can stay conservative.
-- Options search now loads on demand, reducing first-open cost.
+- The settings panel builds on the first frame after login, so it opens instantly.
 
 ### QUI Chat
 
@@ -112,7 +110,9 @@ These are the user-facing changes since beta43. None of these betas require a pr
 
 ## Upgrade Notes
 
-- v3.5.11 to QUI 4 beta is a major upgrade. Back up `WTF`, then install all `QUI*` folders.
-- If a module is missing, check for a partial manual install first.
+- **4.x to 5.0 is an install over the top.** Same addon folders, same saved variables (`QUIDB` and `QUI_StorageDB`) — nothing to move by hand. Profiles migrate to the current schema on first login and are backed up beforehand; `/qui migration status` and `/qui migration restore` expose those backups.
+- Back up your `WTF` folder before installing an alpha or beta build.
+- Manual installs must copy every top-level `QUI*` folder from the release zip, not only the `QUI` folder.
+- **If you hand-installed 5.0.0-alpha29 or earlier**, the eleven `QUI_OptionsSearch` folders are left behind after updating. Nothing loads them — delete them.
 - If a feature does not open, check `/qui` > **Module Addons** before troubleshooting settings.
 - Some account-cache data, especially offline inventory and equipment, repopulates as each character logs in.

--- a/docs/features/damage-meter.md
+++ b/docs/features/damage-meter.md
@@ -7,7 +7,7 @@ nav_order: 21
 
 # Damage Meter
 
-QUI ships a native damage meter for Midnight 12.0+. It provides QUI-styled meter windows with Layout Mode placement, selectable views, row breakdowns, and per-window appearance controls.
+QUI ships a native damage meter for Midnight 12.1+. It provides QUI-styled meter windows with Layout Mode placement, selectable views, row breakdowns, and per-window appearance controls.
 
 ## How to Enable
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Installation
 
-QUI requires **World of Warcraft Midnight (12.0+)**.
+QUI requires **World of Warcraft Midnight (12.1+)**. It will not load on the 12.0.x client.
 
 ## Fastest Option: Addon Manager
 
@@ -31,7 +31,7 @@ For most players, the easiest path is an addon manager.
 4. Make sure the folder structure is correct -- `QUI.toc` should be directly inside `Interface\AddOns\QUI\`, `QUI_Options.toc` should be directly inside `Interface\AddOns\QUI_Options\`, and the other `QUI_*` folders should sit beside them.
 
 {: .important }
-QUI 4 beta is a multi-folder addon suite. If you manually copy only `QUI`, the options panel and feature modules will be missing.
+QUI is a multi-folder addon suite. If you manually copy only `QUI`, the options panel and feature modules will be missing.
 
 ## Confirm It Loaded Correctly
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,10 @@ nav_order: 1
 # QUI Documentation
 {: .fs-9 }
 
-A modular World of Warcraft UI suite for Midnight 12.0+ that you can install, understand, and tune from one settings experience.
+A modular World of Warcraft UI suite for Midnight 12.1+ that you can install, understand, and tune from one settings experience.
 {: .fs-6 .fw-300 }
 
-**Current Beta: 4.0.0-beta56**
+**Current Release: 5.0.0**
 {: .label .label-purple }
 
 [Get Started](getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
@@ -31,7 +31,7 @@ QUI's interface is also localized into 11 languages and follows your WoW client 
 If you are new to QUI, the easiest way to think about it is this: install all `QUI*` folders, open `/qui`, choose which optional modules you want, then fine-tune the pieces you care about.
 
 {: .important }
-QUI 4 beta is a multi-folder addon suite. Addon-manager installs handle this automatically. Manual installs must copy every top-level `QUI*` folder from the release zip into `Interface\AddOns\`, not only the `QUI` folder.
+QUI is a multi-folder addon suite. Addon-manager installs handle this automatically. Manual installs must copy every top-level `QUI*` folder from the release zip into `Interface\AddOns\`, not only the `QUI` folder.
 
 ## Why Players Pick QUI
 


### PR DESCRIPTION
Brings `beta` up to `main` again, carrying the three documentation commits from #680. No code changes — `git diff` between the two branches is documentation only.

- README: links pointed at `torresdrew/QUI`, which is archived with Pages disabled, so the user-guide link was dead. Two more pointed at `zol-wow/QUI` from inside `zol-wow/QUI` and returned the reader to the same README.
- README: the "Coming from QUI" section told the reader to copy `QUI.lua` and rename the copy to `QUI.lua`, and warned that overwriting it "deletes them". Replaced with real 4.x upgrade steps — both lineages ship the same folders and the same saved variables, so there is nothing to migrate.
- `docs/`: the site advertised **Midnight 12.0+** on four pages while the build is 12.1-only and will not load on 12.0.x. Also still described v4.0.0-beta56 from June.

Same situation as #679: this is the fast-forward the branch ruleset will not let us push directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
