### PR TITLE
Land staged fixes: action bar icon repaint gaps, micro menu reclaim restore

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_events.lua
+++ b/QUI_ActionBars/actionbars/actionbars_events.lua
@@ -225,7 +225,10 @@ end)
 
 function ScheduleSlotUpdate(slot)
     if not slot or slot < 1 then return end
-    if GetTime() - _lastPagingTime < 0.5 then return end
+    if GetTime() - _lastPagingTime < 0.5 then
+        ScheduleABVisualUpdate(false, true)
+        return
+    end
     abDirtySlots[slot] = true
     abSlotFrame:Show()
 end
@@ -279,6 +282,7 @@ function OnOwnedEvent(self, event, ...)
                 ActionBarsOwned.UpdateOverlayGlow(btn)
             end
         end
+        ScheduleABVisualUpdate(false, true)
         if not InCombatLockdown() then
             UpdateStanceBarLayout()
         else
@@ -321,6 +325,7 @@ function OnOwnedEvent(self, event, ...)
         end
 
     elseif event == "PLAYER_REGEN_ENABLED" then
+        ScheduleABVisualUpdate(false, true)
         FinishBlockedOverrideBarExit()
         if ActionBarsOwned.pendingExtraButtonInit then
             ActionBarsOwned.pendingExtraButtonInit = false

--- a/modules/skinning/frames/overrideactionbar.lua
+++ b/modules/skinning/frames/overrideactionbar.lua
@@ -32,18 +32,22 @@ local function MicroMenuDockedInOverrideBar()
 end
 
 local function CacheMicroMenuHome()
-    if microMenuHome then return end
     local menu = _G.MicroMenu
-    if not (menu and menu.GetPoint) then return end
+    if not menu then return end
     if MicroMenuDockedInOverrideBar() then return end
-    local point, relativeTo, relativePoint, x, y = menu:GetPoint(1)
-    if issecretvalue and (issecretvalue(point) or issecretvalue(relativeTo)
-        or issecretvalue(relativePoint) or issecretvalue(x) or issecretvalue(y)) then
+    local stride, isStacked, isHorizontal = menu.stride, menu.isStacked, menu.isHorizontal
+    local goingRight, goingUp = menu.layoutFramesGoingRight, menu.layoutFramesGoingUp
+    if issecretvalue and (issecretvalue(stride) or issecretvalue(isStacked)
+        or issecretvalue(isHorizontal) or issecretvalue(goingRight) or issecretvalue(goingUp)) then
         return
     end
-    if point then
-        microMenuHome = { point, relativeTo, relativePoint, x or 0, y or 0 }
-    end
+    microMenuHome = {
+        stride = stride,
+        isStacked = isStacked,
+        isHorizontal = isHorizontal,
+        goingRight = goingRight,
+        goingUp = goingUp,
+    }
 end
 
 local function ReclaimMicroMenuFromOverrideBar()
@@ -54,10 +58,20 @@ local function ReclaimMicroMenuFromOverrideBar()
     CacheMicroMenuHome()
     if not MicroMenuDockedInOverrideBar() then return end
     menu:SetParent(container)
-    if microMenuHome then
-        menu:ClearAllPoints()
-        menu:SetPoint(microMenuHome[1], microMenuHome[2] or container, microMenuHome[3], microMenuHome[4], microMenuHome[5])
+    if menu.ClearOverrideScale then menu:ClearOverrideScale() end
+    local home = microMenuHome
+    if home then
+        menu.stride = home.stride or menu.numButtons
+        menu.isStacked = home.isStacked
+        menu.isHorizontal = home.isHorizontal
+        menu.layoutFramesGoingRight = home.goingRight
+        menu.layoutFramesGoingUp = home.goingUp
+    else
+        menu.stride = menu.numButtons
+        menu.isStacked = false
     end
+    if menu.Layout then menu:Layout() end
+    if container.Layout then container:Layout() end
 end
 
 local function StyleActionButton(button, index, sr, sg, sb, sa, bgr, bgg, bgb)


### PR DESCRIPTION
Two fixes for regressions surfaced by v5.2.0-beta1 in-game testing and the PR #704 review:

- **fix(actionbars): repaint icons through the owned pipeline** — with owned buttons out of both Blizzard dispatch registries (#704/#716) the owned pipeline is the sole icon painter; it never repainted on page/stance changes, dropped slot updates for 0.5s after paging events, and scheduled nothing on combat exit, so icons stayed stale until hover forced a full update. Adds an immediate visual pass at all three sites.
- **fix(skinning): restore micro menu scale and layout on reclaim** — closes both findings from the #704 review: the reclaim now clears the 0.85 override scale, restores the five layout fields, and lets MicroMenu:Layout() re-derive the anchor instead of caching a point once per session.

`bash tools/test.sh`: all 9 gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)