### PR TITLE
fix: restore CDM text styling and reset dropdown scroll

### DIFF
--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -12,6 +12,22 @@ end
 
 local _countFontCache = {}
 
+-- Exact per-path interning for the font-object cache key: stripping the path
+-- to a "safe" charset could collide two fonts differing only in punctuation.
+local _fontPathIndex = {}
+local _fontPathCount = 0
+
+local function _FontPathKey(font)
+    local path = tostring(font or "")
+    local idx = _fontPathIndex[path]
+    if not idx then
+        _fontPathCount = _fontPathCount + 1
+        idx = _fontPathCount
+        _fontPathIndex[path] = idx
+    end
+    return idx
+end
+
 local function _EnsureCountFont(font, sz, outline, color)
     if not CreateFont then return nil end
     sz = (type(sz) == "number" and sz > 0) and sz or 14
@@ -23,8 +39,7 @@ local function _EnsureCountFont(font, sz, outline, color)
             .. "," .. math.floor((color[3] or 1) * 255 + 0.5)
             .. "," .. math.floor((color[4] or 1) * 255 + 0.5)
     end
-    local fk = tostring(font or ""):gsub("[^%w]", "")
-    local key = fk .. "_" .. sz .. (outline ~= "" and "_" .. outline or "") .. ck
+    local key = "F" .. _FontPathKey(font) .. "_" .. sz .. (outline ~= "" and "_" .. outline or "") .. ck
     local name = _countFontCache[key]
     if not name then
         name = "QUI_CDM_CountFont_" .. key

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -48,37 +48,49 @@ local function _EnsureCountFont(font, sz, outline, color)
     return name
 end
 
-local function _EachCooldownFontString(cd, fn)
-    if not cd then return end
+-- Resolved countdown fontstring per Cooldown widget. applyChrome runs per
+-- claimed icon per collect pass, so the resolve (and its GetRegions table)
+-- must not re-run on the hot path; misses are retried until the fontstring
+-- exists (it is created lazily on the first SetCooldown).
+local _cdCountdownFS = setmetatable({}, { __mode = "k" })
+
+local function _CollectRegions(cd)
+    return { cd:GetRegions() }
+end
+
+local function _ResolveCountdownFontString(cd)
+    local fs = _cdCountdownFS[cd]
+    if fs then return fs end
     if cd.GetCountdownFontString then
-        local ok, fs = ns.SafeCallMethod("best-effort-style", cd, "GetCountdownFontString")
-        if ok and fs and not _issecretvalue(fs) then fn(fs) end
+        local ok, got = ns.SafeCallMethod("best-effort-style", cd, "GetCountdownFontString")
+        if ok and got and not _issecretvalue(got) then fs = got end
     end
-    if cd.GetRegions then
-        local ok, regions = ns.SafeCall("best-effort-style", function() return { cd:GetRegions() } end)
+    if not fs and cd.GetRegions then
+        local ok, regions = ns.SafeCall("best-effort-style", _CollectRegions, cd)
         if ok and type(regions) == "table" then
             for i = 1, #regions do
                 local region = regions[i]
                 if region and not _issecretvalue(region)
                     and region.GetObjectType and region:GetObjectType() == "FontString" then
-                    fn(region)
+                    fs = region
+                    break
                 end
             end
         end
     end
+    if fs then _cdCountdownFS[cd] = fs end
+    return fs
 end
 
 local function _AnchorCountdownText(cd, frame, rowConfig)
     if not (cd and frame) then return end
-    local anchor = rowConfig.durationAnchor or "CENTER"
-    local ox = rowConfig.durationOffsetX or 0
-    local oy = rowConfig.durationOffsetY or 0
-    _EachCooldownFontString(cd, function(fs)
-        if fs.ClearAllPoints and fs.SetPoint then
-            fs:ClearAllPoints()
-            fs:SetPoint(anchor, frame, anchor, ox, oy)
-        end
-    end)
+    local fs = _ResolveCountdownFontString(cd)
+    if fs and fs.ClearAllPoints and fs.SetPoint then
+        fs:ClearAllPoints()
+        fs:SetPoint(rowConfig.durationAnchor or "CENTER", frame,
+            rowConfig.durationAnchor or "CENTER",
+            rowConfig.durationOffsetX or 0, rowConfig.durationOffsetY or 0)
+    end
 end
 
 local function _ResolveStackText(frame)

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -23,7 +23,8 @@ local function _EnsureCountFont(font, sz, outline, color)
             .. "," .. math.floor((color[3] or 1) * 255 + 0.5)
             .. "," .. math.floor((color[4] or 1) * 255 + 0.5)
     end
