### PR TITLE
release: v5.2.0-beta5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.0-beta5 - 2026-08-15
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+A focused Cooldown Manager pass: Frame Levels controls work again, tracked
+buff bars mirror their paired icon exactly, and tooltips can show aura
+spell IDs.
+
+### Added
+
+- **Show Aura Spell ID tooltip setting.** A new tooltip toggle surfaces the
+  client's aura spell ID line on buff and debuff tooltips, re-applied at
+  login so the choice survives sessions.
+
+### Fixed
+
+- **Frame Levels sliders move Cooldown Manager containers again.** The
+  Frame Levels tab wrote layering keys no Cooldown Manager container ever
+  read, and the game's own viewers were never leveled alongside them; both
+  now route through per-container keys so the sliders visibly reorder the
+  HUD.
+- **Tracked buff bars mirror their paired icon every update.** Multi-variant
+  buff bars could still show a stale variant between refreshes; the bar now
+  copies its paired icon's visuals on every tick and resolves tooltips by
+  aura instance, so the bar and its tooltip always show the variant that
+  actually rolled.
+
 ## v5.2.0-beta4 - 2026-08-15
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta4
+## Version: 5.2.0-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Version bump to 5.2.0-beta5: 13 suite TOCs + CHANGELOG entry.

Ships PR #728 (CDM Frame Levels per-container keys + leveled viewers, Show Aura Spell ID tooltip setting, tracked-bar mirror-passthrough rework).

Gates: test.sh 9/9 on work tree and on a shared clone of this commit; changelog extractor dry-run 26 lines, stops before the beta4 heading; event allowlist regen no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)