### PR TITLE
chore: credit Zol alongside Drew in the addon author field

### DIFF
--- a/QUI.toc
+++ b/QUI.toc
@@ -5,7 +5,7 @@
 ## AddonCompartmentFuncOnEnter: QUI_CompartmentOnEnter
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Debug Tools
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Options
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
-## Author: Drew
+## Author: Zol and Drew
 ## Version: 5.0.0
 ## Category: User Interface
 ## Group: QUI


### PR DESCRIPTION
The thirteen suite TOCs carried `## Author: Drew`. QUI is Zol's work as much as his, and the author line is what the game shows in the addon list, so it now reads **Zol and Drew**.

Scope is the thirteen suite TOCs only. Vendored library TOCs under `libs/` (`deezo`, `Adirelle, Nebula`) and the FrameXML corpus under `tests/` (`Blizzard Entertainment`) keep their own authors — checked, none touched.

Nothing in the gates or workflows asserts the author field, so this changes no behaviour. `bash tools/test.sh` → 9/9 green.

**Timing note:** `v5.0.0` is committed on `main` but not yet tagged, so this can land before the tag and ship with 5.0.0 rather than waiting for a follow-up. If it does, the tag should point at `main`'s tip after this merges, not at the `release: v5.0.0` commit itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
