### PR TITLE
fix: cast-on-key-press dispatch and CDM override-spell families

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_builder.lua
+++ b/QUI_ActionBars/actionbars/actionbars_builder.lua
@@ -30,7 +30,7 @@ function EnsureOwnedActionButton(container, barKey, btnName, index)
     local existed = btn ~= nil
     if not btn then
         local ok
-        ok, btn = ns.SafeCall("best-effort-style", CreateFrame, "CheckButton", btnName, container, "ActionBarButtonTemplate")
+        ok, btn = ns.SafeCall("best-effort-style", CreateFrame, "CheckButton", btnName, container, "ActionBarButtonTemplate, SecureActionButtonTemplate")
         if not ok then btn = _G[btnName] end
         btn:SetAttribute("type", "action")
         btn:SetAttribute("checkselfcast", true)

--- a/QUI_CDM/cdm/cdm_spelldata.lua
+++ b/QUI_CDM/cdm/cdm_spelldata.lua
@@ -1951,6 +1951,92 @@ local function NormalizeOwnedSpells(ownedSpells)
     return ownedSpells
 end
 
+local function ResolveOverrideID(spellID)
+    if not (Sources and Sources.QueryOverrideSpell) then return nil end
+    local overrideID = Sources.QueryOverrideSpell(spellID)
+    if overrideID and overrideID ~= spellID then return overrideID end
+    return nil
+end
+
+local function ResolveBaseID(spellID)
+    if not (Sources and Sources.QueryBaseSpell) then return nil end
+    local baseID = Sources.QueryBaseSpell(spellID)
+    if baseID and baseID ~= spellID then return baseID end
+    return nil
+end
+
+function CDMSpellData.AddSpellIDFamily(set, spellID)
+    local id = tonumber(spellID)
+    if type(set) ~= "table" or not id then return end
+    set[id] = true
+    local overrideID = ResolveOverrideID(id)
+    if overrideID then set[overrideID] = true end
+    local baseID = ResolveBaseID(id)
+    if baseID then set[baseID] = true end
+end
+
+function CDMSpellData.IsSpellIDFamilyInSet(set, spellID)
+    local id = tonumber(spellID)
+    if type(set) ~= "table" or not id then return false end
+    if set[id] then return true end
+    local overrideID = ResolveOverrideID(id)
+    if overrideID and set[overrideID] then return true end
+    local baseID = ResolveBaseID(id)
+    if baseID and set[baseID] then return true end
+    return false
+end
+
+function CDMSpellData.ResolveSpellFamilyKey(spellID)
+    local id = tonumber(spellID)
+    if not id then return nil end
+    local overrideID = ResolveOverrideID(id)
+    local anchor = overrideID or id
+    return ResolveBaseID(anchor) or anchor
+end
+
+function CDMSpellData.BuildOwnedSet(db)
+    local ownedSet = {}
+    if type(db) ~= "table" then return ownedSet end
+
+    local list = db.ownedSpells
+    if db.containerType == "customBar" and type(db.entries) == "table" then
+        list = db.entries
+    end
+
+    if type(list) == "table" then
+        for _, rawEntry in ipairs(list) do
+            local entry = NormalizeOwnedEntry(rawEntry)
+            if entry and entry.id then
+                local etype = entry.type or "spell"
+                ownedSet[etype .. ":" .. tostring(entry.id)] = true
+                if etype == "spell" then
+                    CDMSpellData.AddSpellIDFamily(ownedSet, entry.id)
+                else
+                    ownedSet[entry.id] = true
+                end
+                if etype == "item" and Sources and Sources.QueryBestOwnedItemVariant then
+                    local bestItemID = Sources.QueryBestOwnedItemVariant(entry.id)
+                    if bestItemID then
+                        ownedSet["item:" .. tostring(bestItemID)] = true
+                        ownedSet[bestItemID] = true
+                    end
+                end
+            end
+        end
+    end
+
+    if type(db.dormantSpells) == "table" then
+        for sid in pairs(db.dormantSpells) do
+            if type(sid) == "number" then
+                ownedSet["spell:" .. tostring(sid)] = true
+                CDMSpellData.AddSpellIDFamily(ownedSet, sid)
+            end
+        end
+    end
+
+    return ownedSet
+end
+
 local WoW_IsSpellKnown = IsSpellKnown
 local WoW_IsPlayerSpell = IsPlayerSpell
 local function IsSpellKnownByPlayer(spellID)