-    local key = sz .. (outline ~= "" and "_" .. outline or "") .. ck
+    local fk = tostring(font or ""):gsub("[^%w]", "")
+    local key = fk .. "_" .. sz .. (outline ~= "" and "_" .. outline or "") .. ck
     local name = _countFontCache[key]
     if not name then
         name = "QUI_CDM_CountFont_" .. key
@@ -45,6 +46,88 @@ local function _EnsureCountFont(font, sz, outline, color)
         end
     end
     return name
+end
+
+local function _EachCooldownFontString(cd, fn)
+    if not cd then return end
+    if cd.GetCountdownFontString then
+        local ok, fs = ns.SafeCallMethod("best-effort-style", cd, "GetCountdownFontString")
+        if ok and fs and not _issecretvalue(fs) then fn(fs) end
+    end
+    if cd.GetRegions then
+        local ok, regions = ns.SafeCall("best-effort-style", function() return { cd:GetRegions() } end)
+        if ok and type(regions) == "table" then
+            for i = 1, #regions do
+                local region = regions[i]
+                if region and not _issecretvalue(region)
+                    and region.GetObjectType and region:GetObjectType() == "FontString" then
+                    fn(region)
+                end
+            end
+        end
+    end
+end
+
+local function _AnchorCountdownText(cd, frame, rowConfig)
+    if not (cd and frame) then return end
+    local anchor = rowConfig.durationAnchor or "CENTER"
+    local ox = rowConfig.durationOffsetX or 0
+    local oy = rowConfig.durationOffsetY or 0
+    _EachCooldownFontString(cd, function(fs)
+        if fs.ClearAllPoints and fs.SetPoint then
+            fs:ClearAllPoints()
+            fs:SetPoint(anchor, frame, anchor, ox, oy)
+        end
+    end)
+end
+
+local function _ResolveStackText(frame)
+    local apps = frame.Applications
+    if apps then
+        if apps.GetObjectType and apps:GetObjectType() == "FontString" then
+            return apps, nil
+        end
+        local fs = apps.Applications
+        if fs and fs.GetObjectType and fs:GetObjectType() == "FontString" then
+            return fs, apps
+        end
+    end
+    local charge = frame.ChargeCount
+    if charge then
+        local fs = charge.Current
+        if fs and fs.GetObjectType and fs:GetObjectType() == "FontString" then
+            return fs, charge
+        end
+    end
+    return nil, nil
+end
+
+local function _StyleStackText(frame, rowConfig, baseFont, outline)
+    local fs, holder = _ResolveStackText(frame)
+    if not fs then return end
+    if rowConfig.hideStackText then
+        if holder and holder.SetAlpha then holder:SetAlpha(0) end
+        if fs.SetAlpha then fs:SetAlpha(0) end
+        return
+    end
+    if holder and holder.SetAlpha then holder:SetAlpha(1) end
+    if fs.SetAlpha then fs:SetAlpha(1) end
+    local font = baseFont
+    local LSM = ns.LSM
+    if LSM and rowConfig.stackFont and rowConfig.stackFont ~= "" then
+        font = LSM:Fetch("font", rowConfig.stackFont) or font
+    end
+    local stackSize = rowConfig.stackSize
+    if font and type(stackSize) == "number" and stackSize > 0 then
+        local name = _EnsureCountFont(font, stackSize, outline or "",
+            rowConfig.stackTextColor or {1, 1, 1, 1})
+        if name and fs.SetFontObject then fs:SetFontObject(name) end
+    end
+    if fs.ClearAllPoints and fs.SetPoint then
+        local anchor = rowConfig.stackAnchor or "BOTTOMRIGHT"
+        fs:ClearAllPoints()
+        fs:SetPoint(anchor, frame, anchor, rowConfig.stackOffsetX or 0, rowConfig.stackOffsetY or 0)
+    end
 end
 
 local function _DecorateWork(decorator, live, shell, rowConfig)
@@ -266,20 +349,30 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
             if cd.SetSwipeTexture then cd:SetSwipeTexture("Interface\\Buttons\\WHITE8X8") end
             if cd.SetDrawBling then cd:SetDrawBling(false) end
         end
+        local generalFont, generalOutline
         if Helpers and Helpers.GetGeneralFont then
-            local font = Helpers.GetGeneralFont()
-            local outline = Helpers.GetGeneralFontOutline and Helpers.GetGeneralFontOutline() or ""
+            generalFont = Helpers.GetGeneralFont()
+            generalOutline = Helpers.GetGeneralFontOutline and Helpers.GetGeneralFontOutline() or ""
+        end
+        if generalFont then
+            local durationFont = generalFont
+            local LSM = ns.LSM
+            if LSM and rowConfig.durationFont and rowConfig.durationFont ~= "" then
+                durationFont = LSM:Fetch("font", rowConfig.durationFont) or durationFont
+            end
             local dtc = rowConfig.durationTextColor or {1, 1, 1, 1}
