### PR TITLE
release: v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.0.0 - 2026-08-11
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+The 5.0.0 line, released. Nameplates become their own addon, nameplates and
+group frames and unit frames move onto one shared aura engine, the suite drops
+from 22 addon folders to 11, and QUI adapts to 12.1's stricter rules about what
+an addon is allowed to read. Everything below landed across alpha1 to beta4; the
+per-build entries under this one carry the full detail.
+
+### Added
+
+- **Nameplates are their own addon**, with a setup wizard and a settings preview
+  that renders a real plate 1:1 and follows whatever you are editing.
+- **Every plate type gets its own config** — pets and minions, friendly units,
+  bosses and elites, minor and trivial units, enemy players and enemy NPCs —
+  picked from a dropdown with a Copy From control.
+- **Target indicators** (arrow, brackets and glow line), class power pips on the
+  target plate, execute-threshold health colouring and threat colour mapping.
+- **A nameplate Visibility tab** with an enemy-plate master toggle, friendly NPCs
+  exposed, and Minions nesting Guardians, Pets and Totems on both sides.
+  `Show In Instances` is a never / name-only / always choice.
+- **Pandemic glow on aura icons**, driven by the game's own pandemic region
+  rather than a timer QUI approximates, so it stays in step with the real
+  duration.
+- **Dispel borders and stealable buffs come from the game.** An aura element can
+  be set to `Debuffs + Stealable Buffs` or `All Auras`.
+
+### Changed
+
+- **One aura engine drives nameplates, group frames and unit frames**, so an
+  element configured on one behaves the same on the others.
+- **Name-only is a real render mode** — QUI draws the name and hides the bar and
+  aura containers instead of restyling Blizzard's own text.
+- **The suite is 11 addon folders instead of 22.** Locales ship packed, so only
+  the language in use is ever compiled, and login memory drops by roughly 2.3 MB.
+- **Settings search is 2.5–3x faster.** One English index ships instead of ten
+  translated copies, and typing the English term still finds the translated row
+  on non-English clients.
+- **The options panel opens instantly**, building on the first frame after login,
+  and moving between settings tabs reuses the page it already built.
+- **Every non-English locale is actually translated now.** Nine of the ten had
+  been falling back to English for roughly 900 strings each.
+- **Atonement tracking no longer reads the combat log.** 12.1 closed combat log
+  events to addons, so the counter watches auras directly.
+
+### Removed
+
+- **The Brez counter's resurrection list.** Naming who battle-rezzed whom needed
+  combat log events, which 12.1 does not give addons. The charge count, the
+  recharge timer and the per-pull tally are unaffected.
+
+### Upgrading
+
+4.x to 5.0 is an install over the top: the same addon folders and the same saved
+variables (`QUIDB` and `QUI_StorageDB`), so nothing moves by hand. Profiles
+migrate to the current schema on first login and are backed up beforehand —
+`/qui migration status` and `/qui migration restore` expose those backups.
+
+If you hand-installed 5.0.0-alpha29 or earlier, the eleven `QUI_OptionsSearch`
+folders are left behind after updating. Nothing loads them; delete them.
+
 ## v5.0.0-beta4 - 2026-08-11
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Drew
-## Version: 5.0.0-beta4
+## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Release commit for **v5.0.0**: the CHANGELOG entry plus the 13 shipped TOCs bumped from `5.0.0-beta4`.

**No code changes.** 5.0.0 ships beta4's tree exactly — `git diff v5.0.0-beta4 origin/main` outside `README.md` and `docs/` is empty. The only work since that tag was documentation.

## Checks run

- **13 shipped TOCs re-counted**, not assumed, and all were on one version string (`5.0.0-beta4`) before the bump. `QUI_Debug` and `QUI_Logger` are in the bump set but excluded from the zip.
- **Release notes extractor dry-run** — the `ver_re` + `DUI_NOTES_PAT` + `awk` block lifted from `release.yml`, run against this CHANGELOG. Returns 61 lines and stops before the `## v5.0.0-beta4` heading, which is the substring case that trailing character class exists to prevent.
- `bash tools/test.sh` → **9/9 green** on this exact tree.

## Notes

The CHANGELOG entry summarises the whole 5.0 line rather than just the gap since beta4 — anyone arriving from 4.1.1 gets all of it at once, and `release.yml` publishes that section verbatim as the GitHub Release body and the Discord announcement.

Version surfaces outside the shipped TOCs are deliberately not in this commit, per the release procedure — `docs/index.md` was already set to 5.0.0 in #680, which keeps this diff clean.

**No tag is being cut here.** Tagging is Drew's step, and the tag must point at the merged SHA rather than this branch's commit, since the merge rewrites it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
