### PR TITLE
ci(review): give the PR reviewer a way to post its findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,6 +55,8 @@ jobs:
         run: luarocks install luacheck
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Lets the reviewer read this PR's CI results, so it can cite an
@@ -62,11 +64,18 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --allowed-tools "Read,Grep,Glob,Bash(lua:*),Bash(luacheck:*),Bash(bash tools/check_compile.sh),Bash(git diff:*),Bash(git log:*)"
+            --allowed-tools "Read,Grep,Glob,Bash(lua:*),Bash(luacheck:*),Bash(bash tools/check_compile.sh),Bash(git diff:*),Bash(git log:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*)"
           prompt: |
             Review the changes in this pull request. QUI is a World of
-            Warcraft 12.1 addon suite in Lua 5.1. Post review comments; do not
-            approve, do not push commits, do not open other PRs.
+            Warcraft 12.1 addon suite in Lua 5.1. Do not approve, do not push
+            commits, do not open other PRs.
+
+            Your final assistant message is discarded — it is not posted
+            anywhere. A finding you do not write through a tool is lost. Post
+            each finding with mcp__github_inline_comment__create_inline_comment
+            on the line it concerns, then close with one summary via
+            `gh pr comment` listing every finding and its severity. Post the
+            summary even when the diff is clean.
 
             Scope yourself to the diff. Read surrounding code for context, but
             only report problems the diff introduces or exposes.


### PR DESCRIPTION
The Claude PR reviewer has never posted a comment. Runs are real — PR #698 was 57 turns, 10m34s, `$2.38`, `is_error: false` — and the output is discarded when the runner dies.

**Cause.** The action auto-detects `mode: agent` (an explicit `prompt:` is given). From `anthropics/claude-code-action` `src/mcp/install-mcp-server.ts`, the inline-comment MCP server is installed in agent mode *only* when `allowedTools` already names an `mcp__github_inline_comment__` tool. Our allowlist was read-only, so the server was never registered — the tool did not exist rather than being denied (`permission_denials_count: 6`). Agent mode also creates no tracking comment and never echoes the final message, so `mcp__github_comment__update_claude_comment` is not an option either (it needs `CLAUDE_COMMENT_ID`, set only in tag mode).

Confirmed empty on PRs #693, #695, #697, #698, #699 across `pulls/<n>/comments`, `pulls/<n>/reviews` and `issues/<n>/comments`; every log ends `No buffered inline comments`.

**Change.** Add `mcp__github_inline_comment__create_inline_comment` and `Bash(gh pr comment:*)` to the allowlist, set `GH_TOKEN` in the step `env` so the raw `gh` call authenticates, and state in the prompt that the final message is discarded.

`pull-requests: write` was already granted; no permission change. The reviewer still cannot approve or push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)