### PR TITLE
fix(groupframes): limit auto-detected raid buffs to class buff

### DIFF
--- a/QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua
+++ b/QUI_GroupFrames/groupframes/groupframes_missing_raid_buffs.lua
@@ -609,8 +609,9 @@ end
 
 local function ElementShouldCheckBuff(element, buff)
     if element.classDetection ~= false then
+        -- Auto-detect tracks only the raid buff the player's class provides;
+        -- CDM Group Buff entries (no providerClass) are opt-in via manual mode.
         return CLASS_TO_BUFF_KEY[GetPlayerClass() or ""] == buff.key
-            or buff.providerClass == nil
     end
     local checks = element.buffChecks
     if type(checks) ~= "table" then

--- a/tests/unit/groupframes_mrb_relevance_test.lua
+++ b/tests/unit/groupframes_mrb_relevance_test.lua
@@ -1,6 +1,6 @@
 -- tests/unit/groupframes_mrb_relevance_test.lua
--- ElementShouldCheckBuff: in classDetection mode, a no-providerClass (CDM) buff is
--- always relevant; built-in buffs stay gated to the player's class.
+-- ElementShouldCheckBuff: in classDetection mode, only the player's class buff is
+-- relevant; no-providerClass (CDM) buffs are opt-in via manual buffChecks.
 -- Run: lua tests/unit/groupframes_mrb_relevance_test.lua
 
 _G.issecretvalue = function() return false end
@@ -16,11 +16,17 @@ local MRB = assert(ns.QUI_GroupFrameMissingRaidBuffs)
 local check = assert(MRB.ElementShouldCheckBuff, "ElementShouldCheckBuff must be exposed")
 
 local el = { classDetection = true }
-assert(check(el, { key = "cdm:100", providerClass = nil }) == true,
-    "CDM (no providerClass) buff is always relevant in classDetection mode")
+assert(check(el, { key = "cdm:100", providerClass = nil }) == false,
+    "CDM (no providerClass) buff is NOT relevant in classDetection mode")
 assert(check(el, { key = "intellect", providerClass = "MAGE" }) == true,
     "player-class (MAGE -> intellect) built-in buff is relevant")
 assert(check(el, { key = "stamina", providerClass = "PRIEST" }) == false,
     "non-player-class built-in buff (PRIEST) is NOT relevant for a MAGE")
+
+local manual = { classDetection = false, buffChecks = { ["cdm:100"] = true } }
+assert(check(manual, { key = "cdm:100", providerClass = nil }) == true,
+    "CDM buff is relevant in manual mode when its buffCheck is enabled")
+assert(check(manual, { key = "cdm:200", providerClass = nil }) == false,
+    "CDM buff is NOT relevant in manual mode when unchecked")
 
 print("OK groupframes_mrb_relevance_test")

--- a/tests/unit/groupframes_preview_driver_test.lua
+++ b/tests/unit/groupframes_preview_driver_test.lua
@@ -359,15 +359,15 @@ test("missing-raid-buff preview honors auto/manual buff selection", function()
         ElementShouldCheckBuff = function(element, buff)
             if element.noAutoCandidate then return false end
             if element.classDetection ~= false then
-                return buff.key == "fortitude" or buff.providerClass == nil
+                return buff.key == "fortitude"
             end
             return element.buffChecks and element.buffChecks[buff.key] == true
         end,
     }
 
     local auto = D._BuildMissingRaidBuffMatches({ classDetection = true, maxIcons = 5 }, 0)
-    assert(#auto == 2 and auto[1].spellId == 10 and auto[2].spellId == 30,
-        "auto mode must show only the current-class/CDM candidates")
+    assert(#auto == 1 and auto[1].spellId == 10,
+        "auto mode must show only the current-class candidate")
 
     local noAutoCandidate = D._BuildMissingRaidBuffMatches({
         classDetection = true, noAutoCandidate = true, maxIcons = 5,


### PR DESCRIPTION
- Keep CDM Group Buff entries opt-in through manual buff selection
- Update relevance and preview tests