### PR TITLE
fix(cdm): pair tracked bars through linked spell families

### DIFF
--- a/QUI_CDM/cdm/cdm_bar_renderer.lua
+++ b/QUI_CDM/cdm/cdm_bar_renderer.lua
@@ -411,6 +411,7 @@ local function NormalizeTrackedBarRuntimeEntries(runtimeEntries)
                     baseSpellID = baseSpellID,
                     overrideSpellID = entry.overrideSpellID,
                     linkedSpellID = entry.linkedSpellID,
+                    linkedSpellIDs = entry.linkedSpellIDs,
                     name = entry.name or "",
                     type = "spell",
                     kind = "aura",
@@ -451,7 +452,7 @@ local function AddTrackedSpellIdentity(out, value)
     out[tostring(value)] = true
 end
 
-local function BuildTrackedSpellIdentitySet(entry)
+local function BuildTrackedSpellIdentitySet(entry, includeLinkedSpellIDs)
     local out = {}
     if type(entry) ~= "table" then return out end
     AddTrackedSpellIdentity(out, entry.id)
@@ -459,6 +460,11 @@ local function BuildTrackedSpellIdentitySet(entry)
     AddTrackedSpellIdentity(out, entry.baseSpellID)
     AddTrackedSpellIdentity(out, entry.overrideSpellID)
     AddTrackedSpellIdentity(out, entry.itemID)
+    if includeLinkedSpellIDs and type(entry.linkedSpellIDs) == "table" then
+        for _, linkedSpellID in ipairs(entry.linkedSpellIDs) do
+            AddTrackedSpellIdentity(out, linkedSpellID)
+        end
+    end
     return out
 end
 
@@ -474,7 +480,7 @@ local function TrackedEntriesMatch(configured, runtime)
             return false
         end
     end
-    local runtimeIDs = BuildTrackedSpellIdentitySet(runtime)
+    local runtimeIDs = BuildTrackedSpellIdentitySet(runtime, runtime.linkedSpellID == nil)
     for id in pairs(configuredIDs) do
         if runtimeIDs[id] then
             return true
@@ -524,6 +530,7 @@ local function MergeTrackedRuntimeFields(configured, runtime)
     if out.baseSpellID == nil then out.baseSpellID = runtime.baseSpellID end
     if out.overrideSpellID == nil then out.overrideSpellID = runtime.overrideSpellID end
     out.linkedSpellID = runtime.linkedSpellID
+    out.linkedSpellIDs = runtime.linkedSpellIDs or out.linkedSpellIDs
     if (out.name == nil or out.name == "") and runtime.name then out.name = runtime.name end
     if out.iconTexture == nil then out.iconTexture = runtime.iconTexture end
     out.cooldownID = runtime.cooldownID

--- a/QUI_CDM/cdm/cdm_buff_layout.lua
+++ b/QUI_CDM/cdm/cdm_buff_layout.lua
@@ -510,10 +510,11 @@ end
 local function GetTrackedBarSpellData(frame)
     if not frame then return nil end
 
-    local resolvedSpellID, baseSpellID, overrideSpellID, linkedSpellID, name
+    local resolvedSpellID, baseSpellID, overrideSpellID, linkedSpellID, linkedSpellIDs, name
     local cdInfo = frame.cooldownInfo
     if cdInfo then
         linkedSpellID = ReadNumber(cdInfo.linkedSpellID, nil)
+        if type(cdInfo.linkedSpellIDs) == "table" then linkedSpellIDs = cdInfo.linkedSpellIDs end
         overrideSpellID = ReadNumber(cdInfo.overrideSpellID, nil)
         baseSpellID = ReadNumber(cdInfo.spellID, nil)
         name = ReadString(cdInfo.name, nil)
@@ -524,6 +525,9 @@ local function GetTrackedBarSpellData(frame)
         local apiInfo = ns.CDMCatalog and ns.CDMCatalog.GetCooldownInfo
             and ns.CDMCatalog.GetCooldownInfo(frame.cooldownID)
         if apiInfo then
+            if not linkedSpellIDs and type(apiInfo.linkedSpellIDs) == "table" then
+                linkedSpellIDs = apiInfo.linkedSpellIDs
+            end
             overrideSpellID = overrideSpellID or ReadNumber(apiInfo.overrideSpellID, nil)
             baseSpellID = baseSpellID or ReadNumber(apiInfo.spellID, nil)
             name = name or ReadString(apiInfo.name, nil)
