### PR TITLE
fix: CDM editmode save-pending taint loop + tooltip widget unskin

### DIFF
--- a/QUI_CDM/cdm/cdm_editmode_policy.lua
+++ b/QUI_CDM/cdm/cdm_editmode_policy.lua
@@ -91,21 +91,14 @@ function CDMEditModePolicy.Enforce()
     })
 
     _applied = true
+    local db = _G.QUIDB
     if not changed then
-        local db = _G.QUIDB
         if db then db.cdmEditModeSavePending = nil end
         return
     end
 
-    C_EditMode.SaveLayouts(layoutInfo)
-
-    if not (_G.StaticPopupDialogs and _G.StaticPopup_Show) then return end
-
-    local db = _G.QUIDB
-    local savePending = db and db.cdmEditModeSavePending
-    if db then db.cdmEditModeSavePending = true end
-
-    if savePending then
+    if db and db.cdmEditModeSavePending then
+        if not (_G.StaticPopupDialogs and _G.StaticPopup_Show) then return end
         _G.StaticPopupDialogs["QUI_CDM_EDITMODE_MANUAL"] = {
             text = "QUI could not save the Cooldown Manager Edit Mode settings,"
                 .. " so they must be set by hand:\n\n"
@@ -126,6 +119,11 @@ function CDMEditModePolicy.Enforce()
         return
     end
 
+    C_EditMode.SaveLayouts(layoutInfo)
+    if db then db.cdmEditModeSavePending = true end
+
+    if not (_G.StaticPopupDialogs and _G.StaticPopup_Show) then return end
+
     _G.StaticPopupDialogs["QUI_CDM_EDITMODE_RELOAD"] = {
         text = "QUI has updated your Cooldown Manager Edit Mode settings"
             .. " (viewers must be Always visible with Hide When Inactive on"
@@ -145,9 +143,21 @@ end
 local enforceFrame = CreateFrame("Frame")
 enforceFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 enforceFrame:SetScript("OnEvent", function(self, event)
-    if event ~= "PLAYER_ENTERING_WORLD" then return end
-    if self and self.UnregisterEvent then
-        self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+    if event == "PLAYER_ENTERING_WORLD" then
+        if self and self.UnregisterEvent then
+            self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+        end
+        if _G.InCombatLockdown and _G.InCombatLockdown()
+            and self and self.RegisterEvent then
+            self:RegisterEvent("PLAYER_REGEN_ENABLED")
+            return
+        end
+    elseif event == "PLAYER_REGEN_ENABLED" then
+        if self and self.UnregisterEvent then
+            self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+        end
+    else
+        return
     end
     CDMEditModePolicy.Enforce()
 end)

--- a/core/utils.lua
+++ b/core/utils.lua
@@ -59,7 +59,7 @@ function Helpers.HasTaintedWidgetContainer(tooltip)
     for i = 1, #children do
         local child = children[i]
         if child then
-            local ok, isWidgetContainer, widgetSetID, shownWidgetCount, numWidgetsShowing, dirty, numPoints = pcall(function()
+            local ok, isWidgetContainer, widgetSetID, numWidgetsShowing, dirty, numPoints = pcall(function()
                 local isWidget = child.RegisterForWidgetSet
                     or child.widgetType
                     or child.widgetSetID ~= nil
@@ -71,7 +71,7 @@ function Helpers.HasTaintedWidgetContainer(tooltip)
                     points = child:GetNumPoints()
                 end
 
-                return isWidget, child.widgetSetID, child.shownWidgetCount, child.numWidgetsShowing, child.dirty, points
+                return isWidget, child.widgetSetID, child.numWidgetsShowing, child.dirty, points
             end)
 
             if not ok then
@@ -80,7 +80,6 @@ function Helpers.HasTaintedWidgetContainer(tooltip)
 
             if isWidgetContainer then
                 if Helpers.IsSecretValue(widgetSetID)
-                    or Helpers.IsSecretValue(shownWidgetCount)
                     or Helpers.IsSecretValue(numWidgetsShowing)
                     or Helpers.IsSecretValue(dirty)
                     or Helpers.IsSecretValue(numPoints) then
@@ -88,11 +87,6 @@ function Helpers.HasTaintedWidgetContainer(tooltip)
                 end
 
                 if widgetSetID ~= nil or dirty == true then
-                    return true
-                end
-
-                local shownCount = tonumber(shownWidgetCount)
-                if shownCount and shownCount > 0 then
                     return true
                 end
 

--- a/modules/skinning/system/tooltips.lua
+++ b/modules/skinning/system/tooltips.lua
@@ -558,19 +558,6 @@ HasActiveWidgetContainer = function(tooltip)
                 return true
             end
 
-            local shownWidgetCount = child.shownWidgetCount
-            if shownWidgetCount ~= nil then
-                if Helpers.IsSecretValue(shownWidgetCount) then
-                    TooltipDebugCount("skin.widgetHit")
-                    return true -- @secret-policy: keep-native-when-unknown
-                end
-                shownWidgetCount = tonumber(shownWidgetCount)
-                if shownWidgetCount and shownWidgetCount > 0 then
-                    TooltipDebugCount("skin.widgetHit")
-                    return true
-                end
-            end
-
             local numWidgetsShowing = child.numWidgetsShowing
             if numWidgetsShowing ~= nil then
                 if Helpers.IsSecretValue(numWidgetsShowing) then

--- a/tests/unit/cdm_editmode_policy_test.lua
+++ b/tests/unit/cdm_editmode_policy_test.lua
@@ -212,6 +212,7 @@ do
     loadChunk("QUI_CDM/cdm/cdm_editmode_policy.lua", "cdm_editmode_policy.lua")("QUI", ns5)
     eventHandler(nil, "PLAYER_ENTERING_WORLD")
     assert(popupsShown[1] == "QUI_CDM_EDITMODE_MANUAL", "still unresolved next session -> manual instructions, no reload loop")
+    assert(#savedLayouts == 0, "save-pending state never re-saves (a re-save taints the whole session)")
     assert(_G.QUIDB.cdmEditModeSavePending == true, "save-pending flag stays latched while unresolved")
 end
 
@@ -224,6 +225,33 @@ do
     assert(#savedLayouts == 0 and #popupsShown == 0, "settled layout -> no save, no prompt")
     assert(_G.QUIDB.cdmEditModeSavePending == nil, "settled layout re-arms the loop breaker")
     _G.QUIDB = nil
+end
+
+---------------------------------------------------------------------------
+-- Combat deferral: a PEW during combat lockdown must not save (a save
+-- taints the session and reload is impossible in combat); enforcement runs
+-- at PLAYER_REGEN_ENABLED instead.
+---------------------------------------------------------------------------
+do
+    local ns7 = {}
+    savedLayouts, popupsShown = {}, {}
+    local regs = {}
+    local frameStub = {
+        RegisterEvent = function(_, ev) regs[ev] = true end,
+        UnregisterEvent = function(_, ev) regs[ev] = nil end,
+    }
+    _G.InCombatLockdown = function() return true end
+    layoutInfoToReturn = staleLayout()
+    loadChunk("QUI_CDM/cdm/cdm_editmode_policy.lua", "cdm_editmode_policy.lua")("QUI", ns7)
+    eventHandler(frameStub, "PLAYER_ENTERING_WORLD")
+    assert(#savedLayouts == 0 and #popupsShown == 0, "in-combat PEW -> enforcement deferred, nothing saved")
+    assert(regs["PLAYER_REGEN_ENABLED"], "in-combat PEW -> waits for PLAYER_REGEN_ENABLED")
+    _G.InCombatLockdown = function() return false end
+    eventHandler(frameStub, "PLAYER_REGEN_ENABLED")
+    assert(#savedLayouts == 1, "regen after deferral -> save runs")
+    assert(popupsShown[1] == "QUI_CDM_EDITMODE_RELOAD", "regen after deferral -> forced reload prompt")
+    assert(regs["PLAYER_REGEN_ENABLED"] == nil, "regen listener unregistered after firing")
+    _G.InCombatLockdown = nil
 end
 
 print("OK: cdm_editmode_policy_test")

--- a/tests/unit/tooltip_widget_container_stale_state_test.lua
+++ b/tests/unit/tooltip_widget_container_stale_state_test.lua
@@ -1,0 +1,65 @@
+-- tests/unit/tooltip_widget_container_stale_state_test.lua
+-- Run: lua tests/unit/tooltip_widget_container_stale_state_test.lua
+local function readAll(path)
+    local f = assert(io.open(path, "rb"))
+    local data = f:read("*a"); f:close()
+    return (data:gsub("\r\n", "\n"))
+end
+
+local src = readAll("core/utils.lua")
+local body = src:match("function Helpers%.HasTaintedWidgetContainer.-\nend")
+assert(body, "HasTaintedWidgetContainer not found in core/utils.lua")
+
+local SECRET = setmetatable({}, { __tostring = function() return "<secret>" end })
+local HelpersStub = {
+    IsSecretValue = function(v) return v == SECRET end,
+}
+
+local loader = loadstring or load
+local factory = assert(loader(
+    "return function(Helpers)\n" .. body .. "\nreturn Helpers.HasTaintedWidgetContainer\nend",
+    "HasTaintedWidgetContainer"))
+local HasTaintedWidgetContainer = factory()(HelpersStub)
+assert(type(HasTaintedWidgetContainer) == "function", "helper extracted")
+
+local function makeContainer(overrides)
+    local child = {
+        RegisterForWidgetSet = function() end,
+        widgetSetID = nil,
+        shownWidgetCount = 3,
+        numWidgetsShowing = 0,
+        IsShown = function() return false end,
+        GetNumPoints = function() return 0 end,
+    }
+    for k, v in pairs(overrides or {}) do child[k] = v end
+    return child
+end
+
+local function makeTooltip(child)
+    return {
+        GetChildren = function()
+            if child then return child end
+        end,
+    }
+end
+
+assert(HasTaintedWidgetContainer(makeTooltip(nil)) == false,
+    "no children -> not tainted")
+
+assert(HasTaintedWidgetContainer(makeTooltip(makeContainer())) == false,
+    "cleared container with stale shownWidgetCount high-water mark -> not tainted")
+
+assert(HasTaintedWidgetContainer(makeTooltip(makeContainer({ widgetSetID = 5 }))) == true,
+    "registered widget set -> tainted")
+
+assert(HasTaintedWidgetContainer(makeTooltip(makeContainer({ numWidgetsShowing = 2 }))) == true,
+    "widgets showing -> tainted")
+
+assert(HasTaintedWidgetContainer(makeTooltip(makeContainer({
+    IsShown = function() return true end,
+}))) == true, "container currently shown -> tainted")
+
+assert(HasTaintedWidgetContainer(makeTooltip(makeContainer({ widgetSetID = SECRET }))) == true,
+    "secret widget state -> tainted (keep native when unknown)")
+
+print("OK: tooltip_widget_container_stale_state_test")


### PR DESCRIPTION
Two staged fixes, both with proven-discriminator unit tests; `tools/test.sh` 9/9 green.

## fix(cdm): stop edit mode layout saves from re-tainting every login
A pending-save session re-ran `C_EditMode.SaveLayouts` at every login with no reload path, leaving the session permanently tainted. The savePending branch now returns before `SaveLayouts` (manual-instructions popup only), and `PLAYER_ENTERING_WORLD` in combat defers `Enforce` to `PLAYER_REGEN_ENABLED`.

## fix(skinning): keep skinning tooltips after the first widget tooltip
`shownWidgetCount` is a never-reset high-water mark on the widget container, so the first widget tooltip of the session made every later tooltip read as "has active widgets" and skinning stopped until reload. Both detection paths (`core/utils.lua` taint probe and the skinner's `HasActiveWidgetContainer`) now rely on `numWidgetsShowing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)