### PR TITLE
fix(actionbars): let owned buttons create the assisted rotation arrow frame

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_glow.lua
+++ b/QUI_ActionBars/actionbars/actionbars_glow.lua
@@ -284,10 +284,6 @@ UpdateAssistedCombatRotationFrame = function(button)
 
     if show and not frame then
         ActionBarsOwned._assistedCombatEverActive = true
-        if button.UpdateAssistedCombatRotationFrame then
-            _assistRotationButton = button
-            return
-        end
         frame = CreateFrame("Frame", nil, button, "ActionBarButtonAssistedCombatRotationTemplate")
         button.AssistedCombatRotationFrame = frame
         _assistRotationButton = button


### PR DESCRIPTION
## Summary
The one-button rotation action on QUI bars never showed Blizzard's arrow overlay. Regression from 1b2a73d4: the guard `if button.UpdateAssistedCombatRotationFrame then ... return` was meant to skip Blizzard-managed buttons, but every QUI-owned button inherits that mixin method from `ActionBarButtonTemplate`, so the guard fired on 100% of callers and made QUI's frame-creation branch unreachable. Owned buttons are also kept out of `ActionBarActionEventsFrame`/`ActionBarButtonEventsFrame`, so the Blizzard updater the guard deferred to never runs on them.

## Fix
Delete the guard (exact revert of that hunk; the loss-of-control-cooldown half of 1b2a73d4 is untouched). No double-frame risk: both QUI's create path and Blizzard's mixin key off the same `button.AssistedCombatRotationFrame` field, so whichever creates first, the other only calls `UpdateState()` on it.

## Testing
- `bash tools/test.sh`: all 9 gates pass
- In-game: pending (arrow should appear on the assisted rotation button after reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)