### PR TITLE
fix(actionbars): keep Blizzard's Update off owned buttons without losing its work

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_builder.lua
+++ b/QUI_ActionBars/actionbars/actionbars_builder.lua
@@ -66,6 +66,24 @@ function EnsureOwnedActionButton(container, barKey, btnName, index)
                 if f == btn then broadcaster.frames[k] = nil end
             end
         end
+        btn.Update = function(self)
+            ns.SafeCall("best-effort-style", ActionBarsOwned.SafeUpdate, self)
+            if HasButtonContent(self, GetSafeActionSlot(self)) then
+                self:UpdateTypeOverlay()
+                self:UpdateHighlightMark()
+            else
+                self:ClearTypeOverlay()
+            end
+        end
+        local castAnim = btn.SpellCastAnimFrame
+        if type(castAnim) == "table" and castAnim.SetScript then
+            local owner = btn
+            castAnim:SetScript("OnHide", function()
+                if owner.ClearReticle then owner:ClearReticle() end
+                if owner.cooldown then owner.cooldown:SetSwipeColor(0, 0, 0, 1) end
+                ScheduleABCooldownUpdate(true)
+            end)
+        end
         btn:SetScript("OnShow", nil)
         btn:SetScript("OnHide", nil)
         if btn.QuickKeybindButtonOnShow and btn.QuickKeybindButtonOnHide then

--- a/QUI_ActionBars/actionbars/actionbars_cooldowns.lua
+++ b/QUI_ActionBars/actionbars/actionbars_cooldowns.lua
@@ -105,11 +105,7 @@ do
         if _locGateAt == now then return _locGateResult end
         _locGateAt = now
         local count = C_LossOfControl.GetActiveLossOfControlDataCount()
-        if Helpers.IsSecretValue(count) then
-            _locGateResult = true -- @secret-policy: probe-loc-when-unknown
-        else
-            _locGateResult = (tonumber(count) or 0) > 0
-        end
+        _locGateResult = (tonumber(count) or 0) > 0
         return _locGateResult
     end
 
@@ -120,15 +116,6 @@ do
             return
         end
         cooldown:SetCooldownFromDurationObject(durationObject)
-    end
-
-    local function DecodePotentialSecretBoolean(value)
-        if Helpers.IsSecretValue(value) then
-            return nil -- @secret-policy: reject-secret-value
-        end
-        if value == true then return true end
-        if value == false then return false end
-        return nil
     end
 
     local _buttonWasActive = setmetatable({}, { __mode = "k" })
@@ -249,18 +236,9 @@ do
 
     local function GetActionCooldownState(button, action)
         local cdInfo = GetActionCooldownInfo(action)
-        local cdActive = DecodePotentialSecretBoolean(cdInfo.isActive)
+        local cdActive = cdInfo.isActive
         local durationObject = cdActive ~= false and GetActionCooldownDurationObject(action) or nil
         return cdInfo, durationObject, cdActive
-    end
-
-    local function ChargeInfoMayHaveCharges(chargeInfo)
-        local maxCharges = chargeInfo.maxCharges
-        if Helpers.IsSecretValue(maxCharges) then
-            return true -- @secret-policy: probe-charges-when-unknown
-        end
-        maxCharges = Helpers.SafeToNumber(maxCharges, 0) or 0
-        return maxCharges > 1
     end
 
     local function GetActionChargeActive(button, action)
@@ -282,14 +260,14 @@ do
         if _abCooldownStats then _abCooldownStats.chargeInfoQueries = _abCooldownStats.chargeInfoQueries + 1 end
         local chargeInfo = C_ActionBar.GetActionCharges(action)
         if type(chargeInfo) ~= "table" then chargeInfo = DEFAULT_CHARGE_INFO end
-        local mayHaveCharges = ChargeInfoMayHaveCharges(chargeInfo)
+        local mayHaveCharges = chargeInfo.maxCharges > 1
         _buttonChargeAction[button] = action
         _buttonMayHaveCharges[button] = mayHaveCharges
         if _cooldownBatchActive then
             _batchChargeInfoSeen[action] = _cooldownBatchToken
             _batchChargeMayHaveCharges[action] = mayHaveCharges
         end
