### PR TITLE
fix: skin-gate leaks, CDM double keybinds, Edit Mode write convention

### DIFF
--- a/QUI_CDM/cdm/cdm_editmode_policy.lua
+++ b/QUI_CDM/cdm/cdm_editmode_policy.lua
@@ -70,6 +70,7 @@ function CDMEditModePolicy.Enforce()
             layoutInfo.layouts = presets
         end
     end
+    if numPresets == 0 then return end
 
     local activeLayout = type(layoutInfo.activeLayout) == "number"
         and layoutInfo.layouts[layoutInfo.activeLayout]

--- a/QUI_Options/wizard.lua
+++ b/QUI_Options/wizard.lua
@@ -95,6 +95,10 @@ local function ApplyEditModeBaseLayout()
         and C_EditMode.SaveLayouts and C_EditMode.SetActiveLayout and Enum and Enum.EditModeLayoutType) then
         return false, L["Edit Mode API unavailable on this client."]
     end
+    local presetMgr = _G.EditModePresetLayoutManager
+    if not (presetMgr and presetMgr.GetCopyOfPresetLayouts) then
+        return false, L["Edit Mode API unavailable on this client."]
+    end
 
     local ok, err = pcall(function()
         local newInfo = C_EditMode.ConvertStringToLayoutInfo(str)
@@ -103,21 +107,19 @@ local function ApplyEditModeBaseLayout()
         end
 
         local layoutInfo = C_EditMode.GetLayouts()
-        local list = layoutInfo and layoutInfo.layouts
-        if type(list) ~= "table" then
+        local customs = layoutInfo and layoutInfo.layouts
+        if type(customs) ~= "table" then
             error(L["Edit Mode layout list unavailable."], 0)
         end
 
-        local presetsInList = 0
-        for _, layout in ipairs(list) do
-            if layout.layoutType == Enum.EditModeLayoutType.Preset then
-                presetsInList = presetsInList + 1
-            end
+        local list = presetMgr:GetCopyOfPresetLayouts()
+        if type(list) ~= "table" or #list == 0 then
+            error(L["Edit Mode layout list unavailable."], 0)
         end
-        local presetOffset = 0
-        if presetsInList == 0 then
-            presetOffset = (Enum.EditModePresetLayoutsMeta and Enum.EditModePresetLayoutsMeta.NumValues) or 2
+        for i = 1, #customs do
+            list[#list + 1] = customs[i]
         end
+        layoutInfo.layouts = list
 
         local targetIndex
         for i, layout in ipairs(list) do
@@ -137,7 +139,7 @@ local function ApplyEditModeBaseLayout()
         end
 
         C_EditMode.SaveLayouts(layoutInfo)
-        C_EditMode.SetActiveLayout(targetIndex + presetOffset)
+        C_EditMode.SetActiveLayout(targetIndex)
     end)
 
     if not ok then

--- a/modules/skinning/character_pane/character.lua
+++ b/modules/skinning/character_pane/character.lua
@@ -3968,8 +3968,10 @@ if ns.WhenLoggedIn then
     end)
 end
 
+-- <<< QUI_TEST_EXTRACT character_refresh_gate
 _G.QUI_RefreshCharacterPane = function()
-    if CharacterFrame then
+    local settings = GetSettings()
+    if settings.enabled and CharacterFrame then
         if CharacterFrame.CloseButton then
             StyleCloseButton(CharacterFrame.CloseButton)
         end
@@ -3977,6 +3979,7 @@ _G.QUI_RefreshCharacterPane = function()
     end
     ScheduleUpdate()
 end
