### PR TITLE
release: v5.1.0-beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.1.0-beta3 - 2026-08-12
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+A short follow-up to beta2: resource bars that keep working in combat, two
+action bar fixes that keep QUI out of Blizzard's own code, and one new option
+for aura duration text.
+
+### Added
+
+- **Hide Time Unit** for aura duration text, per text region. Shows `4` instead
+  of `4s`; durations over 90 seconds keep their m/h/d unit.
+
+### Fixed
+
+- **Resource bars keep drawing in combat.** On 12.1 the client can hand back a
+  protected power value, and the bar took a separate path whenever it did —
+  dropping its text placement, tick marks and indicator lines for as long as the
+  value stayed protected. It now renders the same way either way: the value goes
+  straight to the bar and to the text, and indicator lines are positioned by the
+  game instead of by arithmetic QUI is no longer allowed to do. Soul fragments
+  show their real count rather than falling back to zero, and both power bars
+  reuse their frame instead of stacking a second one over the first.
+- **Action bar cooldowns stay off Blizzard's own fields.** The loss-of-control
+  swirl was stored on a field Blizzard's code reads, so that code inherited QUI's
+  taint; it lives on a private field now. A button that carries its own
+  assisted-combat rotation frame builds that frame itself instead of receiving a
+  second one.
+- **The original QUI logo is back.**
+
 ## v5.1.0-beta2 - 2026-08-12
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta2
+## Version: 5.1.0-beta3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Version bump only: 13 shipped TOCs `5.1.0-beta2` → `5.1.0-beta3`, plus the `## v5.1.0-beta3` CHANGELOG section.

Pre-flight:

- `bash tools/test.sh` → **ALL GATES PASSED 9/9**
- `release.yml` extractor dry-run → 29 lines, stops before the `v5.1.0-beta2` heading
- `lua tools/generate_event_allowlist.lua` re-run by hand (ungated) → no drift
- TOC count re-counted at **13** (11 ship; `QUI_Debug`/`QUI_Logger` excluded from the zip)
- `docs/` untouched — it reads `Current Release: 5.0.0` and builds from `main`; a prerelease does not move it

Tag `v5.1.0-beta3` goes on the merged SHA after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)