-        local chargeActive = DecodePotentialSecretBoolean(chargeInfo.isActive)
+        local chargeActive = chargeInfo.isActive
         if mayHaveCharges and chargeActive ~= false then
             if _abCooldownStats then _abCooldownStats.chargeInfoActive = _abCooldownStats.chargeInfoActive + 1 end
             if _cooldownBatchActive then
@@ -366,8 +344,8 @@ do
 
             local locInfo = GetActionLoCInfo(action)
 
-            local locActive = DecodePotentialSecretBoolean(locInfo.isActive)
-            local locReplacesNormal = DecodePotentialSecretBoolean(locInfo.shouldReplaceNormalCooldown)
+            local locActive = locInfo.isActive
+            local locReplacesNormal = locInfo.shouldReplaceNormalCooldown
             local showLoC    = locActive ~= false
             local showCharge = locReplacesNormal ~= true and chActive == true
             local showNormal = locReplacesNormal ~= true and cdActive ~= false

--- a/QUI_ActionBars/actionbars/actionbars_glow.lua
+++ b/QUI_ActionBars/actionbars/actionbars_glow.lua
@@ -270,6 +270,45 @@ ActionBarsOwned._assistedCombatEverActive = false
 
 _assistRotationButton = nil
 
+local assistTicker, assistTickerRate
+
+local function StopAssistTicker()
+    if assistTicker then
+        assistTicker:Cancel()
+        assistTicker = nil
+        assistTickerRate = nil
+    end
+end
+
+local function AssistTickRate()
+    local manager = _G.AssistedCombatManager
+    local rate = manager and manager.GetUpdateRate and manager:GetUpdateRate()
+    if type(rate) ~= "number" or rate <= 0 then return 0.2 end
+    return rate
+end
+
+local function AssistTick()
+    local button = _assistRotationButton
+    if not button then
+        StopAssistTicker()
+        return
+    end
+    local slot = GetSafeActionSlot(button)
+    if not slot then return end
+    if C_ActionBar.ForceUpdateAction then
+        C_ActionBar.ForceUpdateAction(slot, true)
+    end
+    ns.SafeCall("best-effort-style", ActionBarsOwned.SafeUpdate, button)
+end
+
+local function ArmAssistTicker()
+    local rate = AssistTickRate()
+    if assistTicker and assistTickerRate == rate then return end
+    StopAssistTicker()
+    assistTickerRate = rate
+    assistTicker = C_Timer.NewTicker(rate, AssistTick)
+end
+
 UpdateAssistedCombatRotationFrame = function(button)
     if not (C_ActionBar and C_ActionBar.IsAssistedCombatAction) then return end
     local frame = button.AssistedCombatRotationFrame
@@ -286,20 +325,23 @@ UpdateAssistedCombatRotationFrame = function(button)
         ActionBarsOwned._assistedCombatEverActive = true
         frame = CreateFrame("Frame", nil, button, "ActionBarButtonAssistedCombatRotationTemplate")
         button.AssistedCombatRotationFrame = frame
-        _assistRotationButton = button
-        if not button.OnActionBarSlotChanged then
-            button.OnActionBarSlotChanged = function(self)
-                local slot = GetSafeActionSlot(self)
-                if slot and ClearNewActionHighlight then ClearNewActionHighlight(slot, true) end
-                if self.Update then self:Update() end
-            end
-        end
         frame:SetFrameLevel(button:GetFrameLevel() + 5)
     end
     if frame then
+        if frame:GetScript("OnUpdate") then
+            frame:SetScript("OnUpdate", nil)
+        end
         frame:UpdateState()
         frame:SetFrameLevel(button:GetFrameLevel() + 5)
     end
+    if show then
+        _assistRotationButton = button
+        ArmAssistTicker()
+    elseif button == _assistRotationButton then
+        _assistRotationButton = nil
+        StopAssistTicker()
+    end
+    return show
 end
 
 function UpdateAllAssistedCombatRotation()

