### PR TITLE
fix(cdm): stop fighting Blizzard over the cooldown swipe draw flag

### DIFF
--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -132,15 +132,6 @@ end
 local function BlankReanchoredNativeItemFrame(frame)
     if not frame then return end
     if frame.SetAlpha then frame:SetAlpha(0) end
-
-    local cd = frame.Cooldown
-    if not cd then
-        local ok, cooldown = ns.SafeCallMethodIfPresent("best-effort-style", frame, "GetCooldownFrame")
-        if ok then cd = cooldown end
-    end
-    if cd and cd.SetDrawSwipe then
-        cd:SetDrawSwipe(false)
-    end
 end
 
 local GetDB = Helpers.CreateDBGetter("ncdm")

--- a/QUI_CDM/cdm/cdm_reanchor.lua
+++ b/QUI_CDM/cdm/cdm_reanchor.lua
@@ -73,10 +73,6 @@ function CDMReanchor:Sink(frame)
     fd.sunk = true
     local raw, sc = self._raw, self._securecall
     sc(raw.SetAlpha, frame, 0)
-    local cd = (frame.GetCooldownFrame and frame:GetCooldownFrame()) or frame.Cooldown
-    if cd and cd.SetDrawSwipe then
-        sc(cd.SetDrawSwipe, cd, false)
-    end
 end
 
 function CDMReanchor:InstallAnchorGuard(frame)

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -280,7 +280,6 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
         if cd and cd.SetHideCountdownNumbers then
             cd:SetHideCountdownNumbers(rowConfig.hideDurationText and true or false)
         end
-        if cd and cd.SetDrawSwipe then cd:SetDrawSwipe(true) end
         local lvlOk, baseLvl = ns.SafeCallMethod("best-effort-style", frame, "GetFrameLevel")
         if lvlOk and type(baseLvl) == "number" then
             local textLvl = baseLvl + 23

--- a/tests/unit/cdm_reanchor_realenv_test.lua
+++ b/tests/unit/cdm_reanchor_realenv_test.lua
@@ -352,14 +352,11 @@ end
 
 -- Reference-parity PER-PASS writes on claimed frames (re-anchor reference
 -- re-asserts these every collect pass):
---  1) SetDrawSwipe(true): blank-on-acquire disables the swipe on every acquired
---     native item and nothing re-enabled it on claim -- a blanked-then-claimed
---     frame lost its cooldown swirl for the session.
---  2) Applications/ChargeCount frame-level raise: both are child FRAMES
---     (CooldownViewer.xml:54/:189), Blizzard resets pooled frame levels on zone
---     transitions, so the native stack/charge text must be re-raised above the
---     swirl every pass. Writes are on CHILD frames -- the live item frame keeps
---     its zero-forbidden-writes pin (no SetFrameLevel on the item itself).
+-- Applications/ChargeCount frame-level raise: both are child FRAMES
+-- (CooldownViewer.xml:54/:189), Blizzard resets pooled frame levels on zone
+-- transitions, so the native stack/charge text must be re-raised above the
+-- swirl every pass. Writes are on CHILD frames -- the live item frame keeps
+-- its zero-forbidden-writes pin (no SetFrameLevel on the item itself).
 do
     local cdCalls, appLevels, chargeLevels = {}, {}, {}
     local live = {
@@ -383,13 +380,12 @@ do
         return n
     end
     envC.applyChrome(live, { borderSize = 1 }, false) -- NON-first pass: per-pass writes only
-    assert(countCalls("SetDrawSwipe", true) == 1,
-        "claimed pass re-enables the native cooldown swipe (SetDrawSwipe true)")
     assert(appLevels[1] == 33 and chargeLevels[1] == 33,
         "claimed pass raises native stack/charge text child frames above the swirl (live level + 23)")
     envC.applyChrome(live, { borderSize = 1 }, false)
-    assert(countCalls("SetDrawSwipe", true) == 2,
-        "swipe re-assert runs EVERY claimed pass (re-acquire can re-blank between passes)")
+    assert(countCalls("SetDrawSwipe") == 0,
+        "applyChrome must NEVER write SetDrawSwipe -- Blizzard owns that channel per event; "
+        .. "a per-pass force-true alternates with Blizzard's charge edge-only false and flickers")
     assert(#appLevels == 2 and #chargeLevels == 2,
         "text raise runs every pass (Blizzard resets pooled frame levels on zone transitions)")
     -- Full reference parity: the native Cooldown widget writes also re-assert

--- a/tests/unit/cdm_reanchor_sink_test.lua
+++ b/tests/unit/cdm_reanchor_sink_test.lua
@@ -1,10 +1,10 @@
 -- tests/unit/cdm_reanchor_sink_test.lua
 -- Run: lua tests/unit/cdm_reanchor_sink_test.lua
--- G10: Sink hides an unclaimed pool frame with SetAlpha(0) + Cooldown:SetDrawSwipe(false)
--- ONLY -- NO ClearAllPoints, NO offscreen SetPoint. The anchor guard's unclaimed-branch
+-- G10: Sink hides an unclaimed pool frame with SetAlpha(0) ONLY -- NO ClearAllPoints,
+-- NO offscreen SetPoint, NO Cooldown writes. The anchor guard's unclaimed-branch
 -- alpha-0 + Blizzard's next Layout pass (which overwrites any point we set) already hide
 -- it, so the offscreen move was a redundant extra combat SetPoint + ClearAllPoints churn
--- on a managed GridLayout child. Mirrors the re-anchor reference's unclaimed-hide recipe.
+-- on a managed GridLayout child.
 local ns = {}
 local loadChunk = dofile("tests/helpers/load_cdm_consolidated_chunk.lua")
 loadChunk("QUI_CDM/cdm/cdm_reanchor.lua", "cdm_reanchor.lua")("QUI", ns)
@@ -42,8 +42,9 @@ end
 assert(sawAlpha0, "G10: Sink sets alpha 0")
 assert(not sawClear, "G10: Sink must NOT ClearAllPoints (redundant churn on managed GridLayout child)")
 assert(not sawOffscreen, "G10: Sink must NOT re-anchor offscreen (redundant extra combat SetPoint)")
-assert(#drawSwipeCalls == 1 and drawSwipeCalls[1] == false,
-    "G10: Sink calls Cooldown:SetDrawSwipe(false) for swipe-hide parity")
+assert(#drawSwipeCalls == 0,
+    "G10: Sink must NOT write Cooldown:SetDrawSwipe -- Blizzard owns that channel; "
+    .. "alpha 0 already hides the frame and a false here re-creates the swipe flicker fight")
 
 local keyCount = 0
 for _ in pairs(frame) do keyCount = keyCount + 1 end


### PR DESCRIPTION
CDM cooldown swipes on reanchored native frames were wiped/flickering. Root cause: two writers alternating on one channel. Blizzard rewrites `SetDrawSwipe` on every cooldown event (`false` for a recharging charge spell, which is edge-only by design), while QUI's container pass force-wrote it back to `true` up to 50ms later — each writer's value persisted across render frames, which reads as flicker.

Fix is pure deletion — give the channel back to Blizzard:

- `applyChrome` no longer force-writes `SetDrawSwipe(true)` per pass
- `Sink()` and blank-on-acquire no longer write `SetDrawSwipe(false)` — the frame is already alpha-0 there, and these writes were why the force-true existed
- Swipe visibility remains enforced through the swipe color choke-point hooks, which re-assert synchronously and cannot flicker

Charge recharges return to the native edge-only look. The two tests that pinned the old writes now pin their absence, so reintroducing either side of the fight reddens the suite.

`bash tools/test.sh`: all 9 gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)