### PR TITLE
fix(tracker): capture GetScenarioInfo result before type check

### DIFF
--- a/modules/skinning/gameplay/objectivetracker.lua
+++ b/modules/skinning/gameplay/objectivetracker.lua
@@ -381,7 +381,8 @@ end
 
 local function IsScenarioActive()
     if not C_ScenarioInfo or not C_ScenarioInfo.GetScenarioInfo then return false end
-    return type(C_ScenarioInfo.GetScenarioInfo()) ~= "nil"
+    local scenarioInfo = C_ScenarioInfo.GetScenarioInfo()
+    return type(scenarioInfo) ~= "nil"
 end
 
 local function ApplyMaxWidth(settings)


### PR DESCRIPTION
C_ScenarioInfo.GetScenarioInfo may return nothing, and `type()` on a bare call that returns nothing throws "value expected". Capture the result to a local first so the nothing adjusts to nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)