### PR TITLE
release: v5.2.0-beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.0-beta4 - 2026-08-15
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Aura displays gain proper load condition pickers, and a fix pass across
+action bars, Cooldown Manager, and skinning: combat cooldowns stay live,
+tracked buff bars follow spell variants, double keybinds are gone, and
+skinning respects module toggles.
+
+### Added
+
+- **Load condition pickers for aura displays.** Aura displays now pick
+  their load conditions from lists — classes, specializations, roles, and
+  encounters — instead of typing comma-separated IDs, alongside a reworked
+  display list with quick create and a single-display preview.
+
+### Fixed
+
+- **Action bar cooldowns, glows, and pressed states stay live in combat.**
+  Reading a button's action in combat can hand back an unreadable secret
+  value, which silently skipped cooldown paints until the fight ended. All
+  slot consumers now resolve the slot from the button's action attribute,
+  which is never secret.
+- **Cooldown Manager icons no longer drop in-combat updates.** When a
+  cooldown event carries a spell that cannot be identified mid-combat, the
+  viewer now refreshes all icons instead of dropping the update.
+- **Tracked buff bars follow the active spell variant.** Multi-variant
+  buffs rendered the wrong bar because tracked-bar matching ignored the
+  linked spell; the linked variant now leads resolution and carries its
+  own name and icon onto the bar.
+- **Cooldown Manager keybind labels no longer double up.** The keybind
+  sweep labelled both a native icon and its invisible click shell, drawing
+  two overlapping keybind texts whenever the two drifted apart.
+- **Edit Mode layouts save against the right layout list.** Both places
+  QUI writes Edit Mode layouts now follow the client's own indexing
+  convention, so a save can no longer edit a layout you never had active.
+- **Objective tracker styling no longer runs inside protected code.** Line
+  icon styling is deferred out of the game's secure hooks and each styled
+  frame is isolated, so one bad frame only costs its own styling.
+- **Skinning leaves disabled modules alone.** The world map and character
+  pane refreshers ran on profile changes even with their modules turned
+  off, burying third-party map buttons and restyling the character pane
+  uninvited.
+
 ## v5.2.0-beta3 - 2026-08-14
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta3
+## Version: 5.2.0-beta4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Version bump + CHANGELOG for the v5.2.0-beta4 prerelease. TOC count 13 (11 ship). 9/9 gates green locally on the release commit via isolated shared clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)