### PR TITLE
release: v5.2.0-beta6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.0-beta6 - 2026-08-16
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+A fix pass across action bars, group frames, and the objective tracker: QUI's
+own action buttons stop dropping updates and throwing blocked-action errors in
+combat, group frame health colors and tracked aura bars work again, and the
+skinned objective tracker and Mythic+ timer keep updating through a fight.
+
+### Added
+
+- **Health bar colors for group frames without class coloring.** Group
+  frames can set their own health bar color when class coloring is off.
+- **Orientation and styling options for tracked aura bars.** Group frame
+  tracked aura bars expose orientation and styling controls alongside the
+  existing tracked aura settings.
+
+### Fixed
+
+- **Action bar buttons keep painting in combat.** QUI's action buttons
+  inherit the game's own button behaviour, and several of its update paths
+  either read values that go unreadable in combat or write protected
+  attributes, which silently stalled cooldowns, glows, and pressed states
+  until the fight ended. QUI now paints those buttons itself and queues the
+  protected writes until combat drops.
+- **The assisted rotation arrow shows on QUI's action bars.** The arrow
+  overlay marking the assisted combat rotation action was never created on
+  QUI-owned buttons, and its repaint timer could keep running against a
+  stale slot.
+- **The skinned objective tracker keeps updating.** Reading the tracker's
+  own geometry in combat froze its layout after the first unreadable value;
+  the tracker now holds position instead of stalling.
+- **Mythic+ timer objectives and progress bar update again.** Boss kills,
+  objective names, and the weighted progress bar are driven directly from
+  the game's values and catch up when combat ends.
+- **Group frame health colors and expiring aura bars work again.** Health
+  tints route through the shared aura feeder, and tracked aura bars recolor
+  during their expiring window.
+- **Tracked buff bars stay on the variant that actually rolled.** A buff bar
+  paired to one of the game's frames could freeze on whatever variant was
+  live when a fight started; its mirror now keeps ticking for as long as the
+  pairing exists.
+- **Cooldown Manager row opacity survives layout changes.** Reanchoring a
+  row's icons no longer resets their configured opacity.
+- **Cooldown Manager tooltips no longer error on unreadable auras.**
+
+### Changed
+
+- **Cooldown Manager mouseover detection does less work per frame.** The
+  detector rebuilt a viewer's whole child list once per child; it now builds
+  it once per frame.
+
 ## v5.2.0-beta5 - 2026-08-15
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta5
+## Version: 5.2.0-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Version bump only: shipped TOC `## Version:` lines (13) and `CHANGELOG.md`.

Local `bash tools/test.sh`: ALL GATES PASSED 9/9 on the work tree and on the release commit in an isolated clone.
Changelog extractor dry-run against `release.yml`'s `awk` block: 51 lines, terminates before the `v5.2.0-beta5` heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)