### PR TITLE
release: v5.1.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.1.0-beta2 - 2026-08-12
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+The first build with real work on the 5.1 line: aura displays you place
+yourself, a hidden-players filter for group frames, and a run of fixes for
+settings that looked like they were doing nothing.
+
+### Added
+
+- **Aura displays you place yourself.** Build a display, point it at a unit,
+  filter it per unit, give it load conditions and drag it where you want it.
+  Displays can be renamed, and a reaction can be parked out of the way.
+- **A hidden-players filter for group frames**, to keep specific players off the
+  raid frames.
+- **Plate Scale for nameplates** (Nameplates → Behavior). One slider grows the
+  whole plate — bar, text, icons and borders together — and the clickable area
+  grows with it, so plates stay clickable at their edges. It multiplies on top
+  of Target Scale and the simplified-plate scale rather than replacing either.
+- **Item cosmetic overlays in bags**, on live and cached bag buttons alike.
+
+### Fixed
+
+- **Cast on Key Press now does something.** Owned action buttons dispatched
+  through a path that forced casting on key release, so the setting wrote a
+  value nothing ever read. Abilities fire on the press when it is on.
+- **Skins survive being loaded early.** When another addon force-loaded a
+  Blizzard frame before QUI had a profile, the skin's one-shot fired against a
+  profile that did not exist yet and never came back — profession windows and
+  their siblings stayed unskinned for the rest of the session.
+- **QUI no longer runs other addons' code while sweeping for action buttons.**
+  The sweep classified frames by calling a method on every global, which threw
+  inside a widget library's generated methods and surfaced as that addon's
+  error with QUI's frames underneath it.
+- **Duplicate abilities in the cooldown composer.** A spell the client replaces
+  with an override was tracked under whichever ID happened to be stored, so it
+  could be offered as available while already owned, or appear twice in a built
+  list.
+- **Group frame headers stop churning.** Re-configuring a header rewrote every
+  secure attribute even when nothing had changed, forcing a re-layout each time.
+- **Orphaned movers are released** instead of lingering in Layout Mode.
+- **The nameplate settings preview opens at real size.** It used to open zoomed
+  all the way in; the grip now zooms both ways from life size.
+
+### Changed
+
+- **The Alts window is translated.** It had been hard-coded English throughout,
+  and the `Back` label it shared with a cloak slot and a UI layer is split so
+  each reads correctly in every language.
+- **Terminology is consistent across all ten locales** — frame and spec wording
+  unified, realm and roster wording unified, five mistranslations corrected and
+  the hidden-players strings translated everywhere.
+- **Discord announcements come only from tagged releases.** The workflow that
+  posted a second notification on every feature-branch push is gone.
+- The vendored Blizzard API corpus is refreshed to 12.1.0.69273.
+
 ## v5.1.0-beta1 - 2026-08-11
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta1
+## Version: 5.1.0-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Version bump only — 13 shipped TOCs to `5.1.0-beta2` plus the `CHANGELOG.md` section. No addon code.

Content shipping in this build is everything merged since `v5.1.0-beta1`: aura displays, the group-frames hidden-players filter, the nameplate Plate Scale slider, the bag item overlay, and fixes for cast-on-key-press, skin lifecycle, the action-button global sweep, CDM override-spell duplicates and group-frame header churn.

Pre-flight:

- `bash tools/test.sh` → ALL GATES PASSED, 9/9
- 13 TOCs re-counted and bumped as a set
- `generate_event_allowlist.lua` re-run, no drift (it is ungated)
- `release.yml` notes extractor dry-run → 55 lines, terminating before the `v5.1.0-beta1` heading

`docs/` is untouched: it still reads `Current Release: 5.0.0`, which is correct — it builds from `main` and this is a prerelease on `beta`.

Tag goes on the rebased SHA after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)