### PR TITLE
fix(actionbars): defer ping attribute updates on owned buttons until combat ends

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_builder.lua
+++ b/QUI_ActionBars/actionbars/actionbars_builder.lua
@@ -35,6 +35,16 @@ end
 -- Update() whenever the button holds an action, so it needs a standing hook.
 local ownedDispatchExcludedButtons = setmetatable({}, { __mode = "k" })
 local actionEventsPurgeHooked = false
+local pendingPingAttributes = setmetatable({}, { __mode = "k" })
+
+function FlushPendingPingAttributes()
+    for pending in pairs(pendingPingAttributes) do
+        pendingPingAttributes[pending] = nil
+        if type(pending.UpdatePingAttributes) == "function" then
+            ns.SafeCallMethod("best-effort-style", pending, "UpdatePingAttributes")
+        end
+    end
+end
 
 local function KeepOwnedButtonOutOfActionEventsFrame(btn)
     ownedDispatchExcludedButtons[btn] = true
@@ -67,12 +77,28 @@ function EnsureOwnedActionButton(container, barKey, btnName, index)
             end
         end
         btn.Update = function(self)
+            local assistFrame = self.AssistedCombatRotationFrame
+            if type(assistFrame) == "table" and assistFrame.GetScript
+                and assistFrame:GetScript("OnUpdate") then
+                assistFrame:SetScript("OnUpdate", nil)
+            end
             ns.SafeCall("best-effort-style", ActionBarsOwned.SafeUpdate, self)
             if HasButtonContent(self, GetSafeActionSlot(self)) then
                 self:UpdateTypeOverlay()
                 self:UpdateHighlightMark()
             else
                 self:ClearTypeOverlay()
+            end
+        end
+        local blizzardPingUpdate = btn.UpdatePingAttributes
+        if type(blizzardPingUpdate) == "function" then
+            btn.UpdatePingAttributes = function(self)
+                if InCombatLockdown() then
+                    pendingPingAttributes[self] = true
+                    return
+                end
+                pendingPingAttributes[self] = nil
+                blizzardPingUpdate(self)
             end
         end
         local castAnim = btn.SpellCastAnimFrame

--- a/QUI_ActionBars/actionbars/actionbars_events.lua
+++ b/QUI_ActionBars/actionbars/actionbars_events.lua
@@ -326,6 +326,7 @@ function OnOwnedEvent(self, event, ...)
 
     elseif event == "PLAYER_REGEN_ENABLED" then
         ScheduleABVisualUpdate(false, true)
+        FlushPendingPingAttributes()
         FinishBlockedOverrideBarExit()
         if ActionBarsOwned.pendingExtraButtonInit then
             ActionBarsOwned.pendingExtraButtonInit = false

--- a/tests/unit/actionbars_owned_update_override_test.lua
+++ b/tests/unit/actionbars_owned_update_override_test.lua
@@ -25,6 +25,8 @@ local actionBarsDB = {
 
 local function noop() end
 
+local pingUpdateCounts = {}
+
 local frameMT
 local function NewFrame()
     local frame = {
@@ -66,6 +68,8 @@ local function NewFrame()
                 return function(self, parent) self.parent = parent end
             elseif key == "CreateTexture" or key == "CreateFontString" then
                 return function() return NewFrame() end
+            elseif key == "UpdatePingAttributes" then
+                return function(self) pingUpdateCounts[self] = (pingUpdateCounts[self] or 0) + 1 end
             end
             return noop
         end,
@@ -98,7 +102,8 @@ function CreateFrame(_, _, parent, template)
     return frame
 end
 
-function InCombatLockdown() return false end
+local testInCombat = false
+function InCombatLockdown() return testInCombat end
 function GetTime() return 1 end
 function HasAction(action) return action ~= nil and action > 0 end
 function RegisterStateDriver() end
@@ -275,6 +280,42 @@ check("losing the assist action stops the ticker",
     rearmed.cancelled == true)
 check("losing the assist action clears the tracked button so the next search can find a new one",
     rawget(env, "_assistRotationButton") == nil)
+
+local pingBtn = env.EnsureOwnedActionButton(container, "bar5", "QUI_Bar5Button3", 3)
+pingBtn.attributes.action = 13
+
+local blizzardSwirl = CreateFrame("Frame", nil, pingBtn, "ActionBarButtonAssistedCombatRotationTemplate")
+assert(blizzardSwirl.scripts.OnUpdate == templateOnUpdate,
+    "sanity: the swirl template must arrive with its OnUpdate bound")
+pingBtn.AssistedCombatRotationFrame = blizzardSwirl
+
+actionBars.SafeUpdate = noop
+pingBtn:Update()
+actionBars.SafeUpdate = realSafeUpdate
+
+check("the Update override neuters a swirl OnUpdate that Blizzard's UpdateAction created",
+    blizzardSwirl.scripts.OnUpdate == nil,
+    "UpdateAction:540 creates it one line above the Update() the override replaces")
+
+testInCombat = true
+pingBtn:UpdatePingAttributes()
+
+check("UpdatePingAttributes defers in combat instead of firing a protected SetAttribute",
+    pingUpdateCounts[pingBtn] == nil,
+    "pingUpdates=" .. tostring(pingUpdateCounts[pingBtn]))
+
+testInCombat = false
+env.FlushPendingPingAttributes()
+
+check("the deferred ping attribute update is flushed when combat ends",
+    pingUpdateCounts[pingBtn] == 1,
+    "pingUpdates=" .. tostring(pingUpdateCounts[pingBtn]))
+
+pingBtn:UpdatePingAttributes()
+
+check("out of combat the ping attribute update passes straight through to Blizzard",
+    pingUpdateCounts[pingBtn] == 2,
+    "pingUpdates=" .. tostring(pingUpdateCounts[pingBtn]))
 
 print(string.format("actionbars_owned_update_override_test: checks complete, %d failed", fails))
 if fails > 0 then os.exit(1) end


### PR DESCRIPTION
Follow-up to #736, closing the last two gaps in the owned-button `Update` path.

### `UpdatePingAttributes` is protected too

`UpdateAction` calls it immediately after `Update` (`ActionButton.lua:546`), and
it writes a secure attribute — blocked in combat on an owned button, exactly
like the cooldown path #736 fixed. Previously the throw at `Update` masked it;
now that `Update` no longer throws, the call actually reaches the protected
write.

Wrapped: in combat the button is recorded in a weak set and the call skipped,
`PLAYER_REGEN_ENABLED` flushes the backlog, and out of combat it passes straight
through to Blizzard's implementation.

### Swirl neuter, second entry point

#736 neuters the assist swirl's `OnUpdate` on every glow pass. Blizzard creates
that frame from `UpdateAction` one line *above* the `Update` call being
replaced, so there is a window where a live `OnUpdate` exists before the glow
pass next runs. Now also neutered from inside the override itself.

### Verification

`bash tools/test.sh` → 9/9, strict taint clean.

Four checks added to `actionbars_owned_update_override_test.lua`, and both
behaviours are mutation-proven:

```
drop the in-combat defer      -> defer check red
drop the in-Update swirl neuter -> swirl check red
```

**Not proven in game.** Same test pass as #736: pull a cooldown in combat, hover
a bar, page bar 1, and put the assisted-rotation spell on a bar.