--- a/tests/.taintrc.lua
+++ b/tests/.taintrc.lua
@@ -367,6 +367,14 @@ return {
         -- Field names that are always non-secret per Blizzard's API contract.
         -- When the analyzer sees `tainted_local.<field>` for any of these,
         -- it treats the read as clean instead of propagating taint.
-        "isOnGCD",  -- SpellCooldownInfo.isOnGCD is always a clean boolean
+        -- Every entry must carry NeverSecret = true on EVERY structure field
+        -- of that name in tests/api-docs/blizzard/ that belongs to a
+        -- secret-guarded structure; tests/unit/taint_clean_fields_test.lua
+        -- enforces that against the generated docs.
+        "isOnGCD",  -- SpellCooldownInfo.isOnGCD
+        "isActive",  -- SpellCooldownInfo / SpellChargeInfo / SpellLossOfControlInfo
+        "isEnabled",  -- SpellCooldownInfo.isEnabled
+        "maxCharges",  -- SpellChargeInfo.maxCharges
+        "shouldReplaceNormalCooldown",  -- SpellLossOfControlInfo
     },
 }

--- a/tests/unit/actionbars_cooldown_secret_batch_test.lua
+++ b/tests/unit/actionbars_cooldown_secret_batch_test.lua
@@ -342,7 +342,12 @@ assert(rawget(nilInfoBtn.cooldown, "cleared") == nil,
     "a nil-struct button must be treated as inactive without churning Clear")
 
 local secretSchedule = { token = "dur-30" }
-cooldownInfoByAction[30] = { isActive = SecretSentinel.MakeSecretSentinel() }
+cooldownInfoByAction[30] = {
+    isActive = true,
+    startTime = SecretSentinel.MakeSecretSentinel(),
+    duration = SecretSentinel.MakeSecretSentinel(),
+    modRate = SecretSentinel.MakeSecretSentinel(),
+}
 cooldownDurationByAction[30] = secretSchedule
 local secretActiveBtn = {
     action = 30,
@@ -355,11 +360,11 @@ actionBars._activeButtons[secretActiveBtn] = true
 currentTime = currentTime + 1
 
 ok, err = pcall(actionBars.UpdateAllCooldowns)
-assert(ok, "a secret isActive must not abort the cooldown batch: " .. tostring(err))
+assert(ok, "the secret-capable SpellCooldownInfo numbers must never be touched: " .. tostring(err))
 assert(secretActiveBtn.cooldown.lastDurationObject == secretSchedule,
-    "a secret isActive must pass the DurationObject through to the sink, never collapse to inactive")
+    "startTime/duration/modRate are secret-capable and ride the DurationObject; isActive is NeverSecret and gates it")
 assert(rawget(secretActiveBtn.cooldown, "cleared") == nil,
-    "a secret isActive must never clear a possibly-running swipe")
+    "a running swipe must never be cleared by a read of the secret schedule numbers")
 
 wipe(actionBars._activeButtons)
 wipe(actionBars._activeStandardButtons)

