### PR TITLE
fix(nameplates): reset complete profile snapshots

### DIFF
--- a/QUI_Nameplates/nameplates/presets.lua
+++ b/QUI_Nameplates/nameplates/presets.lua
@@ -203,7 +203,7 @@ function NPPresets.IsActiveProfileModified()
     local name = NPPresets.GetLastAppliedProfile()
     if not name then return false end
     local store = NPPresets.PeekProfileStore()
-    return not TablesEqual(NPPresets.Snapshot(NP.GetSettings()), store[name])
+    return not TablesEqual(NPPresets.Snapshot(NP.GetSettings()), NPPresets.Snapshot(store[name]))
 end
 
 function NPPresets.ListProfileNames()

--- a/QUI_Nameplates/nameplates/presets.lua
+++ b/QUI_Nameplates/nameplates/presets.lua
@@ -5,6 +5,7 @@ if not NP then return end
 local type = type
 local pairs = pairs
 local pcall = pcall
+local rawget = rawget
 local wipe = wipe
 local CreateFrame = CreateFrame
 
@@ -20,34 +21,51 @@ NPPresets.EXCLUDED_KEYS = EXCLUDED_KEYS
 
 local CopyDeep = NP.CopyDeep
 NPPresets.CopyDeep = CopyDeep
+local IsArrayLike = NP.IsArrayLike
+
+local function MergeDeep(target, patch)
+    for k, v in pairs(patch) do
+        if type(v) == "table" and not IsArrayLike(v) then
+            if type(target[k]) ~= "table" then target[k] = {} end
+            MergeDeep(target[k], v)
+        else
+            target[k] = CopyDeep(v)
+        end
+    end
+end
 
 function NPPresets.Snapshot(settings)
     settings = settings or NP.GetSettings()
-    local snap = {}
-    for k, v in pairs(settings) do
-        if not EXCLUDED_KEYS[k] then
-            snap[k] = CopyDeep(v)
-        end
+    local shipped = ns.defaults and ns.defaults.profile and ns.defaults.profile.nameplates
+    local snap = type(shipped) == "table" and CopyDeep(shipped) or {}
+    MergeDeep(snap, settings)
+    for k in pairs(EXCLUDED_KEYS) do
+        snap[k] = nil
     end
     return snap
 end
 
 function NPPresets.ApplySnapshot(settings, snap)
     if type(settings) ~= "table" or type(snap) ~= "table" then return false end
-    for k, v in pairs(snap) do
-        if not EXCLUDED_KEYS[k] then
-            if type(v) == "table" then
-                if type(settings[k]) ~= "table" then
-                    settings[k] = {}
-                else
-                    wipe(settings[k])
-                end
-                for k2, v2 in pairs(CopyDeep(v)) do
-                    settings[k][k2] = v2
-                end
+    local complete = NPPresets.Snapshot(snap)
+    for k in pairs(settings) do
+        if not EXCLUDED_KEYS[k] and complete[k] == nil then
+            settings[k] = nil
+        end
+    end
+    for k, v in pairs(complete) do
+        if type(v) == "table" then
+            local target = rawget(settings, k)
+            if type(target) ~= "table" then
+                settings[k] = CopyDeep(v)
             else
-                settings[k] = v
+                wipe(target)
+                for k2, v2 in pairs(CopyDeep(v)) do
+                    target[k2] = v2
+                end
             end
+        else
+            settings[k] = v
         end
     end
     return true
@@ -71,19 +89,6 @@ NPPresets.STARTER_STYLES = STARTER_STYLES
 
 function NPPresets.GetStarterStyleKeys()
     return { "default", "compact", "chunky" }
-end
-
-local IsArrayLike = NP.IsArrayLike
-
-local function MergeDeep(target, patch)
-    for k, v in pairs(patch) do
-        if type(v) == "table" and not IsArrayLike(v) then
-            if type(target[k]) ~= "table" then target[k] = {} end
-            MergeDeep(target[k], v)
-        else
-            target[k] = CopyDeep(v)
-        end
-    end
 end
 
 function NPPresets.ApplyStyleTable(styleKey)