@@ -2404,6 +2490,7 @@ function CDMSpellData:BuildSpellListFromOwned(containerKey)
 
     local result = {}
     local seenInstanceKeys = {}
+    local seenSpellFamilyKeys = {}
     for i, entry in ipairs(ownedSpells) do
         if entry and entry.id then
             local isRemoved = false
@@ -2432,9 +2519,21 @@ function CDMSpellData:BuildSpellListFromOwned(containerKey)
                             expandedEntry._isTotemInstance
                             or (expandedEntry.isAura and instanceKey and not instanceKey:find(":entry:", 1, true))
                         )
+                        local familyKey = nil
+                        if expandedEntry and not expandedEntry.isAura
+                            and expandedEntry.type == "spell" then
+                            familyKey = CDMSpellData.ResolveSpellFamilyKey(
+                                expandedEntry.overrideSpellID or expandedEntry.spellID)
+                        end
+
                         if shouldDedupe and instanceKey then
                             if not seenInstanceKeys[instanceKey] then
                                 seenInstanceKeys[instanceKey] = true
+                                result[#result + 1] = expandedEntry
+                            end
+                        elseif familyKey then
+                            if not seenSpellFamilyKeys[familyKey] then
+                                seenSpellFamilyKeys[familyKey] = true
                                 result[#result + 1] = expandedEntry
                             end
                         else
@@ -3206,30 +3305,7 @@ end
 function CDMSpellData:GetAvailableSpells(containerKey)
     local db = GetContainerDB(containerKey)
 
-    local ownedSet = {}
-    if db and type(db.ownedSpells) == "table" then
-        for _, entry in ipairs(db.ownedSpells) do
-            local normalized = NormalizeOwnedEntry(entry)
-            if normalized and normalized.type == "spell" and normalized.id then
-                ownedSet[normalized.id] = true
-                local oid = Sources and Sources.QueryOverrideSpell
-                    and Sources.QueryOverrideSpell(normalized.id)
-                if oid and oid ~= normalized.id then
-                    ownedSet[oid] = true
-                end
-            elseif normalized and normalized.id then
-                ownedSet[normalized.type .. ":" .. normalized.id] = true
-                ownedSet[normalized.id] = true
-            end
-        end
-    end
-    if db and type(db.dormantSpells) == "table" then
-        for sid in pairs(db.dormantSpells) do
-            if type(sid) == "number" then
-                ownedSet[sid] = true
-            end
-        end
-    end
+    local ownedSet = CDMSpellData.BuildOwnedSet(db)
 
     local containerType = db and db.containerType
     if not containerType then

--- a/QUI_CDM/cdm/settings/composer.lua
+++ b/QUI_CDM/cdm/settings/composer.lua
@@ -2845,36 +2845,11 @@ RefreshAddList = function()
     local sourceEntries = {}
     local containerType = ResolveContainerType(activeContainer) or "cooldown"
 
-    local ownedSet = {}
     local activeDB = GetContainerDB(activeContainer)
     local isCustomBar = (activeDB and activeDB.containerType == "customBar")
-    local ownedEntries = activeDB and (isCustomBar and activeDB.entries or activeDB.ownedSpells)
-    if type(ownedEntries) == "table" then
-        for _, entry in ipairs(ownedEntries) do
-            if type(entry) == "table" and entry.id then
-                ownedSet[(entry.type or "spell") .. ":" .. entry.id] = true
-                ownedSet[entry.id] = true
-                if entry.type == "item" and Sources and Sources.QueryBestOwnedItemVariant then
-                    local bestItemID = Sources.QueryBestOwnedItemVariant(entry.id)
-                    if bestItemID then
-                        ownedSet["item:" .. bestItemID] = true
-                        ownedSet[bestItemID] = true
-                    end
-                end
-            elseif type(entry) == "number" then
-                ownedSet["spell:" .. entry] = true
-                ownedSet[entry] = true
-            end
-        end
-    end
-    if activeDB and type(activeDB.dormantSpells) == "table" then
-        for sid in pairs(activeDB.dormantSpells) do
-            if type(sid) == "number" then
-                ownedSet["spell:" .. sid] = true
-                ownedSet[sid] = true
-            end
-        end
-    end
+    local ownedSet = (spellData and type(spellData.BuildOwnedSet) == "function")
+        and spellData.BuildOwnedSet(activeDB)
+        or {}
 
     if activeAddTab == "cdm_spells" or not activeAddTab then
         sourceEntries = spellData:GetAvailableSpells(activeContainer) or {}

--- a/tests/unit/actionbars_ping_receiver_test.lua
+++ b/tests/unit/actionbars_ping_receiver_test.lua
@@ -54,9 +54,9 @@ check("spell ping is SecureOnly and AllowedWhenUntainted",
         and pingDocs:find('Name = "SendPlayerSpellPing"', 1, true) ~= nil
         and pingDocs:find('SecretArguments = "AllowedWhenUntainted"', 1, true) ~= nil)
 
-check("QUI creates standard owned buttons from ActionBarButtonTemplate",
+check("QUI owned buttons keep Blizzard's ActionBarButtonTemplate and append SecureActionButtonTemplate so useOnKeyDown survives",
     builder:find(
-        'CreateFrame, "CheckButton", btnName, container, "ActionBarButtonTemplate"',
+        'CreateFrame, "CheckButton", btnName, container, "ActionBarButtonTemplate, SecureActionButtonTemplate"',
         1, true) ~= nil)
 check("QUI does not replace Blizzard's ping identity or update lifecycle",
     builder:find("btn.HasAction =", 1, true) == nil

--- a/tests/unit/cdm_spelldata_owned_duplicate_family_collapse_test.lua
+++ b/tests/unit/cdm_spelldata_owned_duplicate_family_collapse_test.lua
@@ -1,0 +1,105 @@
+-- luacheck: globals InCombatLockdown GetTime wipe CreateFrame IsSpellKnown IsPlayerSpell
+
+local function noop() end
+
+function InCombatLockdown() return false end
+function GetTime() return 100 end
+function wipe(tbl)
+    for key in pairs(tbl) do
+        tbl[key] = nil
+    end
+end
+function CreateFrame()
+    return {
+        RegisterEvent       = noop,
+        RegisterUnitEvent   = noop,
+        UnregisterEvent     = noop,
+        UnregisterAllEvents = noop,
+        SetScript           = noop,
+    }
+end
+function IsSpellKnown() return true end
+function IsPlayerSpell() return true end
+
+local HAND_ADDED_ID = 8936
+local CDM_HARVESTED_ID = 999001
+local SHARED_BASE_ID = 8930
+local UNRELATED_ID = 774
+
+local essentialDB = {
+    containerType = "cooldown",
+    ownedSpells   = {
+        { type = "spell", id = HAND_ADDED_ID,    kind = "cooldown", row = 1 },
+        { type = "spell", id = UNRELATED_ID,     kind = "cooldown", row = 1 },
+        { type = "spell", id = CDM_HARVESTED_ID, kind = "cooldown", row = 1,
+          source = "blizzardCDM" },
+    },
+}
+
+local ns = {
+    Addon = {
+        db = {
+            profile = {
+                ncdm = {
+                    essential = essentialDB,
+                },
+            },
+        },
+    },
+    Helpers = {
+        IsSecretValue            = function() return false end,
+        SafeValue                = function(value) return value end,
+        IsAuraOwnedByPlayerOrPet = function() return true end,
+    },
+    CDMShared = {
+        IsRuntimeEnabled = function() return true end,
+    },
+    CDMSources = {
+        QueryOverrideSpell = function(spellID)
+            if spellID == HAND_ADDED_ID then return CDM_HARVESTED_ID end
+            return spellID
+        end,
+        QueryBaseSpell = function(spellID)
+            if spellID == CDM_HARVESTED_ID then return SHARED_BASE_ID end
+            return nil
+        end,
+    },
+}
+
+dofile("tests/helpers/load_cdm_spelldata_runtime.lua")(ns)
+assert(loadfile("QUI_CDM/cdm/cdm_spelldata.lua"))("QUI", ns)
+
+local list = ns.CDMSpellData:BuildSpellListFromOwned("essential")
+
+local familyCount = 0
+local unrelatedCount = 0
+for _, entry in ipairs(list) do
+    local id = entry.overrideSpellID or entry.spellID
+    if id == CDM_HARVESTED_ID or id == HAND_ADDED_ID or id == SHARED_BASE_ID then
+        familyCount = familyCount + 1
+    elseif id == UNRELATED_ID then
+        unrelatedCount = unrelatedCount + 1
+    end
+end
+
+assert(familyCount == 1,
+    "a spell owned under both its hand-added ID and its /cdm override ID must render once, got "
+        .. tostring(familyCount))
+assert(unrelatedCount == 1,
+    "an unrelated spell must still render exactly once, got " .. tostring(unrelatedCount))
+assert(#list == 2,
+    "the collapsed list must hold exactly the two distinct abilities, got " .. tostring(#list))
+
+local composerSource
+do
+    local handle = assert(io.open("QUI_CDM/cdm/settings/composer.lua", "rb"))
+    composerSource = handle:read("*a")
+    handle:close()
+end
+
+assert(composerSource:find("spellData.BuildOwnedSet(activeDB)", 1, true),
+    "composer must build its ownedSet through the shared CDMSpellData.BuildOwnedSet")
+assert(not composerSource:find('ownedSet[(entry.type or "spell")', 1, true),
+    "composer must not hand-roll a second ownedSet builder that can drift from the shared one")
+
+print("OK cdm_spelldata_owned_duplicate_family_collapse_test")

--- a/tests/unit/cdm_spelldata_owned_set_override_family_test.lua
+++ b/tests/unit/cdm_spelldata_owned_set_override_family_test.lua
@@ -1,0 +1,95 @@
+-- luacheck: globals InCombatLockdown GetTime wipe CreateFrame IsSpellKnown IsPlayerSpell
+
+local function noop() end
+
+function InCombatLockdown() return false end
+function GetTime() return 100 end
+function wipe(tbl)
+    for key in pairs(tbl) do
+        tbl[key] = nil
+    end
+end
+function CreateFrame()
+    return {
+        RegisterEvent       = noop,
+        RegisterUnitEvent   = noop,
+        UnregisterEvent     = noop,
+        UnregisterAllEvents = noop,
+        SetScript           = noop,
+    }
+end
+function IsSpellKnown() return true end
+function IsPlayerSpell() return true end
+
+local OWNED_ID = 8936
+local OVERRIDE_ID = 999001
+local BASE_ID = 8930
+
+local essentialDB = {
+    containerType = "cooldown",
+    ownedSpells   = { { type = "spell", id = OWNED_ID, kind = "cooldown", row = 1 } },
+}
+
+local ns = {
+    Addon = {
+        db = {
+            profile = {
+                ncdm = {
+                    essential = essentialDB,
+                },
+            },
+        },
+    },
+    Helpers = {
+        IsSecretValue            = function() return false end,
+        SafeValue                = function(value) return value end,
+        IsAuraOwnedByPlayerOrPet = function() return true end,
+    },
+    CDMShared = {
+        IsRuntimeEnabled = function() return true end,
+    },
+    CDMSources = {
+        QueryOverrideSpell = function(spellID)
+            if spellID == OWNED_ID then return OVERRIDE_ID end
+            return spellID
+        end,
+        QueryBaseSpell = function(spellID)
+            if spellID == OWNED_ID then return BASE_ID end
+            return nil
+        end,
+    },
+}
+
+dofile("tests/helpers/load_cdm_spelldata_runtime.lua")(ns)
+assert(loadfile("QUI_CDM/cdm/cdm_spelldata.lua"))("QUI", ns)
+
+local capturedOwned
+ns.CDMCatalog = {
+    GetAvailableSpellsForContainer = function(_containerKey, _containerType, ownedSet)
+        capturedOwned = ownedSet
+        return {}
+    end,
+}
+
+ns.CDMSpellData:GetAvailableSpells("essential")
+
+assert(capturedOwned ~= nil,
+    "ownedSet was not passed to GetAvailableSpellsForContainer")
+assert(capturedOwned[OWNED_ID] == true,
+    "ownedSet must contain the stored spell ID")
+assert(capturedOwned[OVERRIDE_ID] == true,
+    "ownedSet must contain the override spell ID so /cdm cannot re-offer the same ability")
+assert(capturedOwned[BASE_ID] == true,
+    "ownedSet must contain the base spell ID so /cdm cannot re-offer the same ability")
+assert(capturedOwned["spell:" .. OWNED_ID] == true,
+    "ownedSet must keep the type-qualified key for the stored spell ID")
+
+local slotDB = {
+    containerType = "cooldown",
+    ownedSpells   = { { type = "slot", id = 13, kind = "cooldown" } },
+}
+local slotSet = ns.CDMSpellData.BuildOwnedSet(slotDB)
+assert(slotSet["slot:13"] == true, 'BuildOwnedSet must keep the "slot:<id>" key')
+assert(slotSet[13] == true, "BuildOwnedSet must keep the bare id key for non-spell entries")
+
+print("OK cdm_spelldata_owned_set_override_family_test")


### PR DESCRIPTION
Two independent fixes, both gate-green (`bash tools/test.sh` → ALL GATES PASSED, 9/9, 806 unit files).

## Cast on Key Press did nothing

Owned action buttons were built from bare `ActionBarButtonTemplate`. Its OnClick arrives via `ActionBarButtonCodeTemplate` and calls `SecureActionButton_OnClick` with `isKeyPress = false, isSecureAction = true`, which makes `isSecureMousePress` true and short-circuits the `useOnKeyDown` term in `SecureTemplates.lua:812-814` before `SecureActionButton_ShouldUseOnKeyDown` is ever called. `clickAction` collapses to `not down`, so every press cast on release.

The toggle, the profile write and `QUI_ApplyUseOnKeyDown` were all correct — the attribute they set was simply never read. Appending `SecureActionButtonTemplate` puts its `<OnClick function="SecureActionButton_OnClick"/>` last, restoring the plain secure dispatch while leaving the visual and update mixin intact. Owned flyout buttons already used this template pair; bar buttons were the only holdout.

`tests/unit/actionbars_ping_receiver_test.lua` matches the builder's `CreateFrame` literal and is retargeted.

**Still needs an in-game pass.** Replacing the derived OnClick gives up QuickKeybind put-action-in-slot, the right-click pet-autocast toggle and the mixin's locked-bar guards (our own secure snippet already covers pickup). Empowered spells now run through the plain dispatch and want a look too.

## CDM override-spell families

A spell the client replaces with an override ID was tracked under whichever ID happened to be stored, so the composer could offer a spell already owned under its sibling ID, and a built list could show the same ability twice.

`CDMSpellData` gains `AddSpellIDFamily`, `IsSpellIDFamilyInSet` and `ResolveSpellFamilyKey`, which walk `QueryOverrideSpell`/`QueryBaseSpell` so an ID, its override and its base resolve to one key. `BuildSpellListFromOwned` dedupes non-aura spell entries on it.

Owned-set construction moves out of the composer into `CDMSpellData.BuildOwnedSet` — family-aware, and covering custom bar entries, dormant spells and best-owned item variants. `RefreshAddList` calls it instead of rebuilding the set inline. Two new tests cover the collapse and the override-family set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)