### PR TITLE
release: v5.1.0-beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.1.0-beta4 - 2026-08-13
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Two fixes that keep QUI out of Blizzard's own code: the vehicle bar can hide
+itself again, and cooldown swipes stop flickering.
+
+### Fixed
+
+- **Leaving a vehicle no longer jams the override bar.** Blizzard's slide-out
+  code read a field QUI had tainted, so the final hide was blocked — the bar
+  could stick on screen with an "Interface action failed" error. QUI's action
+  buttons now stay out of the event table Blizzard reads, the micro menu is
+  moved back directly instead of through Blizzard's repositioning call, and a
+  bar that still gets stuck hides itself as soon as it legally can.
+- **Cooldown swipes stop flickering.** Two writers alternated on the swipe
+  draw flag: Blizzard rewrote it on every cooldown event and QUI forced it
+  back moments later. The flag belongs to Blizzard again, and recharging
+  charge spells return to their native edge-only look.
+
 ## v5.1.0-beta3 - 2026-08-12
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.1.0-beta3
+## Version: 5.1.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Version bump to 5.1.0-beta4: 13 TOCs + CHANGELOG section covering the OverrideActionBar taint fix (#704) and the CDM swipe flicker fix (#703).

Pre-flight: 9/9 gates on the work tree and again on the release commit in an isolated clone; extractor dry-run 19 lines, stops before the beta3 heading; event allowlist regen no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)