--- a/tests/unit/nameplates_profiles_test.lua
+++ b/tests/unit/nameplates_profiles_test.lua
@@ -236,6 +236,10 @@ test("active-profile tracking: apply/save set it, edits mark it modified, rename
     end
     if Presets.IsActiveProfileModified() then fail("freshly saved profile must not read as modified") end
 
+    Presets.GetProfileStore().Tracked.colors = nil
+    Presets.ApplyProfile("Tracked")
+    if Presets.IsActiveProfileModified() then fail("older sparse profiles must compare against current defaults") end
+
     settings.health.width = 999
     if not Presets.IsActiveProfileModified() then fail("live edits must mark the active profile modified") end
 

--- a/tests/unit/nameplates_profiles_test.lua
+++ b/tests/unit/nameplates_profiles_test.lua
@@ -40,6 +40,11 @@ end
 
 QUI = { db = { global = {}, char = {} } }
 
+local shippedNameplates = {
+    enabled = false,
+    health = { width = 156, height = 17, bgColor = { 0.12, 0.12, 0.12 } },
+    colors = { hostile = { 0.39, 0.11, 0.09 } },
+}
 local settings = {
     enabled = true,
     health = { width = 156, height = 17, bgColor = { 0.12, 0.12, 0.12 } },
@@ -47,6 +52,7 @@ local settings = {
 }
 local refreshCount = 0
 local ns = {
+    defaults = { profile = { nameplates = shippedNameplates } },
     Helpers = {
         GetModuleSettings = function() return settings end,
         IsSecretValue = function() return false end,
@@ -78,6 +84,25 @@ test("store and assignments live in db.global and are lazily created", function(
     if type(assignments.specs) ~= "table" or type(assignments.roles) ~= "table" then
         fail("assignments must seed specs/roles maps")
     end
+end)
+
+test("default-backed snapshots are complete and sparse applies reset prior overrides", function()
+    local live = setmetatable({
+        enabled = true,
+        health = setmetatable({ width = 201, ghostKey = true }, { __index = shippedNameplates.health }),
+    }, { __index = shippedNameplates })
+    local snap = Presets.Snapshot(live)
+    if snap.health.height ~= 17 then fail("snapshot must materialize nested defaults") end
+    if math.abs(snap.colors.hostile[1] - 0.39) > 1e-9 then fail("snapshot must materialize top-level defaults") end
+
+    live.colors = { hostile = { 0.9, 0.9, 0.9 } }
+    live.custom = true
+    Presets.ApplySnapshot(live, { health = { width = 222 } })
+    if live.health.width ~= 222 or live.health.height ~= 17 then fail("sparse apply must merge shipped defaults") end
+    if live.health.ghostKey ~= nil then fail("sparse apply must remove nested leftovers") end
+    if math.abs(live.colors.hostile[1] - 0.39) > 1e-9 then fail("sparse apply must reset omitted settings") end
+    if live.custom ~= nil then fail("sparse apply must remove omitted custom settings") end
+    if live.enabled ~= true then fail("sparse apply must preserve excluded settings") end
 end)
 
 test("save/apply round-trip; ghost keys wiped; name trimmed; empty rejected", function()


### PR DESCRIPTION
## Summary

- materialize named profile snapshots from shipped defaults
- overlay effective settings without losing default-backed keys
- reset settings omitted by sparse or older snapshots

## Root cause

The snapshot path iterated only stored keys, while AceDB-backed defaults may be visible through fallback. Applying a sparse snapshot also left unrelated overrides from the previous profile in place.

## Validation

- focused named-profile and starter-style tests pass
- regression covers default-backed saves and sparse applies
- all nine repository gates pass (838 unit files)