+-- <<< QUI_TEST_EXTRACT character_refresh_gate
 
 QUI.CharacterPane = {
     Refresh = function()

--- a/modules/skinning/frames/worldmap.lua
+++ b/modules/skinning/frames/worldmap.lua
@@ -86,7 +86,7 @@ end
 
 local function RefreshWorldMap()
     local frame = _G.WorldMapFrame
-    if not frame then return end
+    if not frame or not SkinBase.IsSkinned(frame) then return end
     if frame.BorderFrame then
         ApplyBorderBackdrop(SkinBase.GetBackdrop(frame.BorderFrame))
     end

--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -1269,12 +1269,19 @@ local function GetCustomContainerKeys()
     return keys
 end
 
+-- <<< QUI_TEST_EXTRACT viewer_children_sweep
 local function GetViewerChildren(viewerName)
     local viewer = _G.QUI_GetCDMViewerFrame and _G.QUI_GetCDMViewerFrame(viewerName)
     local out
     if viewer then
         local container = viewer.viewerFrame or viewer
-        out = { container:GetChildren() }
+        out = {}
+        local children = { container:GetChildren() }
+        for i = 1, #children do
+            if not children[i]._quiCdmClickSlot then
+                out[#out + 1] = children[i]
+            end
+        end
     end
     if _G.QUI_GetReanchoredCDMFrames then
         local extra = _G.QUI_GetReanchoredCDMFrames(viewerName)
@@ -1287,6 +1294,7 @@ local function GetViewerChildren(viewerName)
     end
     return out
 end
+-- <<< QUI_TEST_EXTRACT viewer_children_sweep
 
 local function UpdateViewerKeybinds(viewerName)
     local children = GetViewerChildren(viewerName)

--- a/tests/unit/cdm_editmode_policy_test.lua
+++ b/tests/unit/cdm_editmode_policy_test.lua
@@ -136,9 +136,22 @@ end
 assert(registeredEvents["PLAYER_ENTERING_WORLD"], "policy registers PLAYER_ENTERING_WORLD")
 assert(type(eventHandler) == "function", "policy installs an OnEvent handler")
 
+-- activeLayout is a COMBINED index in the live client (presets first, then
+-- saved layouts), so the Enforce cases model two presets: user layout 1 = 3.
+local standingPresetManager = {
+    GetCopyOfPresetLayouts = function()
+        return { { systems = mkSystems({}) }, { systems = mkSystems({}) } }
+    end,
+}
+_G.EditModePresetLayoutManager = standingPresetManager
+_G.tAppendAll = function(dst, src)
+    for _, v in ipairs(src) do dst[#dst + 1] = v end
+    return dst
+end
+
 -- changed case: stale VisibleSetting on the active (non-preset) layout
 layoutInfoToReturn = {
-    activeLayout = 1,
+    activeLayout = 3,
     layouts = {
         { systems = mkSystems({ [1] = { { setting = ENUMS.visSetting, value = 2 } } }) },
     },
@@ -155,7 +168,7 @@ assert(#savedLayouts == 1 and #popupsShown == 1, "enforcement is one-shot per se
 do
     local ns2 = {}
     savedLayouts, popupsShown = {}, {}
-    layoutInfoToReturn = { activeLayout = 1, layouts = { { systems = mkSystems({}) } } }
+    layoutInfoToReturn = { activeLayout = 3, layouts = { { systems = mkSystems({}) } } }
     loadChunk("QUI_CDM/cdm/cdm_editmode_policy.lua", "cdm_editmode_policy.lua")("QUI", ns2)
     eventHandler(nil, "PLAYER_ENTERING_WORLD")
     assert(#savedLayouts == 0, "no change -> SaveLayouts never called")
@@ -180,7 +193,7 @@ do
     loadChunk("QUI_CDM/cdm/cdm_editmode_policy.lua", "cdm_editmode_policy.lua")("QUI", ns3)
     eventHandler(nil, "PLAYER_ENTERING_WORLD")
     assert(#savedLayouts == 0, "preset-active layout is read-only: never saved")
-    _G.EditModePresetLayoutManager = nil
+    _G.EditModePresetLayoutManager = standingPresetManager
 end
 
 ---------------------------------------------------------------------------
@@ -188,7 +201,7 @@ end
 -- manual instructions each login until the layout comes back clean.
 ---------------------------------------------------------------------------
 local staleLayout = function()
-    return { activeLayout = 1, layouts = {
+    return { activeLayout = 3, layouts = {
         { systems = mkSystems({ [1] = { { setting = ENUMS.visSetting, value = 2 } } }) },
     } }
 end
@@ -219,12 +232,31 @@ end
 do
     local ns6 = {}
     savedLayouts, popupsShown = {}, {}
-    layoutInfoToReturn = { activeLayout = 1, layouts = { { systems = mkSystems({}) } } }
+    layoutInfoToReturn = { activeLayout = 3, layouts = { { systems = mkSystems({}) } } }
     loadChunk("QUI_CDM/cdm/cdm_editmode_policy.lua", "cdm_editmode_policy.lua")("QUI", ns6)
     eventHandler(nil, "PLAYER_ENTERING_WORLD")
     assert(#savedLayouts == 0 and #popupsShown == 0, "settled layout -> no save, no prompt")
     assert(_G.QUIDB.cdmEditModeSavePending == nil, "settled layout re-arms the loop breaker")
     _G.QUIDB = nil
+end
+
+---------------------------------------------------------------------------
+-- Missing preset data: activeLayout is a combined index, so without the
+-- preset list the index cannot be resolved -- enforcement must not guess,
+-- mutate, or save (a misresolved index edits the WRONG layout).
+---------------------------------------------------------------------------
+do
+    local ns8 = {}
+    savedLayouts, popupsShown = {}, {}
+    _G.EditModePresetLayoutManager = nil
+    local layouts = { { systems = mkSystems({ [1] = { { setting = ENUMS.visSetting, value = 2 } } }) } }
+    layoutInfoToReturn = { activeLayout = 1, layouts = layouts }
+    loadChunk("QUI_CDM/cdm/cdm_editmode_policy.lua", "cdm_editmode_policy.lua")("QUI", ns8)
+    eventHandler(nil, "PLAYER_ENTERING_WORLD")
+    assert(#savedLayouts == 0, "missing preset data -> never saved")
+    assert(#popupsShown == 0, "missing preset data -> no prompt")
+    assert(layouts[1].systems[1].settings[1].value == 2, "missing preset data -> stored settings untouched")
+    _G.EditModePresetLayoutManager = standingPresetManager
 end
 
 ---------------------------------------------------------------------------

--- a/tests/unit/character_refresh_disabled_gate_test.lua
+++ b/tests/unit/character_refresh_disabled_gate_test.lua
@@ -1,0 +1,72 @@
+local loadstring = loadstring or load
+
+local function readAll(path)
+    local f = assert(io.open(path, "rb"))
+    local d = f:read("*a"); f:close()
+    return d:gsub("\r\n", "\n")
+end
+
+local source = readAll("modules/skinning/character_pane/character.lua")
+
+local function extract(name)
+    local S = "-- <<< QUI_TEST_EXTRACT " .. name
+    local a1 = assert(source:find(S, 1, true), "start sentinel must exist: " .. name)
+    local a2 = assert(source:find(S, a1 + #S, true), "end sentinel must exist: " .. name)
+    return source:sub(a1 + #S, a2 - 1)
+end
+
+local chunk = table.concat({
+    "local _G, GetSettings, CharacterFrame, StyleCloseButton, StyleSidebarTabs, ScheduleUpdate = ...",
+    extract("character_refresh_gate"),
+}, "\n")
+
+local failures = 0
+local function check(name, cond, detail)
+    if cond then
+        print("ok   - " .. name)
+    else
+        failures = failures + 1
+        print("FAIL - " .. name .. (detail and ("  (" .. detail .. ")") or ""))
+    end
+end
+
+local function runRefresh(enabled, characterFrame)
+    local calls = { style = 0, close = 0, schedule = 0 }
+    local fakeG = {}
+    assert(loadstring(chunk, "character_refresh_gate"))(
+        fakeG,
+        function() return { enabled = enabled } end,
+        characterFrame,
+        function() calls.close = calls.close + 1 end,
+        function() calls.style = calls.style + 1 end,
+        function() calls.schedule = calls.schedule + 1 end
+    )
+    assert(type(fakeG.QUI_RefreshCharacterPane) == "function", "extract must define QUI_RefreshCharacterPane")
+    fakeG.QUI_RefreshCharacterPane()
+    return calls
+end
+
+do
+    local calls = runRefresh(false, { CloseButton = {} })
+    check("disabled module skips sidebar tab styling", calls.style == 0, "StyleSidebarTabs calls: " .. calls.style)
+    check("disabled module skips close button styling", calls.close == 0, "StyleCloseButton calls: " .. calls.close)
+    check("disabled module still schedules the overlay update", calls.schedule == 1)
+end
+
+do
+    local calls = runRefresh(true, { CloseButton = {} })
+    check("enabled module styles the sidebar tabs", calls.style == 1)
+    check("enabled module styles the close button", calls.close == 1)
+    check("enabled module schedules the overlay update", calls.schedule == 1)
+end
+
+do
+    local calls = runRefresh(true, nil)
+    check("missing CharacterFrame styles nothing", calls.style == 0 and calls.close == 0)
+    check("missing CharacterFrame still schedules the overlay update", calls.schedule == 1)
+end
+
+if failures > 0 then
+    error(failures .. " assertion(s) failed")
+end
+print("OK: character_refresh_disabled_gate_test")

--- a/tests/unit/keybind_viewer_sweep_skips_click_slots_test.lua
+++ b/tests/unit/keybind_viewer_sweep_skips_click_slots_test.lua
@@ -1,0 +1,81 @@
+local loadstring = loadstring or load
+
+local function readAll(path)
+    local f = assert(io.open(path, "rb"))
+    local d = f:read("*a"); f:close()
+    return d:gsub("\r\n", "\n")
+end
+
+local source = readAll("modules/utility/keybinds.lua")
+
+local function extract(name)
+    local S = "-- <<< QUI_TEST_EXTRACT " .. name
+    local a1 = assert(source:find(S, 1, true), "start sentinel must exist: " .. name)
+    local a2 = assert(source:find(S, a1 + #S, true), "end sentinel must exist: " .. name)
+    return source:sub(a1 + #S, a2 - 1)
+end
+
+local chunk = table.concat({
+    "local _G = ...",
+    extract("viewer_children_sweep"),
+    "return GetViewerChildren",
+}, "\n")
+
+local failures = 0
+local function check(name, cond, detail)
+    if cond then
+        print("ok   - " .. name)
+    else
+        failures = failures + 1
+        print("FAIL - " .. name .. (detail and ("  (" .. detail .. ")") or ""))
+    end
+end
+
+local function contains(list, item)
+    for _, v in ipairs(list or {}) do
+        if v == item then return true end
+    end
+    return false
+end
+
+local function build(container, reanchored)
+    local fakeG = {
+        QUI_GetCDMViewerFrame = container and function() return container end or nil,
+        QUI_GetReanchoredCDMFrames = reanchored and function() return reanchored end or nil,
+    }
+    return assert(loadstring(chunk, "viewer_children_sweep"))(fakeG)
+end
+
+local shell = { _quiCdmClickSlot = true, _spellEntry = { spellID = 1234 } }
+local ownedIcon = { _customCDMEntry = { id = 1 } }
+local native = { spellID = 1234 }
+
+do
+    local container = {
+        GetChildren = function() return shell, ownedIcon end,
+    }
+    local out = build(container, { native })("essential")
+    check("click shell is excluded from the sweep", not contains(out, shell))
+    check("owned icon survives the sweep", contains(out, ownedIcon))
+    check("reanchored native survives the sweep", contains(out, native))
+    check("sweep yields exactly one frame per visual icon", out and #out == 2, "got " .. tostring(out and #out))
+end
+
+do
+    local container = {
+        GetChildren = function() return shell end,
+    }
+    local out = build(container, nil)("essential")
+    check("shell-only container yields no keybind targets", out ~= nil and #out == 0,
+        "got " .. tostring(out and #out))
+end
+
+do
+    local out = build(nil, { native })("essential")
+    check("reanchored natives are swept without a container", contains(out, native) and #out == 1)
+end
+
+if failures > 0 then
+    error(failures .. " assertion(s) failed")
+end
+print("OK: keybind_viewer_sweep_skips_click_slots_test")

--- a/tests/unit/setup_wizard_pages_test.lua
+++ b/tests/unit/setup_wizard_pages_test.lua
@@ -210,35 +210,70 @@ _G.Enum = {
     EditModeLayoutType = { Account = 0, Character = 1, Preset = 2 },
     EditModePresetLayoutsMeta = { NumValues = 2 },
 }
-local layoutList = {}
+_G.EditModePresetLayoutManager = {
+    GetCopyOfPresetLayouts = function()
+        return {
+            { layoutType = 2, layoutName = "Modern" },
+            { layoutType = 2, layoutName = "Classic" },
+        }
+    end,
+}
+-- Engine model: SaveLayouts persists only non-preset entries; GetLayouts
+-- returns those saved customs (activeLayout indexing counts the presets).
+local savedCustoms = {}
 _G.C_EditMode = {
     ConvertStringToLayoutInfo = function(str)
         if str == "2 50 0 0 0" then return { systems = { "SYSTEMS" } } end
         return nil
     end,
-    GetLayouts = function() return { layouts = layoutList } end,
-    SaveLayouts = function(info) saved = info end,
+    GetLayouts = function() return { layouts = savedCustoms } end,
+    SaveLayouts = function(info)
+        saved = info
+        local customs = {}
+        for _, layout in ipairs(info.layouts) do
+            if layout.layoutType ~= 2 then customs[#customs + 1] = layout end
+        end
+        savedCustoms = customs
+    end,
     SetActiveLayout = function(i) activated = i end,
 }
 
 local applyLayout = assert(FindButton("Apply QUI Edit Mode Layout"), "layout page offers the apply")
 applyLayout.onClick()
-assert(saved and #layoutList == 1, "layout apply adds one layout")
-assert(layoutList[1].layoutName == "QUI" and layoutList[1].layoutType == 0,
+assert(saved and #saved.layouts == 3,
+    "layout apply must save the full combined list (2 presets + the QUI layout), matching Blizzard's SaveLayouts convention")
+assert(saved.layouts[1].layoutType == 2 and saved.layouts[2].layoutType == 2,
+    "saved list must lead with the preset copies")
+assert(saved.layouts[3].layoutName == "QUI" and saved.layouts[3].layoutType == 0,
     "added layout is an Account layout named QUI")
-assert(activated == 3, "SetActiveLayout must offset past the presets (1 user layout + 2 presets)")
+assert(#savedCustoms == 1, "engine persists exactly one custom layout")
+assert(activated == 3, "SetActiveLayout must receive the same combined index the save used")
 
 -- Re-apply updates in place instead of duplicating
-layoutList[1].systems = "STALE"
+savedCustoms[1].systems = "STALE"
 applyLayout.onClick()
-assert(#layoutList == 1, "re-apply must update the existing QUI layout, not duplicate it")
-assert(layoutList[1].systems[1] == "SYSTEMS", "re-apply refreshes the layout systems")
+assert(#saved.layouts == 3 and #savedCustoms == 1,
+    "re-apply must update the existing QUI layout, not duplicate it")
+assert(savedCustoms[1].systems[1] == "SYSTEMS", "re-apply refreshes the layout systems")
+assert(activated == 3, "re-apply activates the same combined index")
 
 -- Failure path: unrecognized string fails soft with a reason
 _G.QUI.imports.QUIEditMode.data = "garbage"
 local ok, err = Wizard._ApplyEditModeBaseLayout()
 assert(ok == false and type(err) == "string", "unrecognized layout string fails soft")
 _G.QUI.imports.QUIEditMode.data = "2 50 0 0 0"
+
+-- Failure path: preset data unavailable -> fail soft, never save a list the
+-- combined activeLayout index cannot be resolved against
+do
+    local presetMgr = _G.EditModePresetLayoutManager
+    _G.EditModePresetLayoutManager = nil
+    saved = nil
+    local ok2, err2 = Wizard._ApplyEditModeBaseLayout()
+    assert(ok2 == false and type(err2) == "string", "missing preset data fails soft")
+    assert(saved == nil, "missing preset data must not save layouts")
+    _G.EditModePresetLayoutManager = presetMgr
+end
 
 -- Page 7: finish
 nextBtn.onClick()

--- a/tests/unit/worldmap_fill_layering_test.lua
+++ b/tests/unit/worldmap_fill_layering_test.lua
@@ -118,8 +118,8 @@ ns.SkinBase = {
     GetSkinColors = function()
         return 0.1, 0.2, 0.3, 1, 0.05, 0.06, 0.07, 0.88
     end,
-    IsSkinned = function()
-        return false
+    IsSkinned = function(frame)
+        return frame.markedSkinned == true
     end,
     MarkSkinned = function(frame)
         frame.markedSkinned = true

--- a/tests/unit/worldmap_refresh_unskinned_gate_test.lua
+++ b/tests/unit/worldmap_refresh_unskinned_gate_test.lua
@@ -1,0 +1,113 @@
+local capturedCallbacks = {}
+local frameState = setmetatable({}, { __mode = "k" })
+local appliedBackdrops = {}
+
+local function NewLayeredFrame()
+    local frame = {}
+
+    function frame:SetFrameStrata(strata)
+        self.frameStrata = strata
+    end
+
+    function frame:SetFrameLevel(level)
+        self.frameLevel = level
+    end
+
+    return frame
+end
+
+local worldMapFrame = {
+    ScrollContainer = NewLayeredFrame(),
+    NavBar = NewLayeredFrame(),
+    BorderFrame = {
+        Underlay = { Hide = function() end },
+        InsetBorderTop = { Hide = function() end },
+    },
+}
+worldMapFrame.overlayFrames = {
+    worldMapFrame.NavBar,
+    NewLayeredFrame(),
+}
+
+_G.WorldMapFrame = worldMapFrame
+
+local ns = {
+    Helpers = {
+        GetCore = function()
+            return {
+                db = {
+                    profile = {
+                        general = {
+                            skinWorldMap = false,
+                        },
+                    },
+                },
+            }
+        end,
+    },
+    Registry = {
+        Register = function() end,
+    },
+}
+
+ns.SkinBase = {
+    GetFrameData = function(frame, key)
+        local data = frameState[frame]
+        return data and data[key]
+    end,
+    SetFrameData = function(frame, key, value)
+        local data = frameState[frame]
+        if not data then
+            data = {}
+            frameState[frame] = data
+        end
+        data[key] = value
+    end,
+    GetSkinColors = function()
+        return 0.1, 0.2, 0.3, 1, 0.05, 0.06, 0.07, 0.88
+    end,
+    IsSkinned = function(frame)
+        return frame.markedSkinned == true
+    end,
+    MarkSkinned = function(frame)
+        frame.markedSkinned = true
+    end,
+    SkinButtonFrameTemplate = function(frame)
+        frame.buttonTemplateSkinned = true
+    end,
+    GetBackdrop = function()
+        return {}
+    end,
+    SetBackdropColors = function(frame, borderColor, bgColor)
+        appliedBackdrops[#appliedBackdrops + 1] = { frame = frame, borderColor = borderColor, bgColor = bgColor }
+    end,
+    SkinFrameText = function() end,
+    OnAddOnLoaded = function(addon, callback)
+        capturedCallbacks[addon] = callback
+    end,
+}
+
+assert(loadfile("modules/skinning/frames/worldmap.lua"))("QUI", ns)
+
+local capturedCallback = capturedCallbacks["Blizzard_WorldMap"]
+assert(type(capturedCallback) == "function", "World map skinning must register an addon-loaded callback")
+
+capturedCallback()
+
+assert(worldMapFrame.markedSkinned == nil,
+    "World map must not be skinned when skinWorldMap is disabled")
+assert(worldMapFrame.ScrollContainer.frameLevel == nil,
+    "World map scroll container must keep its native frame level when the skin is disabled")
+
+_G.QUI_RefreshWorldMapColors()
+
+assert(worldMapFrame.ScrollContainer.frameLevel == nil,
+    "World map color refresh must not raise the scroll container when the map was never skinned")
+assert(worldMapFrame.ScrollContainer.frameStrata == nil,
+    "World map color refresh must not change the scroll container strata when the map was never skinned")
+assert(worldMapFrame.NavBar.frameLevel == nil,
+    "World map color refresh must not raise the navbar when the map was never skinned")
+assert(#appliedBackdrops == 0,
+    "World map color refresh must not restyle the border when the map was never skinned")
+
+print("OK: worldmap_refresh_unskinned_gate_test")


### PR DESCRIPTION
Three user-report fixes, each pinned by a unit test that fails on the pre-fix code.

## World map: addon buttons vanish ~0.1s after opening the map
`RefreshWorldMap` ran `RaiseMapCanvas` (ScrollContainer to HIGH/100) with no `skinWorldMap` gate, and the skinning registry group fires it on any profile change or Skinning-page touch — including turning a skin OFF. Third-party buttons parented to the map frame sat below the raised canvas and were covered the moment the map tiles finished loading (the canvas holds alpha 0 until then, which is the visible-then-gone 0.1s). Now gated on the map actually being skinned, matching the FlightMap refresher.

## Character frame: sidebar tabs restyled with everything off
`QUI_RefreshCharacterPane` styled the paper doll sidebar tabs and close button without checking the Character module's enabled toggle, so the same registry refreshes restyled them for users who had disabled the module. The styling is now gated; the overlay update still runs so a disable pass hides the item-level overlays.

## CDM: double keybind text
The keybind sweep walked raw container children, which include the invisible click/tooltip shells minted over reanchored native icons. Shell and native each got a FontString with the same keybind — two labels per icon, visibly doubled whenever the rects drifted (stale Edit Mode layouts, in-combat release refusal). The sweep now skips click-shell frames.

## Edit Mode layout writes
Users fixed the double keybinds by resetting Edit Mode profiles, which pointed at QUI's two layout writers:
- The CDM policy indexed `activeLayout` (a combined presets+customs index) against a preset-less list when `EditModePresetLayoutManager` was unavailable — editing and saving the wrong layout. It now refuses to write when preset data can't be resolved.
- The setup wizard saved the layout list without presets while activating with a preset offset — opposite index conventions in consecutive calls. It now builds the combined list the way the Edit Mode manager itself does and activates the index it saved.

Gates: 9/9 green locally (830 unit files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)