### PR TITLE
fix(tracker): route secret values straight to sinks in skinned tracker and M+ timer

### DIFF
--- a/modules/dungeon/mplus_timer.lua
+++ b/modules/dungeon/mplus_timer.lua
@@ -95,14 +95,13 @@ local defaultState = {
     dungeonName = "",
     deathCount = 0,
     deathTimeLost = 0,
-    currentCount = 0,
-    totalCount = 0,
-    currentPercent = 0,
-    pullCount = 0,
+    forcesQuantity = 0,
+    forcesTotal = 0,
+    forcesQuantityString = "",
     pullPercent = 0,
-    forcesCompleted = false,
-    forcesCompletionTime = nil,
     objectivesList = {},
+    objectivesByIndex = {},
+    weightedByIndex = {},
     currentTargetTier = 3,
     currentTargetTime = 0,
     paceOffset = 0,
@@ -1283,33 +1282,35 @@ function MPlusTimer:RenderAffixIcons()
     end
 end
 
+function MPlusTimer:WriteForcesText(fs)
+    local settings = GetSettings()
+    local format = settings.forcesTextFormat or "both"
+    if format == "count" then
+        fs:SetFormattedText("%s", self.state.forcesQuantityString)
+    elseif format == "percentage" then
+        fs:SetFormattedText("%.2f%%", self.state.forcesQuantity)
+    else
+        fs:SetFormattedText("%.2f%% (%s)", self.state.forcesQuantity, self.state.forcesQuantityString)
+    end
+end
+
 function MPlusTimer:RenderForces()
     if not self.bars.forces then return end
 
     local settings = GetSettings()
-    local displayMode = settings.forcesDisplayMode or "bar"
     local bar = self.bars.forces
-    bar.bar:SetValue(self.state.currentPercent)
+    bar.bar:SetMinMaxValues(0, 100)
+    bar.bar:SetValue(self.state.forcesQuantity)
 
-    local text = ""
-    local format = settings.forcesTextFormat or "both"
-    if format == "count" then
-        text = string.format("%d/%d", self.state.currentCount, self.state.totalCount)
-    elseif format == "percentage" then
-        text = string.format("%.2f%%", self.state.currentPercent * 100)
-    else
-        text = string.format("%.2f%% (%d/%d)", self.state.currentPercent * 100, self.state.currentCount, self.state.totalCount)
-    end
-    bar.text:SetText(text)
+    self:WriteForcesText(bar.text)
 
     if bar.overlay then
-        if self.state.pullPercent > 0 and self.state.currentPercent < 1 then
+        if self.state.pullPercent > 0 then
             local barWidth = bar.bar:GetWidth()
-            local startX = self.state.currentPercent * barWidth
-            local pullWidth = math.min(self.state.pullPercent, 1 - self.state.currentPercent) * barWidth
+            local pullWidth = math.min(self.state.pullPercent, 1) * barWidth
 
             bar.overlay:ClearAllPoints()
-            bar.overlay:SetPoint("LEFT", bar.bar, "LEFT", startX, 0)
+            bar.overlay:SetPoint("LEFT", bar.bar:GetStatusBarTexture(), "RIGHT", 0, 0)
             bar.overlay:SetWidth(math.max(1, pullWidth))
             bar.overlay:Show()
         else
@@ -1319,8 +1320,8 @@ function MPlusTimer:RenderForces()
 
     if self.frames.forcesLabelText and self.frames.forcesValueText then
         local label = settings.forcesLabel or ns.L["Forces"]
-        self.frames.forcesLabelText:SetText(label .. ":")
-        self.frames.forcesValueText:SetText(text)
+        self.frames.forcesLabelText:SetFormattedText("%s:", label)
+        self:WriteForcesText(self.frames.forcesValueText)
         self:AnchorForcesText()
     end
 end
@@ -1343,10 +1344,10 @@ function MPlusTimer:RenderObjectives()
     for i, obj in ipairs(self.state.objectivesList) do
         if i <= 8 then
             local indicator = obj.time and "|cFF66FF66+|r " or "|cFFAAAAAA-|r "
-            local text = obj.name or "Unknown"
+            local suffix = ""
 
-            if sleek then
-                if obj.time then
+            if obj.time then
+                if sleek then
                     local expectedTime = (i / totalBosses) * targetTime
                     local differential = obj.time - expectedTime
 
@@ -1360,19 +1361,15 @@ function MPlusTimer:RenderObjectives()
                     end
 
                     local diffStr = FormatPaceOffset(-differential)
-                    text = indicator .. text .. " " .. diffColor .. diffStr .. "|r |cFF888888" .. FormatTime(obj.time) .. "|r"
+                    suffix = " " .. diffColor .. diffStr .. "|r |cFF888888" .. FormatTime(obj.time) .. "|r"
                 else
-                    text = indicator .. text
-                end
-            else
-                if obj.time then
-                    text = indicator .. text .. " |cFF888888[" .. FormatTime(obj.time) .. "]|r"
-                else
-                    text = indicator .. text
+                    suffix = " |cFF888888[" .. FormatTime(obj.time) .. "]|r"
                 end
             end
 
-            self.objectives[i]:SetText(text)
+            local name = obj.name
+            if type(name) == "nil" then name = "Unknown" end
+            self.objectives[i]:SetFormattedText("%s%s%s", indicator, name, suffix)
         end
     end
 
@@ -1488,12 +1485,10 @@ function MPlusTimer:SetDeathCount(count, timeLost)
     self:RenderDeaths()
 end
 
-function MPlusTimer:SetForces(current, total)
-    self.state.currentCount = current or 0
-    self.state.totalCount = total or 1
-    self.state.currentPercent = self.state.totalCount > 0
-        and (self.state.currentCount / self.state.totalCount)
-        or 0
+function MPlusTimer:SetForces(quantity, total, quantityString)
+    if type(quantity) ~= "nil" then self.state.forcesQuantity = quantity end
+    if type(total) ~= "nil" then self.state.forcesTotal = total end
+    if type(quantityString) ~= "nil" then self.state.forcesQuantityString = quantityString end
     self:RenderForces()
 end
 
@@ -1564,7 +1559,7 @@ function MPlusTimer:EnableDemoMode()
     self:SetTimeLimit(32 * 60)
     self:SetKeyDetails(11, {"Tyrannical", "Storming", "Fortified"}, {9, 124, 10}, 1, "Jade Serpent")
     self:SetDeathCount(3, 15)
-    self:SetForces(198, 289)
+    self:SetForces(68.51, 289, "198/289")
 
     self:SetObjectives({
         { name = "Wise Mari", time = 328 },
@@ -1630,6 +1625,7 @@ function MPlusTimer:EnableChallengeMode()
     self:SetDeathCount(deaths, timeLost)
 
     self:UpdateObjectives()
+    self:UpdateForces()
 
     self:Show()
     self:StartTimerLoop()
@@ -1659,30 +1655,58 @@ function MPlusTimer:CompleteChallenge()
     self:RenderTimer()
 end
 
+-- >>> QUI_TEST_EXTRACT mplus_objectives_secret
 function MPlusTimer:UpdateObjectives()
+    local stepInfo = C_ScenarioInfo.GetScenarioStepInfo()
+    if type(stepInfo) ~= "table" then return end
+
+    local numCriteria = stepInfo.numCriteria
+    if issecretvalue and issecretvalue(numCriteria) then numCriteria = nil end -- @secret-policy: shadow-state (plain count cached below)
+    if type(numCriteria) == "number" then
+        self.state.plainNumCriteria = numCriteria
+    else
+        numCriteria = self.state.plainNumCriteria
+    end
+    if type(numCriteria) ~= "number" then return end
+
+    local byIndex = self.state.objectivesByIndex
+    local weightedByIndex = self.state.weightedByIndex
     local objectives = {}
 
-    local prevTimes = {}
-    for _, prev in ipairs(self.state.objectivesList or {}) do
-        if prev.name and prev.time then
-            prevTimes[prev.name] = prev.time
-        end
-    end
-
-    local stepInfo = C_ScenarioInfo.GetScenarioStepInfo()
-    local numCriteria = stepInfo and stepInfo.numCriteria or 0
     for i = 1, numCriteria do
         local info = C_ScenarioInfo.GetCriteriaInfo(i)
-        local criteriaString = info and info.description
-        local completed = info and info.completed
-        local isWeightedProgress = info and info.isWeightedProgress
-
-        if criteriaString and not isWeightedProgress then
-            local obj = { name = criteriaString, time = nil }
-            if completed then
-                obj.time = prevTimes[criteriaString] or self.state.timer
+        if type(info) == "table" then
+            local isWeighted = info.isWeightedProgress
+            if issecretvalue and issecretvalue(isWeighted) then
+                isWeighted = weightedByIndex[i] -- @secret-policy: shadow-state (structural flag cached from plain reads)
+            else
+                isWeighted = not not isWeighted
+                weightedByIndex[i] = isWeighted
             end
-            table.insert(objectives, obj)
+
+            if isWeighted == true then
+                self.state.forcesIndex = i
+            elseif isWeighted == false then
+                local obj = byIndex[i]
+                if not obj then
+                    obj = {}
+                    byIndex[i] = obj
+                end
+
+                local name = info.description
+                if type(name) ~= "nil" then obj.name = name end
+
+                local completed = info.completed
+                if not (issecretvalue and issecretvalue(completed)) then
+                    if completed then
+                        if not obj.time then obj.time = self.state.timer end
+                    else
+                        obj.time = nil
+                    end
+                end
+
+                table.insert(objectives, obj)
+            end
         end
     end
 
@@ -1690,22 +1714,15 @@ function MPlusTimer:UpdateObjectives()
 end
 
 function MPlusTimer:UpdateForces()
-    local stepInfo = C_ScenarioInfo.GetScenarioStepInfo()
-    local numCriteria = stepInfo and stepInfo.numCriteria or 0
+    local idx = self.state.forcesIndex
+    if type(idx) ~= "number" then return end
 
-    for i = 1, numCriteria do
-        local info = C_ScenarioInfo.GetCriteriaInfo(i)
-        if info and info.isWeightedProgress then
-            local quantityString = info.quantityString
-            local totalQuantity = info.totalQuantity
-            if quantityString then
-                local current = tonumber(quantityString:match("(%d+)")) or 0
-                self:SetForces(current, totalQuantity or 100)
-            end
-            break
-        end
-    end
+    local info = C_ScenarioInfo.GetCriteriaInfo(idx)
+    if type(info) ~= "table" then return end
+
+    self:SetForces(info.quantity, info.totalQuantity, info.quantityString)
 end
+-- <<< QUI_TEST_EXTRACT mplus_objectives_secret
 
 function MPlusTimer:CheckForChallengeMode()
     local _, instanceType, difficulty = GetInstanceInfo()
@@ -1756,6 +1773,12 @@ local function OnEvent(self, event, arg1, ...)
             MPlusTimer:UpdateForces()
         end
 
+    elseif event == "PLAYER_REGEN_ENABLED" then
+        if MPlusTimer.state.inChallenge then
+            MPlusTimer:UpdateObjectives()
+            MPlusTimer:UpdateForces()
+        end
+
     elseif event == "ZONE_CHANGED" or event == "ZONE_CHANGED_NEW_AREA" then
         C_Timer.After(0.5, function()
             MPlusTimer:CheckForChallengeMode()
@@ -1772,6 +1795,7 @@ eventFrame:RegisterEvent("CHALLENGE_MODE_RESET")
 eventFrame:RegisterEvent("CHALLENGE_MODE_DEATH_COUNT_UPDATED")
 eventFrame:RegisterEvent("SCENARIO_CRITERIA_UPDATE")
 eventFrame:RegisterEvent("SCENARIO_POI_UPDATE")
+eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 eventFrame:RegisterEvent("ZONE_CHANGED")
 eventFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 

--- a/modules/skinning/gameplay/objectivetracker.lua
+++ b/modules/skinning/gameplay/objectivetracker.lua
@@ -93,7 +93,11 @@ local function StyleLineIcon(line)
 
     local icon = line.Icon
     if not icon or not icon.GetAtlas then return end
-    if icon.IsShown and not icon:IsShown() then return end
+    if icon.IsShown then
+        local shown = icon:IsShown()
+        if issecretvalue and issecretvalue(shown) then return end -- @secret-policy: reject-secret-value (never touch an icon whose visibility is unreadable)
+        if not shown then return end
+    end
 
     -- Anim lines (quest objectives) only legitimately show their check while
     -- completing/completed; never touch the icon in any other state so we
@@ -192,11 +196,11 @@ local function StyleLine(line, fontPath, textFontSize, textColor, skipHeight)
             CJKFont(line.Text, fontPath, textFontSize, targetFlags)
 
             if not skipHeight then
-                local textHeight = line.Text:GetStringHeight()
+                local textHeight = Helpers.SafeNumberOrNil(line.Text:GetStringHeight())
                 if textHeight and textHeight > 0 then
-                    local currentHeight = line:GetHeight()
+                    local currentHeight = Helpers.SafeNumberOrNil(line:GetHeight())
                     local minHeight = textHeight + 4
-                    if minHeight - currentHeight > 1 then
+                    if currentHeight and minHeight - currentHeight > 1 then
                         line:SetHeight(minHeight)
                         heightChanged = true
                     end
@@ -288,7 +292,9 @@ end
 
 local function ApplyBlockSkinning(tracker, block)
     if not block or IsWidgetPoolBlock(block) then return end
-    if not block:IsShown() then return end
+    local shown = block:IsShown()
+    if issecretvalue and issecretvalue(shown) then return end -- @secret-policy: reject-secret-value (skip styling when visibility is unreadable)
+    if not shown then return end
 
     local settings = GetSettings()
     if not settings or not settings.skinObjectiveTracker then return end
@@ -375,7 +381,7 @@ end
 
 local function IsScenarioActive()
     if not C_ScenarioInfo or not C_ScenarioInfo.GetScenarioInfo then return false end
-    return C_ScenarioInfo.GetScenarioInfo() ~= nil
+    return type(C_ScenarioInfo.GetScenarioInfo()) ~= "nil"
 end
 
 local function ApplyMaxWidth(settings)
@@ -440,36 +446,54 @@ local function UpdateBackdropAnchors()
 
     local bottomModule = nil
     local lowestBottom = math.huge
+    local sawUnreadable = false
 
     for _, trackerName in ipairs(trackerModules) do
         local tracker = not WIDGET_POOL_TRACKER_NAMES[trackerName] and _G[trackerName] or nil
-        if tracker and tracker:IsShown() then
-            local hasContent = false
-            if tracker.GetContentsHeight then
-                local contentHeight = tracker:GetContentsHeight()
-                hasContent = contentHeight and contentHeight > 0
+        if tracker then
+            local shown = tracker:IsShown()
+            if issecretvalue and issecretvalue(shown) then -- @secret-policy: reject-secret-value (anchor scan holds current layout below)
+                shown = nil
+                sawUnreadable = true
             end
-            if not hasContent then
-                local frameHeight = tracker:GetHeight()
-                hasContent = frameHeight and frameHeight > 1
-            end
+            if shown then
+                local contentHeight = nil
+                if tracker.GetContentsHeight then
+                    contentHeight = Helpers.SafeNumberOrNil(tracker:GetContentsHeight())
+                end
+                local frameHeight = Helpers.SafeNumberOrNil(tracker:GetHeight())
+                if frameHeight == nil then
+                    sawUnreadable = true
+                end
 
-            if hasContent then
-                local bottom = tracker:GetBottom()
-                if bottom and bottom < lowestBottom then
-                    lowestBottom = bottom
-                    bottomModule = tracker
+                local hasContent = contentHeight ~= nil and contentHeight > 0
+                if not hasContent then
+                    hasContent = frameHeight ~= nil and frameHeight > 1
+                end
+
+                if hasContent then
+                    local bottom = Helpers.SafeNumberOrNil(tracker:GetBottom())
+                    if bottom then
+                        if bottom < lowestBottom then
+                            lowestBottom = bottom
+                            bottomModule = tracker
+                        end
+                    else
+                        sawUnreadable = true
+                    end
                 end
             end
         end
     end
+
+    if not bottomModule and sawUnreadable then return end
 
     quiBackdrop:ClearAllPoints()
     quiBackdrop:SetPoint("TOPLEFT", TrackerFrame, "TOPLEFT", -15, 0)
     quiBackdrop:SetPoint("TOPRIGHT", TrackerFrame, "TOPRIGHT", 10, 0)
 
     if bottomModule then
-        local trackerTop = TrackerFrame:GetTop()
+        local trackerTop = Helpers.SafeNumberOrNil(TrackerFrame:GetTop())
         local contentHeight = 0
         if trackerTop and lowestBottom and trackerTop > lowestBottom then
             contentHeight = trackerTop - lowestBottom + 15
@@ -529,19 +553,15 @@ local function EnforceWidth()
         maxWidth = settings.objectiveTrackerWidth or 260
     end
 
-    if math.abs(TrackerFrame:GetWidth() - maxWidth) > 0.5 then
-        TrackerFrame:SetWidth(maxWidth)
-    end
-    if TrackerFrame.Header and math.abs(TrackerFrame.Header:GetWidth() - maxWidth) > 0.5 then
+    TrackerFrame:SetWidth(maxWidth)
+    if TrackerFrame.Header then
         TrackerFrame.Header:SetWidth(maxWidth)
     end
     for _, trackerName in ipairs(trackerModules) do
         local tracker = not WIDGET_POOL_TRACKER_NAMES[trackerName] and _G[trackerName] or nil
         if tracker then
-            if math.abs(tracker:GetWidth() - maxWidth) > 0.5 then
-                tracker:SetWidth(maxWidth)
-            end
-            if tracker.Header and math.abs(tracker.Header:GetWidth() - maxWidth) > 0.5 then
+            tracker:SetWidth(maxWidth)
+            if tracker.Header then
                 tracker.Header:SetWidth(maxWidth)
             end
         end
@@ -707,6 +727,7 @@ local function HookLineCreation()
             local block = self
             if IsWidgetPoolBlock(block) then return end
             EnsureBlockHighlightHook(block)
+            if issecretvalue and issecretvalue(objectiveKey) then return end -- @secret-policy: reject-secret-value (cannot index usedLines with a secret key)
             C_Timer.After(0, function()
                 local line = block.usedLines and block.usedLines[objectiveKey]
                 if line then

--- a/tests/unit/mplus_timer_objectives_secret_test.lua
+++ b/tests/unit/mplus_timer_objectives_secret_test.lua
@@ -1,0 +1,143 @@
+-- luacheck: globals issecretvalue
+
+local sentinel = dofile("tests/helpers/secret_sentinel.lua")
+local instrument = dofile("tests/helpers/secret_instrument.lua")
+
+local prev = sentinel.InstallSecretStub()
+
+local source
+do
+    local f = assert(io.open("modules/dungeon/mplus_timer.lua", "r"))
+    source = f:read("*a")
+    f:close()
+end
+
+local beginMark = "-- >>> QUI_TEST_EXTRACT mplus_objectives_secret"
+local endMark = "-- <<< QUI_TEST_EXTRACT mplus_objectives_secret"
+local s = assert(source:find(beginMark, 1, true), "begin sentinel")
+local e = assert(source:find(endMark, 1, true), "end sentinel")
+local slice = source:sub(s + #beginMark, e - 1)
+
+local function NewHarness(criteria, stepInfo)
+    local env = setmetatable({
+        MPlusTimer = nil,
+        C_ScenarioInfo = {
+            GetScenarioStepInfo = function() return stepInfo end,
+            GetCriteriaInfo = function(i) return criteria[i] end,
+        },
+    }, { __index = _G })
+
+    local timer = {
+        state = {
+            timer = 0,
+            objectivesList = {},
+            objectivesByIndex = {},
+            weightedByIndex = {},
+        },
+    }
+    env.MPlusTimer = timer
+
+    function timer:SetObjectives(objectives)
+        self.captureObjectives = objectives
+    end
+
+    function timer:SetForces(quantity, total, quantityString)
+        self.captureForces = { quantity = quantity, total = total, quantityString = quantityString }
+    end
+
+    local chunk, err = instrument.loadString(slice, "mplus_objectives_secret")
+    assert(chunk, err)
+    setfenv(chunk, env)
+    chunk()
+
+    return timer
+end
+
+do
+    local criteria = {
+        { description = "Boss A", completed = false, isWeightedProgress = false },
+        { description = "Boss B", completed = true, isWeightedProgress = false },
+        { description = "Enemy Forces", completed = false, isWeightedProgress = true,
+          quantity = 42.5, totalQuantity = 300, quantityString = "128/300" },
+    }
+    local timer = NewHarness(criteria, { numCriteria = 3 })
+    timer.state.timer = 100
+
+    timer:UpdateObjectives()
+
+    assert(timer.captureObjectives, "plain pass reaches SetObjectives")
+    assert(#timer.captureObjectives == 2, "weighted criteria excluded from boss list")
+    assert(timer.captureObjectives[1].name == "Boss A")
+    assert(timer.captureObjectives[1].time == nil)
+    assert(timer.captureObjectives[2].time == 100, "completed boss stamped with current timer")
+    assert(timer.state.forcesIndex == 3)
+    assert(timer.state.plainNumCriteria == 3)
+    assert(timer.state.weightedByIndex[1] == false)
+    assert(timer.state.weightedByIndex[3] == true)
+
+    timer:UpdateForces()
+    assert(timer.captureForces.quantity == 42.5)
+    assert(timer.captureForces.total == 300)
+    assert(timer.captureForces.quantityString == "128/300")
+
+    timer.state.timer = 200
+    timer:UpdateObjectives()
+    assert(timer.captureObjectives[2].time == 100, "split time survives later passes")
+end
+
+do
+    local secretName = sentinel.MakeSecretSentinel()
+    local criteria = {
+        { description = "Boss A", completed = sentinel.MakeSecretSentinel(),
+          isWeightedProgress = sentinel.MakeSecretSentinel() },
+        { description = secretName, completed = sentinel.MakeSecretSentinel(),
+          isWeightedProgress = sentinel.MakeSecretSentinel() },
+        { description = "Enemy Forces", completed = false,
+          isWeightedProgress = sentinel.MakeSecretSentinel() },
+    }
+    local timer = NewHarness(criteria, { numCriteria = sentinel.MakeSecretSentinel() })
+    timer.state.plainNumCriteria = 3
+    timer.state.weightedByIndex = { false, false, true }
+    timer.state.objectivesByIndex = { {}, { name = "Boss B", time = 55 }, {} }
+    timer.state.forcesIndex = nil
+    timer.state.timer = 300
+
+    local ok, err = pcall(function() timer:UpdateObjectives() end)
+    assert(ok, "secret storm must not throw: " .. tostring(err))
+
+    assert(timer.captureObjectives and #timer.captureObjectives == 2)
+    assert(timer.captureObjectives[2].time == 55, "secret completed holds prior split")
+    assert(rawequal(timer.captureObjectives[2].name, secretName), "secret name passed along raw")
+    assert(timer.state.forcesIndex == 3, "cached weighted flag still routes forces index")
+    assert(timer.state.plainNumCriteria == 3)
+end
+
+do
+    local secretQuantity = sentinel.MakeSecretSentinel()
+    local secretQuantityString = sentinel.MakeSecretSentinel()
+    local secretTotal = sentinel.MakeSecretSentinel()
+    local criteria = {
+        { description = "Enemy Forces", completed = false, isWeightedProgress = true,
+          quantity = secretQuantity, totalQuantity = secretTotal, quantityString = secretQuantityString },
+    }
+    local timer = NewHarness(criteria, { numCriteria = 1 })
+    timer.state.forcesIndex = 1
+
+    local ok, err = pcall(function() timer:UpdateForces() end)
+    assert(ok, "secret forces fields must not throw: " .. tostring(err))
+    assert(timer.captureForces, "secret fields still reach the sink path")
+    assert(rawequal(timer.captureForces.quantity, secretQuantity), "quantity passed along raw")
+    assert(rawequal(timer.captureForces.total, secretTotal), "totalQuantity passed along raw")
+    assert(rawequal(timer.captureForces.quantityString, secretQuantityString), "quantityString passed along raw")
+end
+
+do
+    local timer = NewHarness({}, { numCriteria = sentinel.MakeSecretSentinel() })
+
+    local ok, err = pcall(function() timer:UpdateObjectives() end)
+    assert(ok, "no plain count yet must not throw: " .. tostring(err))
+    assert(timer.captureObjectives == nil, "list held when structure is unreadable")
+end
+
+sentinel.RestoreSecretStub(prev)
+print("mplus_timer_objectives_secret_test: OK")


### PR DESCRIPTION
## Summary
- The skinned objective tracker froze after the first secret value: the post-layout chain (`RunObjectiveTrackerPostLayoutUpdate`) truth-tested `SecretWhenAnchoringSecret` geometry (`GetWidth`/`GetHeight`/`GetBottom`/`GetTop`/`GetStringHeight`) and Shown-aspect secrets from `IsShown`, so one secret killed width enforcement, backdrop, POI and bar styling on every update. `EnforceWidth` is now write-only, `UpdateBackdropAnchors` probes all geometry via `SafeNumberOrNil` and holds current anchors when unreadable, and line/icon/block styling probes its control-flow reads.
- The M+ timer (which replaces the scenario tracker in keystone dungeons) now keys the boss list by index, sets names via `SetFormattedText`, drives its bar as `SetMinMaxValues(0,100)` + `SetValue(quantity)` (weighted quantity is the percent), sinks `quantityString` without parsing, and catches up on `PLAYER_REGEN_ENABLED`. Probes are limited to the control-flow trio (`numCriteria`, `isWeightedProgress`, `completed`); every sink-bound field flows raw to its FontString/StatusBar sink.

## Test plan
- [x] `bash tools/test.sh` — all 9 gates pass
- [x] New unit test `tests/unit/mplus_timer_objectives_secret_test.lua`: sentinel storm plus `rawequal` pins proving secret `quantity`/`quantityString` reach the sinks untouched
- [ ] In-game: skinned tracker keeps updating through an M+ run

🤖 Generated with [Claude Code](https://claude.com/claude-code)