### PR TITLE
release: v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.0 - 2026-08-16
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+QUI 5.2 expands profile management, aura-display setup, and objective tracking
+while delivering a broad reliability pass for action bars, Cooldown Manager,
+group frames, and other combat-facing modules. The beta1 through beta6 entries
+below contain the complete fix-by-fix history.
+
+### Added
+
+- **Named account-wide nameplate profiles.** Create, rename, delete, assign by
+  specialization, import, and export nameplate setups. Existing per-spec
+  presets migrate automatically.
+- **Guided load conditions for aura displays.** Pick classes,
+  specializations, roles, and encounters from lists, with a faster display
+  list, quick creation, and a focused preview.
+- **Objective tracker styling.** Skin progress bars and recolor in-progress
+  bullets and completed-objective checkmarks.
+- **Quick feature toggles in the options sidebar.** Applicable feature
+  sections expose their master switch beside the section name.
+- **Group frame health and tracked-aura styling.** Set a custom health color
+  when class coloring is off, and configure tracked-aura bar orientation and
+  appearance.
+- **New 12.1 consumables in macro dropdowns.** Midnight potions, flasks, and
+  the Tides Vantus Rune are available to consumable macros.
+
+### Fixed
+
+- **Action bars stay responsive in combat.** Cooldowns, glows, pressed states,
+  icons, paging, stances, assisted-rotation indicators, and protected updates
+  now remain live or safely queue until combat ends.
+- **Cooldown Manager state stays accurate.** Spell variants, tracked buff
+  bars, tooltips, keybind labels, frame levels, row opacity, and in-combat
+  refreshes no longer drift or stall.
+- **Objective and Mythic+ trackers keep updating.** Skinned tracker geometry,
+  boss kills, objective names, and weighted progress catch up safely through
+  combat.
+- **Group frame colors and expiring aura bars update correctly.** Health tints
+  route through the shared feeder and tracked bars recolor during expiration.
+- **Bag overlays, dark-skinned mail, module-aware skinning, and community help
+  links work as intended.**
+
+### Changed
+
+- **Cooldown Manager mouseover detection does less per-frame work.** A
+  viewer's child list is built once per frame instead of once per child.
+
 ## v5.2.0-beta6 - 2026-08-16
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Load-on-demand diagnostics and profiling tools for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Logger/QUI_Logger.toc
+++ b/QUI_Logger/QUI_Logger.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Logger (dev)
 ## Notes: Dev-only event stream recorder. Not for release.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## SavedVariablesPerCharacter: QUI_LoggerDB

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.0-beta6
+## Version: 5.2.0
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,111 +8,39 @@ nav_order: 5
 
 This page summarizes the user-facing changes since the last mainline release. For every beta entry and technical fix, see the full [CHANGELOG.md](https://github.com/zol-wow/QUI/blob/main/CHANGELOG.md).
 
-## Current Release: 5.0.0
+## Current Release: 5.2.0
 
 {: .warning }
 **WoW 12.1 only.** This build targets patch 12.1 (interface 120100) and will not load on the 12.0.x client.
 
-QUI 5.0 rebuilds nameplates as their own addon, puts nameplates, group frames and unit frames on one shared aura engine, and cuts the suite from 22 addon folders to 11. It is also the release that adapts to 12.1's stricter rules about what an addon may read.
+QUI 5.2 expands profile management, aura-display setup, and objective tracking while delivering a broad reliability pass for action bars, Cooldown Manager, group frames, and other combat-facing modules.
 
 {: .important }
-Back up your `WTF` folder before installing beta builds. Manual installs must copy every `QUI*` folder from the release zip into `Interface\AddOns\`.
+Back up your `WTF` folder before updating. Manual installs must copy every `QUI*` folder from the release zip into `Interface\AddOns\`.
 
-## What's New in 5.0
+## What's New in 5.2
 
-### Nameplates
+### Profiles and setup
 
-- **Nameplates are their own addon**, with a setup wizard and a settings preview that renders a real plate 1:1 and follows whatever you are editing.
-- **Every plate type gets its own config** — pets and minions, friendly units, bosses and elites, minor and trivial units, enemy players and enemy NPCs — picked from a dropdown with a Copy From control.
-- **Target indicators** (arrow, brackets, glow line), class power pips on the target plate, execute-threshold health colouring, and threat colour mapping.
-- **A Visibility tab** with an enemy-plate master toggle, friendly NPCs exposed, and Minions nesting Guardians, Pets and Totems. `Show In Instances` is a never / name-only / always choice.
-- **Name-only is a real render mode** — QUI draws the name and hides the bar and aura containers rather than restyling Blizzard's text.
+- **Named account-wide nameplate profiles** can be created, assigned by specialization, imported, and exported.
+- **Aura displays have guided load-condition pickers** for classes, specializations, roles, and encounters, plus a faster create/list/preview workflow.
+- **Quick feature toggles in the options sidebar** keep module switches close to the settings they control.
 
-### Auras
+### Combat UI
 
-- **One aura engine drives nameplates, group frames and unit frames**, so an element configured on one behaves the same on the others.
-- **Pandemic glow** flashes an icon as its aura enters the refresh window, driven by the game's own pandemic region rather than a timer QUI approximates.
-- **Dispel borders and stealable buffs come from the game.** An aura element can be set to `Debuffs + Stealable Buffs` or `All Auras`.
+- **Action bars stay responsive in combat**, including cooldowns, glows, pressed states, assisted-rotation indicators, paging, stance changes, and special bars.
+- **Cooldown Manager tracking is more reliable** for spell variants, tracked buff bars, tooltips, keybind labels, frame levels, row opacity, and in-combat refreshes.
+- **Group frames gain custom health colors and tracked-aura bar controls**, including orientation, styling, and expiring-state colors.
 
-### Speed and size
+### Trackers and utility
 
-- **The suite is 11 addon folders instead of 22.** Locales ship packed, so only the language in use is ever compiled, and login memory drops by roughly 2.3 MB.
-- **Settings search is 2.5–3x faster.** One English index ships instead of ten translated copies; typing the English term still finds the translated row on non-English clients.
-- **The options panel opens instantly**, building on the first frame after login, and moving between settings tabs reuses the page it already built.
-
-### Localization
-
-- **Every non-English locale is actually translated now.** Nine of the ten had been falling back to English for roughly 900 strings each.
-
-### Adapting to 12.1
-
-- **Atonement tracking no longer reads the combat log** — 12.1 closed combat log events to addons, so the counter watches auras directly.
-- **The Brez counter lost its resurrection list** for the same reason. The charge count, recharge timer and per-pull tally are unaffected.
-
-## Major Additions
-
-### Modular QUI Suite
-
-- QUI is now split into feature addon folders.
-- The **Module Addons** page controls whole modules such as Chat, Bags, Info Bar, Alts, Group Frames, Damage Meter, Datatexts, Minimap, and Quality of Life.
-- Several large beta modules are off by default so existing setups can stay conservative.
-- The settings panel builds on the first frame after login, so it opens instantly.
-
-### QUI Chat
-
-- Optional QUI-owned chat display.
-- Multi-window chat, saved tabs, whisper conversation tabs, copy window, custom scrollbar, and tab overflow menu.
-- Combat Log can be embedded as a pinned chat tab.
-- Copy Chat preserves visible colors and readable link text.
-- Reply keybind, Battle.net notices, channel colors, guild message of the day, and cross-realm sender display received follow-up fixes.
-
-### QUI Bags
-
-- Optional bag, bank, Warband bank, and guild bank windows.
-- Search Everywhere across cached storage.
-- Item badges, category layout, sorting, junk tools, new-item glow, tooltip item counts, and optional currency bar.
-- Auction-house right-click selling support.
-- Guild bank **All** tab and cached bank/guild-bank browsing away from the bank.
-
-### Info Bar And Datatexts
-
-- Optional top or bottom Info Bar with left, center, and right widget zones.
-- Right-click empty Info Bar space to add, remove, arrange, or configure widgets.
-- New datatexts include Reputation, Great Vault, Mail, Professions, and Alts.
-- Currencies list is shared across Info Bar, minimap/data panels, Bags, and datatext surfaces.
-
-### Alts
-
-- Optional account-wide character tracker.
-- Roster, equipment, professions, reputations, weeklies, currencies, and item search tabs.
-- Equipment tab compares gear across characters.
-- Currency and reputation filters are available in-window and in settings.
-- Character storage moved into core so data collection can run independently of the Alts or Bags UI.
-
-### Damage Meter
-
-- Native QUI damage meter windows.
-- Per-window appearance editing, row breakdown popups, pinned self row, automatic key-start reset, current/overall/previous sessions, and reset command.
-- New toggle to hide secondary row values.
-
-## Important Improvements
-
-- Layout Mode anchored frames now follow live while dragging.
-- Anchored chat and damage meter windows keep their anchor pinned while resizing.
-- Chat windows no longer lose pending Layout Mode moves when chat settings change.
-- Minimap drawer now keeps collected buttons inside the drawer, including late-created buttons.
-- Action bars gained clearer enable toggles for micro menu and bag bar.
-- M+ timer gained objective alignment and bar-height controls.
-- Group frames gained private-aura text scale and additional stability work.
-- Character pane enchant and tooltip behavior received beta fixes.
-- CDM no longer auto-removes tracked spells just because the game temporarily reports them unknown; unusable entries go dormant and return when available.
-- Keyboard click-cast binds now activate only while hovering registered unit frames.
+- **The objective tracker has refreshed styling**, with improved icons and progress bars while preserving safe in-combat updates.
+- **The Mythic+ timer keeps boss, objective, and weighted progress data current** through combat.
+- **New 12.1 consumables and targeted mail, bag, tooltip, skinning, and help fixes** round out the release.
 
 ## Upgrade Notes
 
-- **4.x to 5.0 is an install over the top.** Same addon folders, same saved variables (`QUIDB` and `QUI_StorageDB`) — nothing to move by hand. Profiles migrate to the current schema on first login and are backed up beforehand; `/qui migration status` and `/qui migration restore` expose those backups.
-- Back up your `WTF` folder before installing an alpha or beta build.
+- Install 5.2 over the existing QUI folders; saved variables remain in `QUIDB` and `QUI_StorageDB`.
 - Manual installs must copy every top-level `QUI*` folder from the release zip, not only the `QUI` folder.
-- **If you hand-installed 5.0.0-alpha29 or earlier**, the eleven `QUI_OptionsSearch` folders are left behind after updating. Nothing loads them — delete them.
-- If a feature does not open, check `/qui` > **Module Addons** before troubleshooting settings.
+- If a feature does not open, check `/qui` > **Module Addons** before troubleshooting its settings.
 - Some account-cache data, especially offline inventory and equipment, repopulates as each character logs in.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ nav_order: 1
 A modular World of Warcraft UI suite for Midnight 12.1+ that you can install, understand, and tune from one settings experience.
 {: .fs-6 .fw-300 }
 
-**Current Release: 5.0.0**
+**Current Release: 5.2.0**
 {: .label .label-purple }
 
 [Get Started](getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }


### PR DESCRIPTION
## Release

- publish the stable v5.2.0 changelog
- stamp all 13 shipped TOCs at 5.2.0
- update the public documentation for 5.2.0

## Validation

- bash tools/test.sh (all nine gates passed)
- release-note extractor dry-run (47 lines; beta6 excluded)
- package manifest dry-run (10 sibling addons; 35 required paths)