@@ -559,6 +563,7 @@ local function GetTrackedBarSpellData(frame)
         baseSpellID = baseSpellID or resolvedSpellID,
         overrideSpellID = overrideSpellID,
         linkedSpellID = linkedSpellID,
+        linkedSpellIDs = linkedSpellIDs,
         name = name,
         cooldownID = frame.cooldownID,
     }
@@ -616,6 +621,7 @@ local function GetTrackedBarRuntimeEntries()
                     baseSpellID = spellData.baseSpellID,
                     overrideSpellID = spellData.overrideSpellID,
                     linkedSpellID = spellData.linkedSpellID,
+                    linkedSpellIDs = spellData.linkedSpellIDs,
                     name = spellData.name or "",
                     iconTexture = GetTrackedBarIconTexture(child, spellData),
                     cooldownID = spellData.cooldownID,

--- a/tests/unit/cdm_trackedbar_linked_variant_test.lua
+++ b/tests/unit/cdm_trackedbar_linked_variant_test.lua
@@ -41,12 +41,18 @@ check("GetTrackedBarSpellData must resolve linked before override before base",
 check("GetTrackedBarSpellData must return the linkedSpellID field",
     string.find(spellDataBody, "linkedSpellID = linkedSpellID", 1, true) ~= nil,
     "returned table does not carry linkedSpellID")
+check("GetTrackedBarSpellData must return the linkedSpellIDs family",
+    string.find(spellDataBody, "linkedSpellIDs = linkedSpellIDs", 1, true) ~= nil,
+    "returned table does not carry linkedSpellIDs")
 
 local runtimeBody = sliceFunction(layoutSrc, "GetTrackedBarRuntimeEntries()")
 
 check("runtime entries must carry spellData.linkedSpellID",
     string.find(runtimeBody, "linkedSpellID = spellData.linkedSpellID", 1, true) ~= nil,
     "entry table does not copy spellData.linkedSpellID")
+check("runtime entries must carry spellData.linkedSpellIDs",
+    string.find(runtimeBody, "linkedSpellIDs = spellData.linkedSpellIDs", 1, true) ~= nil,
+    "entry table does not copy spellData.linkedSpellIDs")
 
 check("harvest must enumerate the viewer item pool, never GetChildren",
     string.find(runtimeBody, "pool:EnumerateActive()", 1, true) ~= nil
@@ -148,6 +154,7 @@ local function variantConfig(sid)
     return {
         id = sid,
         spellID = sid,
+        linkedSpellIDs = { RTB_X, RTB_Y, RTB_Z },
         name = "Configured " .. sid,
         type = "spell",
         kind = "aura",
@@ -184,6 +191,17 @@ check("a base-spell config bound to a live variant must KEEP its configured name
     baseBound[1] and baseBound[1].name == "Configured " .. RTB_BASE,
     baseBound[1] and ("got name=%s -- the variant overlay is dead code, the mirror owns display"):format(
         tostring(baseBound[1].name)) or "no merged entry")
+
+local familyOnlyRuntime = liveVariantRuntime(nil)
+familyOnlyRuntime.spellID = 999999
+familyOnlyRuntime.baseSpellID = 999999
+familyOnlyRuntime.linkedSpellIDs = { RTB_X, RTB_Y, RTB_Z }
+local familyConfig = variantConfig(RTB_Y)
+familyConfig.cooldownID = nil
+local familyBound = buildTracked({ familyOnlyRuntime }, { familyConfig }, true)
+check("a linked-family config must bind while the live singular variant is secret",
+    familyBound[1] and familyBound[1]._trackedBarRuntime == true,
+    "linkedSpellIDs were dropped, so the live Blizzard frame never reaches the mirror sinks")
 
 local mergeBody = sliceFunction(rendererSrc, "MergeTrackedRuntimeFields(configured, runtime)")
 check("the merge must not overlay name or icon from the live variant",


### PR DESCRIPTION
## Summary

- preserve the documented `linkedSpellIDs` family while harvesting native buff bars
- use the family during tracked-bar identity pairing when the live singular variant is secret
- add a Roll the Bones regression for configured entries without `cooldownID`

## Verification

- `bash tools/test.sh` — ALL GATES PASSED (9/9, 838 unit files)
- `lua tests/unit/cdm_trackedbar_linked_variant_test.lua` — 0 failures
- mutation proof: the new regression failed before the source fix
- `graphify update .` — graph rebuilt