-            if font then
-                local countFontName = _EnsureCountFont(font, rowConfig.durationSize or 14, outline, dtc)
-                if cd and cd.SetCountdownFont and countFontName then
-                    cd:SetCountdownFont(countFontName)
-                end
+            local countFontName = _EnsureCountFont(durationFont, rowConfig.durationSize or 14, generalOutline, dtc)
+            if cd and cd.SetCountdownFont and countFontName then
+                cd:SetCountdownFont(countFontName)
             end
         end
         if cd and cd.SetHideCountdownNumbers then
             cd:SetHideCountdownNumbers(rowConfig.hideDurationText and true or false)
         end
+        if not rowConfig.hideDurationText then
+            _AnchorCountdownText(cd, frame, rowConfig)
+        end
+        _StyleStackText(frame, rowConfig, generalFont, generalOutline)
         local lvlOk, baseLvl = ns.SafeCallMethod("best-effort-style", frame, "GetFrameLevel")
         if lvlOk and type(baseLvl) == "number" then
             local textLvl = baseLvl + 23

--- a/QUI_Options/framework.lua
+++ b/QUI_Options/framework.lua
@@ -1964,6 +1964,9 @@ local function AcquireSharedMenuFor(menu, container, dropdown, searchable, build
     menu._owner = container
     menu._ownerDropdown = dropdown
     menu._ownerBuildMenu = buildMenu
+    -- The menu is shared across every form dropdown: a scroll offset left by a
+    -- long list would push a short list entirely out of the clipped viewport.
+    menu.scrollFrame:SetVerticalScroll(0)
     if searchable then
         menu.searchContainer:Show()
         menu.scrollFrame:SetPoint("TOPLEFT", 0, -DROPDOWN_SEARCH_BOX_HEIGHT)

--- a/tests/unit/cdm_reanchor_realenv_test.lua
+++ b/tests/unit/cdm_reanchor_realenv_test.lua
@@ -1097,4 +1097,139 @@ do
     factoryStub.ReleaseIcon = savedReleaseIcon
 end
 
+-- Duration/stack text styling on re-anchored live items (Discord report 2026-08):
+-- pre-reanchor, ConfigureIcon styled QUI-owned icons; post-reanchor the live
+-- Blizzard item kept its native centered countdown + small NumberFontNormal
+-- charge/stack text, ignoring durationAnchor/offsets and stackSize/stackAnchor.
+-- applyChrome must now (a) re-anchor the native countdown fontstring per
+-- rowConfig and (b) restyle native ChargeCount.Current / Applications.Applications
+-- via a font OBJECT (SetFontObject -- G14's "never raw SetFont" invariant holds)
+-- plus anchor writes relative to the live item frame.
+do
+    local oldCreateFont, oldHelpers = _G.CreateFont, ns.Helpers
+    local fontObjs = {}
+    _G.CreateFont = function(name)
+        local fo = { _sets = {} }
+        fo.SetFont = function(_, f, sz, o) fo._sets[#fo._sets + 1] = { f, sz, o } end
+        fo.SetTextColor = function() end
+        fontObjs[name] = fo
+        _G[name] = fo
+        return fo
+    end
+    ns.Helpers = {
+        GetGeneralFont = function() return "QUIFONT.TTF" end,
+        GetGeneralFontOutline = function() return "OUTLINE" end,
+        GetSkinBorderColor = function() return 0, 0, 0, 1 end,
+    }
+
+    local function fsWidget()
+        local w = { _log = {} }
+        w.GetObjectType = function() return "FontString" end
+        return setmetatable(w, { __index = function(_, k)
+            return function(_, ...) w._log[#w._log + 1] = { k, ... } end
+        end })
+    end
+    local function logFind(w, m)
+        for _, c in ipairs(w._log) do if c[1] == m then return c end end
+        return nil
+    end
+
+    -- shape = "charge" (essential/utility: ChargeCount.Current) or
+    -- "apps" (buff icon: Applications frame -> Applications fontstring)
+    local function makeItem(shape)
+        local countFs, stackFs = fsWidget(), fsWidget()
+        local cdLog = {}
+        local cd = setmetatable({
+            GetCountdownFontString = function() return countFs end,
+            GetRegions = function() return countFs end,
+        }, { __index = function(_, k)
+            return function(_, ...) cdLog[#cdLog + 1] = { k, ... } end
+        end })
+        local holderAlphas = {}
+        local holder = { SetAlpha = function(_, a) holderAlphas[#holderAlphas + 1] = a end }
+        local frame = {
+            Cooldown = cd,
+            GetFrameLevel = function() return 10 end,
+            SetAlpha = function() end,
+            CreateTexture = function()
+                return setmetatable({}, { __index = function() return function() end end })
+            end,
+        }
+        if shape == "charge" then
+            holder.Current = stackFs
+            frame.ChargeCount = holder
+        else
+            holder.Applications = stackFs
+            frame.Applications = holder
+        end
+        return frame, countFs, stackFs, cdLog, holderAlphas
+    end
+    local function cdLogFind(cdLog, m)
+        for _, c in ipairs(cdLog) do if c[1] == m then return c end end
+        return nil
+    end
+
+    local styleEnv = RE.BuildEnv({})
+    local rc = {
+        borderSize = 0,
+        durationSize = 20, durationAnchor = "TOP", durationOffsetX = 1, durationOffsetY = 5,
+        durationTextColor = { 1, 1, 1, 1 },
+        stackSize = 20, stackAnchor = "BOTTOM", stackOffsetX = 0, stackOffsetY = -8,
+        stackTextColor = { 1, 1, 1, 1 },
+    }
+
+    for _, shape in ipairs({ "charge", "apps" }) do
+        local frame, countFs, stackFs, cdLog = makeItem(shape)
+        styleEnv.applyChrome(frame, rc)
+
+        -- (a) countdown text follows durationAnchor/offsets (was: native center)
+        assert(logFind(countFs, "ClearAllPoints"), shape .. ": countdown fs re-anchored (ClearAllPoints)")
+        local sp = logFind(countFs, "SetPoint")
+        assert(sp and sp[2] == "TOP" and sp[3] == frame and sp[4] == "TOP"
+            and sp[5] == 1 and sp[6] == 5,
+            shape .. ": countdown fs SetPoint(durationAnchor, live, durationAnchor, dx, dy)")
+        local scf = cdLogFind(cdLog, "SetCountdownFont")
+        assert(scf and fontObjs[scf[2]], shape .. ": SetCountdownFont uses a registered font object")
+        assert(fontObjs[scf[2]]._sets[1] and fontObjs[scf[2]]._sets[1][2] == 20,
+            shape .. ": countdown font object carries durationSize")
+
+        -- (b) native stack/charge text picks up stackSize/stackAnchor via font object
+        assert(not logFind(stackFs, "SetFont"), shape .. ": still NEVER raw SetFont on the native fs (G14)")
+        local sfo = logFind(stackFs, "SetFontObject")
+        assert(sfo and fontObjs[sfo[2]], shape .. ": stack fs styled via SetFontObject(font object)")
+        assert(fontObjs[sfo[2]]._sets[1] and fontObjs[sfo[2]]._sets[1][2] == 20,
+            shape .. ": stack font object carries stackSize (was: Blizzard NumberFontNormal)")
+        local ssp = logFind(stackFs, "SetPoint")
+        assert(ssp and ssp[2] == "BOTTOM" and ssp[3] == frame and ssp[4] == "BOTTOM"
+            and ssp[5] == 0 and ssp[6] == -8,
+            shape .. ": stack fs SetPoint(stackAnchor, live, stackAnchor, sx, sy)")
+    end
+
+    -- hideStackText blanks the native count via alpha on holder + fs (Blizzard
+    -- SetShown()s the holder every refresh, so Hide() would not stick)
+    do
+        local frame, _, stackFs, _, holderAlphas = makeItem("charge")
+        styleEnv.applyChrome(frame, {
+            borderSize = 0, durationSize = 20, stackSize = 20, hideStackText = true,
+        })
+        assert(holderAlphas[#holderAlphas] == 0, "hideStackText alpha-0s the native holder frame")
+        local sa = logFind(stackFs, "SetAlpha")
+        assert(sa and sa[2] == 0, "hideStackText alpha-0s the native fs")
+        assert(not logFind(stackFs, "SetFontObject"), "hidden stack text is not restyled")
+    end
+
+    -- hideDurationText suppresses the countdown re-anchor (numbers are hidden
+    -- natively via SetHideCountdownNumbers; no anchor writes needed)
+    do
+        local frame, countFs = makeItem("charge")
+        styleEnv.applyChrome(frame, {
+            borderSize = 0, durationSize = 20, stackSize = 20, hideDurationText = true,
+        })
+        assert(not logFind(countFs, "SetPoint"), "hideDurationText: countdown fs left un-anchored")
+    end
+
+    _G.CreateFont, ns.Helpers = oldCreateFont, oldHelpers
+    print("OK: reanchor chrome styles native countdown + stack text per rowConfig")
+end
+
 print("OK: cdm_reanchor_realenv_test")


### PR DESCRIPTION
- Re-anchor and restyle live countdown and stack text
- Reset shared dropdown scroll when menus are acquired