--- a/tests/unit/actionbars_owned_update_override_test.lua
+++ b/tests/unit/actionbars_owned_update_override_test.lua
@@ -1,0 +1,281 @@
+-- tests/unit/actionbars_owned_update_override_test.lua
+-- Run: lua tests/unit/actionbars_owned_update_override_test.lua
+--
+-- Owned buttons replace ActionBarActionButtonMixin:Update, because Blizzard's
+-- version reaches ActionButton_UpdateCooldown (secret SetCooldown) and
+-- UpdatePressAndHoldAction (protected SetAttribute) on a frame QUI created.
+-- A replacement is only safe if it still performs the parts of Blizzard's
+-- Update that QUI has no equivalent for: UpdateTypeOverlay/ClearTypeOverlay
+-- (:574/:590) and UpdateHighlightMark (:577). UpdateSpellAlert and
+-- UpdateSpellHighlightMark are deliberately NOT called -- ActionBarsOwned
+-- .UpdateOverlayGlow and UpdateSpellHighlight already own those surfaces and
+-- would double-render.
+--
+-- The assisted-rotation swirl frame carries a Lua OnUpdate that calls
+-- OnActionBarSlotChanged every tick. QUI must neuter it wherever the frame
+-- comes from: ActionBarActionButtonMixin:UpdateAssistedCombatRotationFrame
+-- (ActionButton.lua:895) creates the same frame from UpdateAction:542, one
+-- line ABOVE the Update() call the override replaces.
+
+local actionBarsDB = {
+    enabled = true,
+    global = {},
+    bars = {},
+}
+
+local function noop() end
+
+local frameMT
+local function NewFrame()
+    local frame = {
+        attributes = {},
+        scripts = {},
+        frameRefs = {},
+        shown = false,
+        frameLevel = 1,
+    }
+    frameMT = frameMT or {
+        __index = function(_, key)
+            if key == "SetAttribute" then
+                return function(self, name, value) self.attributes[name] = value end
+            elseif key == "GetAttribute" then
+                return function(self, name) return self.attributes[name] end
+            elseif key == "SetScript" then
+                return function(self, script, handler) self.scripts[script] = handler end
+            elseif key == "GetScript" then
+                return function(self, script) return self.scripts[script] end
+            elseif key == "HookScript" then
+                return function(self, script, handler) self.scripts[script] = handler end
+            elseif key == "SetFrameRef" then
+                return function(self, name, ref) self.frameRefs[name] = ref end
+            elseif key == "GetFrameRef" then
+                return function(self, name) return self.frameRefs[name] end
+            elseif key == "Show" then
+                return function(self) self.shown = true end
+            elseif key == "Hide" then
+                return function(self) self.shown = false end
+            elseif key == "IsShown" then
+                return function(self) return self.shown end
+            elseif key == "GetFrameLevel" then
+                return function(self) return self.frameLevel end
+            elseif key == "SetFrameLevel" then
+                return function(self, level) self.frameLevel = level end
+            elseif key == "GetParent" then
+                return function(self) return self.parent end
+            elseif key == "SetParent" then
+                return function(self, parent) self.parent = parent end
+            elseif key == "CreateTexture" or key == "CreateFontString" then
+                return function() return NewFrame() end
+            end
+            return noop
+        end,
+    }
+    return setmetatable(frame, frameMT)
+end
+
+UIParent = NewFrame()
+SlashCmdList = {}
+BINDING_HEADER_QUI_ACTIONBARS = ""
+WOW_PROJECT_MAINLINE = 1
+WOW_PROJECT_ID = WOW_PROJECT_MAINLINE
+RANGE_INDICATOR = ""
+
+function GetBuildInfo()
+    return "12.0.5", "66562", "May 1 2026", 120005
+end
+
+-- Blizzard's virtual templates bind OnUpdate by <OnUpdate method="OnUpdate"/>;
+-- the swirl template is virtual, not intrinsic, so the binding is an ordinary
+-- script that GetScript reports and SetScript can clear.
+local function templateOnUpdate() end
+
+function CreateFrame(_, _, parent, template)
+    local frame = NewFrame()
+    frame.parent = parent
+    if template and template:find("AssistedCombatRotation", 1, true) then
+        frame.scripts.OnUpdate = templateOnUpdate
+    end
+    return frame
+end
+
+function InCombatLockdown() return false end
+function GetTime() return 1 end
+function HasAction(action) return action ~= nil and action > 0 end
+function RegisterStateDriver() end
+function UnregisterStateDriver() end
+function LibStub() return nil end
+function GetCVar() return "0" end
+function hooksecurefunc() end
+
+local tickers = {}
+C_Timer = {
+    After = function(_, callback) if callback then callback() end end,
+    NewTicker = function(seconds, callback)
+        local ticker = { seconds = seconds, callback = callback, cancelled = false }
+        ticker.Cancel = function(self) self.cancelled = true end
+        tickers[#tickers + 1] = ticker
+        return ticker
+    end,
+}
+
+ActionBarButtonEventsFrame = { frames = {} }
+ActionBarActionEventsFrame = { frames = {} }
+function ActionBarActionEventsFrame:RegisterFrame(frame) self.frames[frame] = frame end
+function ActionBarActionEventsFrame:UnregisterFrame(frame) self.frames[frame] = nil end
+
+local assistedSlots = {}
+AssistedCombatManager = { updateRate = 0.25 }
+function AssistedCombatManager:GetUpdateRate() return self.updateRate or 0 end
+
+local ns = {
+    SafeCall = function(_policy, fn, ...) return pcall(fn, ...) end,
+    SafeCallMethod = function(_policy, obj, name, ...)
+        return pcall(function(...) return obj[name](obj, ...) end, ...)
+    end,
+    SafeCallMethodIfPresent = function(_policy, obj, name, ...)
+        if obj == nil then return nil end
+        local okP, m = pcall(function() return obj[name] end)
+        if not okP then return false end
+        if m == nil then return nil end
+        return pcall(m, obj, ...)
+    end,
+    Helpers = {
+        GetCore = function() return {} end,
+        CreateDBGetter = function() return function() return actionBarsDB end end,
+        CreateStateTable = function()
+            local state = setmetatable({}, { __mode = "k" })
+            local function get(frame)
+                local entry = state[frame]
+                if not entry then entry = {} state[frame] = entry end
+                return entry
+            end
+            return state, get
+        end,
+        SafeToNumber = function(value, fallback)
+            return type(value) == "number" and value or fallback
+        end,
+        SafeValue = function(value, fallback)
+            return value == nil and fallback or value
+        end,
+        IsSecretValue = function() return false end,
+        IsEditModeShown = function() return false end,
+    },
+    LSM = { Fetch = function() return nil end },
+}
+
+setmetatable(_G, {
+    __index = function(_, key)
+        if key:match("^QUI_Bar%d") then return nil end
+        local cTable = key:match("^C_[A-Z].*")
+        if cTable then
+            local tbl = setmetatable({}, { __index = function() return noop end })
+            rawset(_G, key, tbl)
+            return tbl
+        end
+        return noop
+    end,
+})
+
+assert(loadfile("QUI_ActionBars/actionbars/actionbars_env.lua"))("QUI", ns)
+assert(loadfile("QUI_ActionBars/actionbars/actionbars.lua"))("QUI", ns)
+assert(loadfile("QUI_ActionBars/actionbars/actionbars_helpers.lua"))("QUI", ns)
+assert(loadfile("QUI_ActionBars/actionbars/actionbars_layout.lua"))("QUI", ns)
+assert(loadfile("QUI_ActionBars/actionbars/actionbars_builder.lua"))("QUI", ns)
+assert(loadfile("QUI_ActionBars/actionbars/actionbars_glow.lua"))("QUI", ns)
+
+rawset(_G, "C_ActionBar", setmetatable({
+    IsAssistedCombatAction = function(action) return assistedSlots[action] == true end,
+    ForceUpdateAction = noop,
+}, { __index = function() return noop end }))
+
+local env = ns.ActionBarsEnv
+local actionBars = ns.ActionBarsOwned
+local container = NewFrame()
+
+local fails = 0
+local function check(name, ok, detail)
+    if ok then
+        print("  ok  " .. name)
+    else
+        fails = fails + 1
+        print("FAIL  " .. name .. (detail and ("\n        " .. detail) or ""))
+    end
+end
+
+local btn = env.EnsureOwnedActionButton(container, "bar5", "QUI_Bar5Button1", 1)
+assert(btn ~= nil, "sanity: create branch must return a button")
+
+local calls = {}
+local realSafeUpdate = actionBars.SafeUpdate
+actionBars.SafeUpdate = function() calls.safeUpdate = (calls.safeUpdate or 0) + 1 end
+btn.UpdateTypeOverlay = function() calls.typeOverlay = (calls.typeOverlay or 0) + 1 end
+btn.ClearTypeOverlay = function() calls.clearType = (calls.clearType or 0) + 1 end
+btn.UpdateHighlightMark = function() calls.highlight = (calls.highlight or 0) + 1 end
+btn.UpdateSpellAlert = function() calls.spellAlert = (calls.spellAlert or 0) + 1 end
+btn.UpdateSpellHighlightMark = function() calls.spellHighlight = (calls.spellHighlight or 0) + 1 end
+
+btn.attributes.action = 7
+btn:Update()
+
+check("the Update override paints through QUI's own pipeline",
+    calls.safeUpdate == 1)
+check("a button holding an action still gets Blizzard's UpdateTypeOverlay (ActionButton.lua:574)",
+    calls.typeOverlay == 1 and calls.clearType == nil,
+    "typeOverlay=" .. tostring(calls.typeOverlay) .. " clearType=" .. tostring(calls.clearType))
+check("a button holding an action still gets UpdateHighlightMark (:577) for NewActionTexture",
+    calls.highlight == 1)
+check("UpdateSpellAlert and UpdateSpellHighlightMark stay UNCALLED — QUI owns those surfaces",
+    calls.spellAlert == nil and calls.spellHighlight == nil,
+    "calling them double-renders against UpdateOverlayGlow / UpdateSpellHighlight")
+
+calls = {}
+btn.attributes.action = nil
+btn:Update()
+
+check("an empty slot clears the type overlay instead of updating it (:590)",
+    calls.clearType == 1 and calls.typeOverlay == nil and calls.highlight == nil,
+    "clearType=" .. tostring(calls.clearType) .. " typeOverlay=" .. tostring(calls.typeOverlay))
+
+actionBars.SafeUpdate = realSafeUpdate
+
+-- Blizzard's own create path: the frame already exists, carrying the template
+-- OnUpdate, before QUI's updater ever runs.
+local assistBtn = env.EnsureOwnedActionButton(container, "bar5", "QUI_Bar5Button2", 2)
+assistBtn.attributes.action = 11
+assistedSlots[11] = true
+actionBars._assistedCombatEverActive = true
+
+local blizzardMade = CreateFrame("Frame", nil, assistBtn, "ActionBarButtonAssistedCombatRotationTemplate")
+assert(blizzardMade.scripts.OnUpdate == templateOnUpdate,
+    "sanity: the swirl template must arrive with its OnUpdate bound")
+assistBtn.AssistedCombatRotationFrame = blizzardMade
+
+env.UpdateAssistedCombatRotationFrame(assistBtn)
+
+check("a swirl frame QUI did not create still gets its OnUpdate neutered",
+    blizzardMade.scripts.OnUpdate == nil,
+    "Blizzard creates the identical frame at ActionButton.lua:895 from UpdateAction:542")
+
+local armed = tickers[#tickers]
+check("an active assist action arms the repaint ticker at the manager's rate",
+    armed ~= nil and armed.cancelled == false and armed.seconds == 0.25,
+    "seconds=" .. tostring(armed and armed.seconds))
+
+AssistedCombatManager.updateRate = 0.5
+env.UpdateAssistedCombatRotationFrame(assistBtn)
+local rearmed = tickers[#tickers]
+check("a changed update rate re-arms the ticker instead of latching the old one",
+    rearmed ~= armed and armed.cancelled == true and rearmed.seconds == 0.5,
+    "seconds=" .. tostring(rearmed and rearmed.seconds))
+
+assistedSlots[11] = nil
+env.UpdateAssistedCombatRotationFrame(assistBtn)
+
+check("losing the assist action stops the ticker",
+    rearmed.cancelled == true)
+check("losing the assist action clears the tracked button so the next search can find a new one",
+    rawget(env, "_assistRotationButton") == nil)
+
+print(string.format("actionbars_owned_update_override_test: checks complete, %d failed", fails))
+if fails > 0 then os.exit(1) end
+print("OK: actionbars_owned_update_override_test")

--- a/tests/unit/actionbars_ping_receiver_test.lua
+++ b/tests/unit/actionbars_ping_receiver_test.lua
@@ -58,12 +58,21 @@ check("QUI owned buttons keep Blizzard's ActionBarButtonTemplate and append Secu
     builder:find(
         'CreateFrame, "CheckButton", btnName, container, "ActionBarButtonTemplate, SecureActionButtonTemplate"',
         1, true) ~= nil)
-check("QUI does not replace Blizzard's ping identity or update lifecycle",
+check("QUI does not replace Blizzard's ping identity or action lifecycle",
     builder:find("btn.HasAction =", 1, true) == nil
         and builder:find("btn.GetActionButtonInfo =", 1, true) == nil
         and builder:find("btn.UpdateAction =", 1, true) == nil
-        and builder:find("btn.Update =", 1, true) == nil
         and builder:find("btn.UpdatePressAndHoldAction =", 1, true) == nil)
+check("owned buttons route Blizzard's Update through QUI's own painter",
+    framexml:find("ActionButton_UpdateCooldown(self);", 1, true) ~= nil
+        and builder:find("btn.Update = function(self)", 1, true) ~= nil
+        and builder:find("ActionBarsOwned.SafeUpdate, self", 1, true) ~= nil)
+check("owned buttons take over the cast-anim OnHide that bypasses Update",
+    framexml:find(
+        "function ActionButtonCastingAnimFrameMixin:OnHide()\n\tlocal parent = self:GetParent();\n\tparent:ClearReticle();\n\tparent.cooldown:SetSwipeColor(0, 0, 0, 1);\n\tActionButton_UpdateCooldown(parent);",
+        1, true) ~= nil
+        and builder:find('castAnim:SetScript("OnHide"', 1, true) ~= nil
+        and builder:find("ScheduleABCooldownUpdate(true)", 1, true) ~= nil)
 check("QUI never assigns the action identity directly",
     builder:find("btn.action =", 1, true) == nil
         and actionbars:find("self.action = action", 1, true) == nil)

--- a/tests/unit/taint_clean_fields_test.lua
+++ b/tests/unit/taint_clean_fields_test.lua
@@ -1,0 +1,114 @@
+-- tests/unit/taint_clean_fields_test.lua
+-- Run: lua tests/unit/taint_clean_fields_test.lua
+
+local DOC_DIR = "tests/api-docs/blizzard"
+
+local function readAll(path)
+    local file = assert(io.open(path, "rb"))
+    local data = file:read("*a")
+    file:close()
+    return (data:gsub("\r\n", "\n"))
+end
+
+local function docFiles()
+    local files = {}
+    local pipe = assert(io.popen('find "' .. DOC_DIR .. '" -name "*.lua" -type f'))
+    for line in pipe:lines() do files[#files + 1] = line end
+    pipe:close()
+    assert(#files > 0, "no generated API docs found under " .. DOC_DIR)
+    return files
+end
+
+local fails = 0
+local function check(name, ok, detail)
+    if ok then
+        print("  ok  " .. name)
+    else
+        fails = fails + 1
+        print("FAIL  " .. name .. (detail and ("\n        " .. detail) or ""))
+    end
+end
+
+local GUARDED_STRUCTURE_MARKERS = {
+    "SecretWhen", "SecretReturns", "SecretArguments",
+    "NeverSecret", "AlwaysSecret", "SecretReturnsForAspect",
+}
+
+local fieldsByName = {}
+
+local function flush(block)
+    if not block then return end
+    for _, entry in ipairs(block.fields) do
+        entry.guarded = block.guarded
+        local entries = fieldsByName[entry.field] or {}
+        fieldsByName[entry.field] = entries
+        entries[#entries + 1] = entry
+    end
+end
+
+for _, path in ipairs(docFiles()) do
+    local block, lastName = nil, nil
+    local lineNumber = 0
+    for line in readAll(path):gmatch("[^\n]*") do
+        lineNumber = lineNumber + 1
+        local standaloneName = line:match('^%s*Name%s*=%s*"([%w_]+)"%s*,%s*$')
+        if standaloneName then lastName = standaloneName end
+        if line:match('^%s*Type%s*=%s*"Structure"%s*,%s*$') then
+            flush(block)
+            block = { structure = lastName, guarded = false, fields = {} }
+        elseif line:match('^%s*Type%s*=%s*"[%w_]+"%s*,%s*$') then
+            flush(block)
+            block = nil
+        end
+        if block then
+            for _, marker in ipairs(GUARDED_STRUCTURE_MARKERS) do
+                if line:find(marker, 1, true) then block.guarded = true end
+            end
+            local field = line:match('{%s*Name%s*=%s*"([%w_]+)"%s*,%s*Type%s*=%s*"[%w_]+"')
+            if field and line:find("Nilable", 1, true) then
+                block.fields[#block.fields + 1] = {
+                    field = field,
+                    structure = block.structure,
+                    never = line:find("NeverSecret = true", 1, true) ~= nil,
+                    where = path .. ":" .. lineNumber,
+                }
+            end
+        end
+    end
+    flush(block)
+end
+
+local config = assert(loadfile("tests/.taintrc.lua"))()
+local cleanFields = assert(config.clean_fields, ".taintrc.lua must declare clean_fields")
+
+check("the generated docs parsed into a usable field index",
+    next(fieldsByName) ~= nil and fieldsByName.isActive ~= nil)
+
+for _, field in ipairs(cleanFields) do
+    local entries = fieldsByName[field]
+    if not entries then
+        check("clean_fields entry '" .. field .. "' names a real documented field", false,
+            "no structure in " .. DOC_DIR .. " declares a field called " .. field)
+    else
+        local offenders = {}
+        local sawGuarded = false
+        for _, entry in ipairs(entries) do
+            if entry.guarded then
+                sawGuarded = true
+                if not entry.never then
+                    offenders[#offenders + 1] = entry.structure .. " (" .. entry.where .. ")"
+                end
+            end
+        end
+        check("clean_fields entry '" .. field .. "' is NeverSecret on every secret-guarded structure",
+            sawGuarded and #offenders == 0,
+            (not sawGuarded)
+                and ("no secret-guarded structure declares " .. field
+                    .. " — the entry buys nothing and hides real taint")
+                or ("secret-capable on: " .. table.concat(offenders, ", ")))
+    end
+end
+
+print(string.format("taint_clean_fields_test: checks complete, %d failed", fails))
+if fails > 0 then os.exit(1) end
+print("OK: taint_clean_fields_test")


### PR DESCRIPTION
Fixes the `SetCooldown` secret-value errors on owned action buttons, and removes
the probe ceremony that made the cooldown gating look unsafe.

### Why the action bars kept breaking

Owned buttons carry the full `ActionBarActionButtonMixin`, so Blizzard's
`Update()` runs on them under our taint. That one function reaches
`ActionButton_UpdateCooldown` (secret `SetCooldown`) and
`UpdatePressAndHoldAction` (protected `SetAttribute` in combat). Every previous
fix patched a different *caller* — OnShow, the two dispatch registries, combat
paging, hover — and the next patch reopened another. The reported crash came
from the newest caller: the assisted-rotation swirl frame's `OnUpdate`, which
calls `OnActionBarSlotChanged` on a timer.

This replaces `Update` on owned buttons instead, at the choke point.

### What the replacement has to keep doing

`SafeUpdate` covers 13 of Blizzard's 18 steps. Auditing the rest by grepping for
a QUI *equivalent* rather than for the symbol:

| Blizzard step | QUI equivalent | action |
|---|---|---|
| `UpdateSpellAlert` | `UpdateOverlayGlow` — same `IsSpellOverlayed` source | not called; would double-render |
| `UpdateSpellHighlightMark` | `UpdateSpellHighlight` — owns the same texture | not called; would fight it |
| `feedback_action` | — | written twice in FrameXML, read nowhere |
| `UpdateTypeOverlay` / `ClearTypeOverlay` | none | **restored** |
| `UpdateHighlightMark` | none | **restored** |

### The swirl frame

Neutered on every pass, not just where we create it — Blizzard creates the
identical frame from `UpdateAction`, one line above the `Update` call being
replaced. Its repaint moves to a ticker that arms while an assist action is on a
bar, re-arms on a rate change, and stops when the action leaves. That last part
also fixes a standing bug: the tracked assist button was never cleared, and the
search early-returns on it, so once the action moved buttons the search never
re-ran.

### Second commit: the probes were guarding nothing

`isActive` on all three cooldown structs, plus `maxCharges` and
`shouldReplaceNormalCooldown`, are declared `NeverSecret = true`. Only the
numbers are secret-capable, and those never enter Lua — they ride the duration
object to the sink. The gating was correct; the probes around it were not, and
made the code read as though deleting the gate would be a hardening.

That fact had already been worked out once in the flyout module and buried in a
local comment. It now lives in `clean_fields`, and a new gate verifies every
entry against the generated API docs.

### Verification

`bash tools/test.sh` → 9/9, strict taint scan clean.

`tests/unit/actionbars_owned_update_override_test.lua` is 10 behavioural checks,
each mutation-proven — restoring any one of the original bugs reddens exactly its
own check:

```
drop the restored methods            -> 3 checks red
neuter the swirl only at create      -> swirl check red
latch the ticker rate                -> re-arm check red
never clear the tracked button       -> tracked-button check red
also call UpdateSpellAlert           -> double-render check red
```

All four other gates passed every one of those broken versions, so this test is
the only thing standing between the override and silent visual loss.

**Not yet proven in game.** Worth testing in combat: pull a cooldown, hover a
bar, page bar 1, and put the assisted-rotation spell on a bar.
