### PR TITLE
Harden secret-value handling and apply character pane layout in combat

### DIFF
--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -738,39 +738,6 @@ local function ScheduleCooldownExpiryRefreshAt(icon, key, expiresAt)
     end
 end
 
-local function ScheduleCooldownExpiryRefresh(icon, key, cdInfo)
-    if not icon or not key or not cdInfo or not C_Timer then return end
-    if not GetTime then return end
-
-    local getCooldownInfoField = Resolvers and Resolvers.GetCooldownInfoField
-    if not getCooldownInfoField then return end
-
-    local start, startSecret = getCooldownInfoField(cdInfo, "startTime")
-    if not startSecret and start == nil then
-        start, startSecret = getCooldownInfoField(cdInfo, "start")
-    end
-    local duration, durationSecret = getCooldownInfoField(cdInfo, "duration")
-    if startSecret or durationSecret
-        or (issecretvalue and (issecretvalue(start) or issecretvalue(duration))) then
-        if icon._cooldownExpiryTimerKey and icon._cooldownExpiryTimerKey ~= key then
-            CancelCooldownExpiryRefresh(icon)
-        end
-        return
-    end
-    if type(start) ~= "number" or type(duration) ~= "number" then
-        if icon._cooldownExpiryTimerKey and icon._cooldownExpiryTimerKey ~= key then
-            CancelCooldownExpiryRefresh(icon)
-        end
-        return
-    end
-    if start <= 0 or duration <= 0 then
-        CancelCooldownExpiryRefresh(icon)
-        return
-    end
-
-    ScheduleCooldownExpiryRefreshAt(icon, key, start + duration)
-end
-
 function _resolverRuntimePolicy.IsRealCooldownDurationMode(mode)
     return mode == "cooldown"
         or mode == "item-cooldown"
@@ -1089,7 +1056,6 @@ ApplyResolvedCooldown = function(icon, preResolvedState)
     end
 
     local cdActive = mode ~= "inactive" and resolvedState.isOnCooldown == true
-    local resolvedCdInfo = resolvedState.cooldownInfo
     local _dbgIsActive = resolvedState.cooldownInfoActive
     local _dbgIsOnGCD = resolvedState.cooldownInfoOnGCD
 
@@ -1180,19 +1146,14 @@ ApplyResolvedCooldown = function(icon, preResolvedState)
         return false
     end
 
-    local shouldScheduleExpiry = (mode == "aura" and hasNumericCooldown == true)
-        or (cdActive == true
-            and (resolvedCdInfo ~= nil or hasNumericCooldown)
-            and (mode == "cooldown" or mode == "item-cooldown"))
+    local shouldScheduleExpiry = hasNumericCooldown == true
+        and (mode == "aura"
+            or (cdActive == true and (mode == "cooldown" or mode == "item-cooldown")))
     local sameDurationBinding = DurationBindingMatches(icon, mode, keySource, durObj)
     if sameDurationBinding then
         if shouldScheduleExpiry then
             local key = GetDurationBindingKey(icon, mode, keySource)
-            if resolvedCdInfo then
-                ScheduleCooldownExpiryRefresh(icon, key, resolvedCdInfo)
-            else
-                ScheduleCooldownExpiryRefreshAt(icon, key, resolvedStart + resolvedDuration)
-            end
+            ScheduleCooldownExpiryRefreshAt(icon, key, resolvedStart + resolvedDuration)
         else
             CancelCooldownExpiryRefresh(icon)
         end
@@ -1252,11 +1213,7 @@ ApplyResolvedCooldown = function(icon, preResolvedState)
     end
 
     if shouldScheduleExpiry then
-        if resolvedCdInfo then
-            ScheduleCooldownExpiryRefresh(icon, key, resolvedCdInfo)
-        else
-            ScheduleCooldownExpiryRefreshAt(icon, key, resolvedStart + resolvedDuration)
-        end
+        ScheduleCooldownExpiryRefreshAt(icon, key, resolvedStart + resolvedDuration)
     else
         CancelCooldownExpiryRefresh(icon)
     end

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -193,10 +193,11 @@ local function CleanOpaqueValue(value)
 end
 
 function CDMResolvers.GetCooldownInfoField(info, key)
-    if not info then return nil, false end
+    if ResolverIsSecretValue(info) then return nil, true end -- @secret-policy: reject-secret-value
+    if info == nil then return nil, false end
     local value = info[key]
     if ResolverIsSecretValue(value) then
-        return value, true
+        return nil, true -- @secret-policy: reject-secret-value
     end
     if value == nil then return nil, false end
     return value, false
@@ -468,10 +469,6 @@ local function IsSupportedMirrorMode(mode)
         or mode == "item-cooldown"
         or mode == "gcd-only"
         or mode == "inactive"
-end
-
-local function ShouldRenderLiveGCD(currentOnGCD)
-    return currentOnGCD == true
 end
 
 function CDMResolvers.GetSpellCastInfo(spellID)
@@ -1100,10 +1097,10 @@ local QueryItemCooldown
 local QuerySlotCooldown
 
 local function BuildDurationObjectFromStart(startTime, duration)
-    local startSecret = ResolverIsSecretValue(startTime)
-    local durationSecret = ResolverIsSecretValue(duration)
-    if not startSecret and startTime == nil then return nil end
-    if not durationSecret and duration == nil then return nil end
+    if ResolverIsSecretValue(startTime) or ResolverIsSecretValue(duration) then
+        return nil -- @secret-policy: reject-secret-value
+    end
+    if startTime == nil or duration == nil then return nil end
     if not (C_DurationUtil and C_DurationUtil.CreateDuration) then return nil end
 
     local okCreate, durObj = pcall(C_DurationUtil.CreateDuration)
@@ -1292,6 +1289,11 @@ QueryItemCooldown = function(itemID)
         return nil, nil, nil
     end
     local startTime, duration, enabled = Sources.QueryItemCooldown(itemID)
+    if ResolverIsSecretValue(startTime)
+        or ResolverIsSecretValue(duration)
+        or ResolverIsSecretValue(enabled) then
+        return nil, nil, nil -- @secret-policy: reject-secret-value
+    end
     return startTime, duration, enabled
 end
 
@@ -1301,7 +1303,13 @@ QuerySlotCooldown = function(slotID)
     if not slotID or not _GetInventoryItemCooldown then
         return nil, nil, nil
     end
-    return _GetInventoryItemCooldown("player", slotID)
+    local startTime, duration, enabled = _GetInventoryItemCooldown("player", slotID)
+    if ResolverIsSecretValue(startTime)
+        or ResolverIsSecretValue(duration)
+        or ResolverIsSecretValue(enabled) then
+        return nil, nil, nil -- @secret-policy: reject-secret-value
+    end
+    return startTime, duration, enabled
 end
 
 function CDMResolvers.BuildEntryItemDurationObject(entry)
@@ -1913,18 +1921,18 @@ local function ResolveCooldownStateCore(context)
 
     do
         local cdInfo = gcdCdInfo or QueryCooldown(sid)
-        local cdInfoActive = cdInfo and IsCooldownInfoActive(cdInfo)
+        local cdInfoActive = IsCooldownInfoActive(cdInfo)
         if cdInfoActive ~= false then
             local cdInfoOnGCD = GetCurrentIsOnGCD(cdInfo)
             local durObj = QueryDuration(sid)
-            local renderLiveGCD = ShouldRenderLiveGCD(cdInfoOnGCD)
-            if durObj and not renderLiveGCD then
+            state.cooldownInfoActive = cdInfoActive
+            state.cooldownInfoOnGCD = cdInfoOnGCD
+            if durObj then
                 state.mode = "cooldown"
                 SetCooldownStateActivity(state, true)
                 state.durObj = durObj
                 state.sourceID = sid
                 state.spellID = sid
-                state.cooldownInfo = cdInfo
                 MemAuditProfilerMark("CDM_rsReturnLiveCD")
                 return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
             end
@@ -1936,18 +1944,7 @@ local function ResolveCooldownStateCore(context)
                     state.durObj = gcdDur
                     state.sourceID = sid
                     state.spellID = sid
-                    state.cooldownInfo = cdInfo
                     MemAuditProfilerMark("CDM_rsReturnGCD")
-                    return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
-                end
-                if durObj and renderLiveGCD then
-                    state.mode = "gcd-only"
-                    SetCooldownStateActivity(state, true)
-                    state.durObj = durObj
-                    state.sourceID = sid
-                    state.spellID = sid
-                    state.cooldownInfo = cdInfo
-                    MemAuditProfilerMark("CDM_rsReturnGCDDur")
                     return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
                 end
             end
@@ -1961,7 +1958,7 @@ local function ResolveCooldownStateCore(context)
         state.durObj = gcdDurObj
         state.sourceID = sid
         state.spellID = sid
-        state.cooldownInfo = gcdCdInfo
+        state.cooldownInfoOnGCD = currentOnGCD
         MemAuditProfilerMark("CDM_rsReturnGCDCached")
         return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
     end

--- a/QUI_CDM/cdm/cdm_runtime_queries.lua
+++ b/QUI_CDM/cdm/cdm_runtime_queries.lua
@@ -206,6 +206,9 @@ function CDMRuntimeQueries.QueryCooldown(spellID, owner)
     if Sources and Sources.QuerySpellCooldown then
         info = Sources.QuerySpellCooldown(spellID)
     end
+    if IsSecretValue(info) then
+        info = nil
+    end
     return StoreRuntimeCache("cooldown", owner, spellID, info, "cooldownSource")
 end
 

--- a/QUI_CDM/cdm/cdm_sources.lua
+++ b/QUI_CDM/cdm/cdm_sources.lua
@@ -422,7 +422,21 @@ local _C_GetCooldownAuraBySpellID = C_UnitAuras and C_UnitAuras.GetCooldownAuraB
 local _C_GetAuraDataBySpellName = C_UnitAuras and C_UnitAuras.GetAuraDataBySpellName
 local _C_GetUnitAuras = C_UnitAuras and C_UnitAuras.GetUnitAuras
 
+local _opaqueAuraPresence = {}
+
+local function NormalizeAuraDataResult(result)
+    if WoW_IsSecretValue and WoW_IsSecretValue(result) then
+        return _opaqueAuraPresence
+    end
+    return result
+end
+
+function CDMSources.IsOpaqueAuraPresence(value)
+    return value == _opaqueAuraPresence
+end
+
 local function EnforceAuraFilterPolarity(result, filter)
+    result = NormalizeAuraDataResult(result)
     if result == nil or filter == nil then return result end
     local wantHelpful = string.find(filter, "HELPFUL", 1, true) ~= nil
     local wantHarmful = string.find(filter, "HARMFUL", 1, true) ~= nil
@@ -433,7 +447,7 @@ local function EnforceAuraFilterPolarity(result, filter)
     else
         field = result.isHarmful
     end
-    if issecretvalue and issecretvalue(field) then return result end
+    if WoW_IsSecretValue and WoW_IsSecretValue(field) then return _opaqueAuraPresence end
     if field == nil then return result end
     if field then return result end
     return nil
@@ -472,6 +486,7 @@ local function AuraMemoGet(unit, bucketKey, id)
 end
 
 local function AuraMemoStore(unit, bucketKey, id, result)
+    if result == _opaqueAuraPresence then return end
     local u = _auraMemo[unit]
     if not u then u = {}; _auraMemo[unit] = u end
     local b = u[bucketKey]
@@ -495,7 +510,7 @@ end
 function CDMSources.QueryAuraDataByAuraInstanceID(unit, auraInstanceID)
     if not unit or not HasOpaqueValue(auraInstanceID) or not _C_GetAuraDataByAuraInstanceID then return nil end
     if AreAurasSecret() then return nil end
-    return _C_GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+    return NormalizeAuraDataResult(_C_GetAuraDataByAuraInstanceID(unit, auraInstanceID))
 end
 
 function CDMSources.QueryAuraHasExpirationTime(unit, auraInstanceID)
@@ -538,12 +553,12 @@ function CDMSources.QueryPlayerAuraBySpellID(spellID)
         local bucketKey = _auraMemoBucket.playerBySpell.n
         local v, hit = AuraMemoGet("player", bucketKey, spellID)
         if hit then return v end
-        local result = _C_GetPlayerAuraBySpellID(spellID)
+        local result = NormalizeAuraDataResult(_C_GetPlayerAuraBySpellID(spellID))
         AuraMemoStore("player", bucketKey, spellID, result)
         return result
     end
     if auraMemoStats then auraMemoStats.bypass = auraMemoStats.bypass + 1 end
-    return _C_GetPlayerAuraBySpellID(spellID)
+    return NormalizeAuraDataResult(_C_GetPlayerAuraBySpellID(spellID))
 end
 
 function CDMSources.QueryAuraDataBySpellID(unit, spellID, filter)
@@ -553,7 +568,7 @@ function CDMSources.QueryAuraDataBySpellID(unit, spellID, filter)
         if bucketKey then
             local v, hit = AuraMemoGet(unit, bucketKey, spellID)
             if hit then return v end
-            local result = _C_GetAuraDataBySpellID(unit, spellID, filter)
+            local result = NormalizeAuraDataResult(_C_GetAuraDataBySpellID(unit, spellID, filter))
             if _auraDataFallbackNeedsPolarity then
                 result = EnforceAuraFilterPolarity(result, filter)
             end
@@ -562,7 +577,7 @@ function CDMSources.QueryAuraDataBySpellID(unit, spellID, filter)
         end
     end
     if auraMemoStats then auraMemoStats.bypass = auraMemoStats.bypass + 1 end
-    local result = _C_GetAuraDataBySpellID(unit, spellID, filter)
+    local result = NormalizeAuraDataResult(_C_GetAuraDataBySpellID(unit, spellID, filter))
     if _auraDataFallbackNeedsPolarity then
         result = EnforceAuraFilterPolarity(result, filter)
     end
@@ -581,13 +596,13 @@ function CDMSources.QueryAuraDataBySpellName(unit, name, filter)
         if bucketKey then
             local v, hit = AuraMemoGet(unit, bucketKey, name)
             if hit then return v end
-            local result = _C_GetAuraDataBySpellName(unit, name, filter)
+            local result = NormalizeAuraDataResult(_C_GetAuraDataBySpellName(unit, name, filter))
             AuraMemoStore(unit, bucketKey, name, result)
             return result
         end
     end
     if auraMemoStats then auraMemoStats.bypass = auraMemoStats.bypass + 1 end
-    return _C_GetAuraDataBySpellName(unit, name, filter)
+    return NormalizeAuraDataResult(_C_GetAuraDataBySpellName(unit, name, filter))
 end
 
 function CDMSources.QueryUnitAuras(unit, filter, maxCount)

--- a/QUI_CDM/cdm/cdm_spelldata.lua
+++ b/QUI_CDM/cdm/cdm_spelldata.lua
@@ -809,6 +809,10 @@ end
 
 local function AuraDataMatchesFilter(unit, auraData, filter, filterWasApplied)
     if not auraData then return false end
+    if Sources and Sources.IsOpaqueAuraPresence
+        and Sources.IsOpaqueAuraPresence(auraData) then
+        return true
+    end
     if type(filter) ~= "string" or filter == "" then
         return true
     end
@@ -1113,7 +1117,8 @@ local function FormatTotemSlotScan()
     wipe(_totemScanReport)
     for slot = 1, slotCount do
         local hasTotem, _, _, _, _, _, totemSpellID = GetTotemInfo(slot)
-        if IsUsableTableKey(hasTotem) then
+        if issecretvalue and issecretvalue(hasTotem) then hasTotem = nil end
+        if hasTotem == true then
             -- @secret-safe: guarded by IsUsableSpellIDKey, which probes issecretvalue and rejects secrets; the analyzer is non-interprocedural and cannot see through the helper
             local shown = IsUsableSpellIDKey(totemSpellID) and tostring(totemSpellID) or "?"
             _totemScanReport[#_totemScanReport + 1] = tostring(slot) .. ":" .. shown
@@ -1131,7 +1136,8 @@ local function FindTotemSlotForSpellIDs(...)
     if #candidates == 0 then return nil end
     for slot = 1, slotCount do
         local hasTotem, _, _, _, _, _, totemSpellID = GetTotemInfo(slot)
-        if IsUsableTableKey(hasTotem) and IsUsableSpellIDKey(totemSpellID) then
+        if issecretvalue and issecretvalue(hasTotem) then hasTotem = nil end
+        if hasTotem == true and IsUsableSpellIDKey(totemSpellID) then
             for i = 1, #candidates do
                 -- @secret-safe: both operands cleared IsUsableSpellIDKey, which probes issecretvalue and rejects secrets; the analyzer is non-interprocedural and cannot see through the helper
                 if candidates[i] == totemSpellID then
@@ -1147,13 +1153,17 @@ local function ResolveVirtualAuraState(explicitSlot)
     local slot = SafeMaybeNumber(explicitSlot)
     local state = { slot = slot }
 
-    if slot and GetTotemInfo then
-        local _, totemName, _, _, totemIcon = GetTotemInfo(slot)
-        state.totemName = totemName
-        state.totemIcon = totemIcon
-    end
+    if not (slot and GetTotemInfo) then return state end
 
-    if slot and GetTotemDuration then
+    local haveTotem, totemName, _, _, totemIcon = GetTotemInfo(slot)
+    if issecretvalue and issecretvalue(haveTotem) then return state end
+    if haveTotem ~= true then return state end
+    if issecretvalue and issecretvalue(totemName) then totemName = nil end
+    if issecretvalue and issecretvalue(totemIcon) then totemIcon = nil end
+    state.totemName = totemName
+    state.totemIcon = totemIcon
+
+    if GetTotemDuration then
         local durObj = GetTotemDuration(slot)
         if durObj and type(durObj) ~= "number" then
             state.isActive = true

--- a/modules/skinning/character_pane/character.lua
+++ b/modules/skinning/character_pane/character.lua
@@ -23,10 +23,7 @@ local function GetSkinBase()
     return ns.SkinBase
 end
 
-local pendingDecorMode = nil
 local pendingStatsPanelRefresh = false
-local pendingCharacterFrameScale = nil
-local pendingPaneLayout = false
 local ScheduleUpdate
 local ApplyCharacterPaneLayout
 
@@ -54,41 +51,9 @@ end
 local charCombatFrame = CreateFrame("Frame")
 charCombatFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 charCombatFrame:SetScript("OnEvent", function()
-    if pendingCharacterFrameScale then
-        if CharacterFrame then CharacterFrame:SetScale(pendingCharacterFrameScale) end
-        pendingCharacterFrameScale = nil
-    end
-
     if not CharacterFrame or not CharacterFrame:IsShown() then
-        pendingDecorMode = nil
         pendingStatsPanelRefresh = false
-        pendingPaneLayout = false
         return
-    end
-
-    if pendingPaneLayout then
-        pendingPaneLayout = false
-        if ApplyCharacterPaneLayout then ApplyCharacterPaneLayout(true) end
-    end
-
-    if pendingDecorMode then
-        local skinHandles = _G.QUI_CharacterFrameSkinning
-        if pendingDecorMode == "other" then
-            if not (skinHandles and skinHandles.SetExtended) then
-                if CharacterFramePortrait then CharacterFramePortrait:Show() end
-                if CharacterFrame.Background then CharacterFrame.Background:Show() end
-                if CharacterFrame.NineSlice then CharacterFrame.NineSlice:Show() end
-                if CharacterFrameBg then CharacterFrameBg:Show() end
-            end
-        elseif pendingDecorMode == "character" then
-            if not (skinHandles and skinHandles.SetExtended) then
-                if CharacterFramePortrait then CharacterFramePortrait:Hide() end
-                if CharacterFrame.Background then CharacterFrame.Background:Hide() end
-                if CharacterFrame.NineSlice then CharacterFrame.NineSlice:Hide() end
-                if CharacterFrameBg then CharacterFrameBg:Hide() end
-            end
-        end
-        pendingDecorMode = nil
     end
 
     if pendingStatsPanelRefresh then
@@ -101,10 +66,6 @@ end)
 
 local function SetCharacterFrameScale(scale)
     if not CharacterFrame then return end
-    if InCombatLockdown() then
-        pendingCharacterFrameScale = scale
-        return
-    end
     CharacterFrame:SetScale(scale)
 end
 
@@ -1337,11 +1298,6 @@ local function IsSkinningHandlingBackground()
 end
 
 local function HideBlizzardDecorations()
-    if InCombatLockdown() then
-        pendingPaneLayout = true
-        return
-    end
-
     local settings = GetSettings()
 
     if CharacterFrame.TopTileStreaks then CharacterFrame.TopTileStreaks:Hide() end
@@ -1599,11 +1555,6 @@ local RIGHT_COLUMN_SLOTS = {
 }
 
 local function RepositionSlots()
-    if InCombatLockdown() then
-        pendingPaneLayout = true
-        return
-    end
-
     local settings = GetSettings()
     if not CharacterFrameBg then return end
 
@@ -1798,24 +1749,16 @@ ApplyCharacterPaneLayout = function(force)
 
     if layoutApplied and not force then return end
 
-    local inCombat = InCombatLockdown()
-    if inCombat then
-        pendingPaneLayout = true
-    else
-        HideBlizzardDecorations()
-    end
-
+    HideBlizzardDecorations()
     CreateCustomBackground()
     SetupTitleArea()
 
-    if not inCombat then
-        RunAfterCharacterPaneLayoutTick(function()
-            RepositionSlots()
-            RefreshEquipmentSlotBorders()
-            PositionModelScene()
-            PositionStatsPanelForLayout()
-        end)
-    end
+    RunAfterCharacterPaneLayoutTick(function()
+        RepositionSlots()
+        RefreshEquipmentSlotBorders()
+        PositionModelScene()
+        PositionStatsPanelForLayout()
+    end)
 
     layoutApplied = true
 end
@@ -3455,14 +3398,10 @@ local function HookCharacterFrame()
             end
         else
             if customBg then customBg:Hide() end
-            if InCombatLockdown() then
-                pendingDecorMode = "other"
-            else
-                if CharacterFramePortrait then CharacterFramePortrait:Show() end
-                if CharacterFrame.Background then CharacterFrame.Background:Show() end
-                if CharacterFrame.NineSlice then CharacterFrame.NineSlice:Show() end
-                if CharacterFrameBg then CharacterFrameBg:Show() end
-            end
+            if CharacterFramePortrait then CharacterFramePortrait:Show() end
+            if CharacterFrame.Background then CharacterFrame.Background:Show() end
+            if CharacterFrame.NineSlice then CharacterFrame.NineSlice:Show() end
+            if CharacterFrameBg then CharacterFrameBg:Show() end
         end
 
         SetCharacterFrameScale(1.0)
@@ -3501,14 +3440,10 @@ local function HookCharacterFrame()
                     end
                 else
                     if customBg then customBg:Show() end
-                    if InCombatLockdown() then
-                        pendingDecorMode = "character"
-                    else
-                        if CharacterFramePortrait then CharacterFramePortrait:Hide() end
-                        if CharacterFrame.Background then CharacterFrame.Background:Hide() end
-                        if CharacterFrame.NineSlice then CharacterFrame.NineSlice:Hide() end
-                        if CharacterFrameBg then CharacterFrameBg:Hide() end
-                    end
+                    if CharacterFramePortrait then CharacterFramePortrait:Hide() end
+                    if CharacterFrame.Background then CharacterFrame.Background:Hide() end
+                    if CharacterFrame.NineSlice then CharacterFrame.NineSlice:Hide() end
+                    if CharacterFrameBg then CharacterFrameBg:Hide() end
                 end
 
                 MaskNativeStatsPane()

--- a/tests/unit/cdm_resolvers_aura_active_state_test.lua
+++ b/tests/unit/cdm_resolvers_aura_active_state_test.lua
@@ -16,6 +16,7 @@ end
 local capturedLookupIDs
 local capturedLookupName
 local queriedSpellIDs = {}
+local opaqueAuraPresence = {}
 
 local ns = {
     Helpers = {},
@@ -24,6 +25,9 @@ local ns = {
             queriedSpellIDs[#queriedSpellIDs + 1] = spellID
             if spellID == 20002 then
                 return { auraInstanceID = 9002 }
+            end
+            if spellID == 10003 then
+                return opaqueAuraPresence
             end
             return nil
         end,
@@ -79,5 +83,15 @@ assert(unit == "player", "direct aura lookup should report player unit")
 assert(instanceID == 9002, "direct aura lookup should return auraInstanceID")
 assert(queriedSpellIDs[1] == 10002, "direct lookup should try configured ID first")
 assert(queriedSpellIDs[2] == 20002, "direct lookup should fall back to mapped aura ID")
+
+active, unit, instanceID = resolve({
+    spellID = 10003,
+    id = 10003,
+    name = "Opaque Aura",
+})
+
+assert(active == true, "clean opaque presence should keep the custom aura active")
+assert(unit == "player", "clean opaque presence should retain the queried unit")
+assert(instanceID == nil, "clean opaque presence must not invent an auraInstanceID")
 
 print("OK: cdm_resolvers_aura_active_state_test")

--- a/tests/unit/cdm_resolvers_cooldown_state_test.lua
+++ b/tests/unit/cdm_resolvers_cooldown_state_test.lua
@@ -23,6 +23,8 @@ local gcdDur = { token = "gcd-dur" }
 local itemAuraDur = { token = "item-aura-dur" }
 local secretItemStart = { token = "secret-item-start" }
 local secretItemDuration = { token = "secret-item-duration" }
+local secretCooldownStart = { token = "secret-cooldown-start" }
+local secretCooldownDuration = { token = "secret-cooldown-duration" }
 local secretChargeZero = { token = "secret-current-charges", value = 0 }
 local secretChargeOne = { token = "secret-current-charges", value = 1 }
 local secretChargeUnknown = { token = "secret-current-charges", value = "unknown" }
@@ -38,6 +40,8 @@ function issecretvalue(value)
         or value == secretChargeUnknown
         or value == secretItemStart
         or value == secretItemDuration
+        or value == secretCooldownStart
+        or value == secretCooldownDuration
 end
 
 Enum = { LuaCurveType = { Step = "Step" } }
@@ -232,6 +236,14 @@ local ns = {
             if spellID == 70001 then
                 return { isActive = true, isOnGCD = true }
             end
+            if spellID == 70002 then
+                return {
+                    isActive = true,
+                    isOnGCD = true,
+                    startTime = secretCooldownStart,
+                    duration = secretCooldownDuration,
+                }
+            end
             if spellID == 91004 and itemUseSpellCooldownActive then
                 return { isActive = true, isOnGCD = false }
             end
@@ -240,6 +252,9 @@ local ns = {
         QuerySpellCooldownDuration = function(spellID, ignoreGCD)
             if spellID == 70001 and ignoreGCD == false then
                 return gcdDur
+            end
+            if spellID == 70002 then
+                return ignoreGCD == true and cooldownDur or gcdDur
             end
             -- 60011: a GCD duration is available (a GCD swipe would otherwise be
             -- drawn) so the test proves the active recharge wins over it.
@@ -708,6 +723,21 @@ assert(state.gcdOnly == true, "GCD-only state should publish gcdOnly")
 assert(state.isGCDOnly == true, "GCD-only state should publish isGCDOnly")
 assert(state.isRealCooldownMode == false, "GCD-only state should not publish real cooldown mode")
 
+state = resolve({
+    entry = cooldownEntry(70002),
+    runtimeSpellID = 70002,
+    containerKey = "essential",
+    useBuffSwipe = false,
+    showGCDSwipe = true,
+})
+
+assert(state.mode == "cooldown", "a real ignore-GCD duration should outrank isOnGCD")
+assert(state.durObj == cooldownDur, "real cooldown should bind its ignore-GCD DurationObject")
+assert(state.cooldownInfo == nil, "resolved state must not retain SpellCooldownInfo")
+assert(state.start == nil and state.duration == nil, "secret cooldown timing must not enter resolved state")
+local secretField, wasSecret = resolvers.GetCooldownInfoField({ startTime = secretCooldownStart }, "startTime")
+assert(secretField == nil and wasSecret == true, "secret cooldown fields must be discarded at read time")
+
 itemAuraActive = true
 itemCooldownActive = false
 state = resolve({
@@ -943,15 +973,12 @@ state = resolve({
     showGCDSwipe = true,
 })
 
-assert(state.mode == "item-cooldown", "secret item timing should still resolve as an item cooldown")
-assert(state.isOnCooldown == true, "secret item DurationObject should publish cooldown activity")
-assert(state.durObj == createdDurationObjects[1],
-    "secret item timing should be passed through a DurationObject")
-assert(state.numericCooldownActive == nil, "secret item timing must not publish numeric cooldown timing")
-assert(state.start == nil and state.duration == nil, "secret item timing must not be exposed as SetCooldown timing")
-assert(durationObjectSetCalls[1].start == secretItemStart
-    and durationObjectSetCalls[1].duration == secretItemDuration,
-    "secret item cooldown values should pass directly into DurationObject setup")
+assert(state.mode == "inactive", "secret item timing should be rejected")
+assert(state.isOnCooldown == false, "rejected secret item timing must not publish cooldown activity")
+assert(state.durObj == nil, "rejected secret item timing must not create a DurationObject")
+assert(state.start == nil and state.duration == nil, "secret item timing must not enter resolved state")
+assert(#createdDurationObjects == 0 and #durationObjectSetCalls == 0,
+    "secret item timing must never reach DurationObject construction")
 
 createdDurationObjects = {}
 durationObjectSetCalls = {}

--- a/tests/unit/cdm_resolvers_runtime_query_cache_test.lua
+++ b/tests/unit/cdm_resolvers_runtime_query_cache_test.lua
@@ -27,9 +27,12 @@ local durationObject = { token = "cooldown-duration" }
 local chargeDurationObject = { token = "charge-duration" }
 local secretDisplayCount = { token = "secret-display-count" }
 local secretSpellCount = { token = "secret-spell-count" }
+local secretCooldownInfo = { token = "secret-cooldown-info" }
 
 function issecretvalue(value)
-    return rawequal(value, secretDisplayCount) or rawequal(value, secretSpellCount)
+    return rawequal(value, secretDisplayCount)
+        or rawequal(value, secretSpellCount)
+        or rawequal(value, secretCooldownInfo)
 end
 
 local ns = {
@@ -44,6 +47,7 @@ local ns = {
         QuerySpellCooldown = function(spellID)
             cooldownCalls = cooldownCalls + 1
             if spellID == 101 then return cooldownInfo end
+            if spellID == 303 then return secretCooldownInfo end
             return nil
         end,
         QuerySpellCharges = function(spellID)
@@ -208,6 +212,18 @@ assert(spellCountCalls == 2,
 runtime.QueryCooldown(101)
 assert(cooldownCalls == 7,
     "ending a batch should restore live cooldown reads")
+
+local secretCooldownCalls = cooldownCalls
+assert(runtime.QueryCooldown(303) == nil,
+    "whole-secret cooldown info should be rejected before resolver consumers")
+runtime.BeginRuntimeQueryBatch()
+assert(runtime.QueryCooldown(303) == nil,
+    "whole-secret cooldown info should stay rejected in a batch")
+assert(runtime.QueryCooldown(303) == nil,
+    "rejected whole-secret cooldown info should cache as nil within a batch")
+runtime.EndRuntimeQueryBatch()
+assert(cooldownCalls == secretCooldownCalls + 2,
+    "whole-secret cooldown info should use one source read outside and one inside the batch")
 
 runtime.BeginRuntimeQueryBatch()
 assert(runtime.QueryOverrideSpell(101) == 202,

--- a/tests/unit/cdm_sources_secret_aura_gate_test.lua
+++ b/tests/unit/cdm_sources_secret_aura_gate_test.lua
@@ -31,7 +31,18 @@ C_Secrets = {
     ShouldAurasBeSecret = function() return aurasSecret end,
 }
 
-local calls = { duration = 0, data = 0, expiration = 0, filtered = 0, appCount = 0, unitAuras = 0, bySpell = 0 }
+local calls = {
+    duration = 0,
+    data = 0,
+    expiration = 0,
+    filtered = 0,
+    appCount = 0,
+    unitAuras = 0,
+    bySpell = 0,
+    playerBySpell = 0,
+    dataBySpell = 0,
+    byName = 0,
+}
 
 local function instanceGetter(counterKey, result)
     return function(...)
@@ -45,18 +56,43 @@ end
 
 local durationToken = { token = "duration" }
 local auraDataToken = { token = "aura-data" }
+local wholeSecretAura = SecretSentinel.MakeSecretSentinel()
+local secretPolarity = { token = "secret-polarity" }
+local auraWithSecretPolarity = { isHelpful = secretPolarity }
+secretValues[wholeSecretAura] = true
+secretValues[secretPolarity] = true
 
 C_UnitAuras = {
     GetAuraDuration = instanceGetter("duration", durationToken),
-    GetAuraDataByAuraInstanceID = instanceGetter("data", auraDataToken),
+    GetAuraDataByAuraInstanceID = function(_unit, auraInstanceID)
+        if aurasSecret then
+            error("data(): Auras cannot be accessed when secret while tainted")
+        end
+        calls.data = calls.data + 1
+        return auraInstanceID == 777 and wholeSecretAura or auraDataToken
+    end,
     DoesAuraHaveExpirationTime = instanceGetter("expiration", true),
     IsAuraFilteredOutByInstanceID = instanceGetter("filtered", false),
     GetAuraApplicationDisplayCount = instanceGetter("appCount", 3),
     GetUnitAuras = instanceGetter("unitAuras", { auraDataToken }),
-    GetUnitAuraBySpellID = function(_unit, _spellID, _filter)
+    GetUnitAuraBySpellID = function(_unit, spellID, _filter)
         -- Spell getters never throw; they return (possibly secret) AuraData.
         calls.bySpell = calls.bySpell + 1
+        if spellID == 101 then return wholeSecretAura end
+        if spellID == 102 then return auraWithSecretPolarity end
         return auraDataToken
+    end,
+    GetPlayerAuraBySpellID = function()
+        calls.playerBySpell = calls.playerBySpell + 1
+        return wholeSecretAura
+    end,
+    GetAuraDataBySpellID = function()
+        calls.dataBySpell = calls.dataBySpell + 1
+        return wholeSecretAura
+    end,
+    GetAuraDataBySpellName = function()
+        calls.byName = calls.byName + 1
+        return wholeSecretAura
     end,
 }
 
@@ -111,6 +147,37 @@ assert(calls.duration == 1 and calls.data == 1 and calls.expiration == 1
 assert(S.QueryUnitAuraBySpellID("player", 100) == auraDataToken, "T4: spell getter still resolves while secret")
 assert(calls.bySpell >= 1, "T4: spell getter reached the C function")
 aurasSecret = false
+
+local function assertCleanOpaquePresence(label, query)
+    local ok, value = pcall(query)
+    assert(ok, label .. " must quarantine the whole-secret AuraData")
+    assert(type(value) == "table", label .. " must return clean presence metadata")
+    assert(value.auraInstanceID == nil, label .. " must not expose the secret payload")
+end
+
+local bySpellBefore = calls.bySpell
+assertCleanOpaquePresence("T4 unit spell getter", function()
+    return S.QueryUnitAuraBySpellID("player", 101, "HELPFUL")
+end)
+assertCleanOpaquePresence("T4 repeated unit spell getter", function()
+    return S.QueryUnitAuraBySpellID("player", 101, "HELPFUL")
+end)
+assert(calls.bySpell == bySpellBefore + 2, "T4 opaque presence must not be memoized")
+assertCleanOpaquePresence("T4 secret polarity", function()
+    return S.QueryUnitAuraBySpellID("player", 102, "HELPFUL")
+end)
+assertCleanOpaquePresence("T4 player spell getter", function()
+    return S.QueryPlayerAuraBySpellID(101)
+end)
+assertCleanOpaquePresence("T4 data spell getter", function()
+    return S.QueryAuraDataBySpellID("player", 101, "HELPFUL")
+end)
+assertCleanOpaquePresence("T4 name getter", function()
+    return S.QueryAuraDataBySpellName("player", "Secret Aura", "HELPFUL")
+end)
+assertCleanOpaquePresence("T4 instance getter", function()
+    return S.QueryAuraDataByAuraInstanceID("player", 777)
+end)
 
 ---------------------------------------------------------------------------
 -- T5: secret auraInstanceID still rejected even when auras are NOT secret

--- a/tests/unit/cdm_spelldata_totem_state_test.lua
+++ b/tests/unit/cdm_spelldata_totem_state_test.lua
@@ -1,0 +1,94 @@
+-- tests/unit/cdm_spelldata_totem_state_test.lua
+-- Run: lua tests/unit/cdm_spelldata_totem_state_test.lua
+
+local function noop() end
+
+function InCombatLockdown() return false end
+function GetTime() return 100 end
+function wipe(tbl)
+    for key in pairs(tbl) do tbl[key] = nil end
+end
+function CreateFrame()
+    return {
+        RegisterEvent = noop,
+        RegisterUnitEvent = noop,
+        UnregisterEvent = noop,
+        UnregisterAllEvents = noop,
+        SetScript = noop,
+    }
+end
+
+local secretHaveTotem = {}
+local secretName = {}
+local secretIcon = {}
+local haveTotem = false
+local totemName = "Test Totem"
+local totemIcon = 12345
+local durationObject = { token = "totem-duration" }
+local durationQueries = 0
+
+function issecretvalue(value)
+    return value == secretHaveTotem or value == secretName or value == secretIcon
+end
+
+function GetTotemInfo()
+    return haveTotem, totemName, 0, 0, totemIcon, 1, 777
+end
+
+function GetTotemDuration()
+    durationQueries = durationQueries + 1
+    return durationObject
+end
+
+local ns = {
+    Helpers = {
+        IsSecretValue = issecretvalue,
+        SafeValue = function(value) return value end,
+        IsAuraOwnedByPlayerOrPet = function() return false end,
+    },
+    CDMShared = {
+        IsRuntimeEnabled = function() return true end,
+    },
+    CDMSources = {},
+}
+
+dofile("tests/helpers/load_cdm_spelldata_runtime.lua")(ns)
+assert(loadfile("QUI_CDM/cdm/cdm_spelldata.lua"))("QUI", ns)
+
+local function resolve()
+    return ns.CDMAuraRuntime.ResolveState({
+        spellID = 777,
+        entrySpellID = 777,
+        entryID = 777,
+        entryName = "Test Totem",
+        entryKind = "aura",
+        entryIsAura = true,
+        entryType = "spell",
+        viewerType = "customBar",
+        totemSlot = 1,
+    })
+end
+
+local state = resolve()
+assert(state.isActive ~= true, "an empty totem slot must remain inactive")
+assert(durationQueries == 0, "an empty totem slot must not query its duration object")
+
+haveTotem = secretHaveTotem
+totemName = secretName
+totemIcon = secretIcon
+state = resolve()
+assert(state.isActive ~= true, "secret totem presence must remain unknown")
+assert(state.totemName == nil and state.totemIcon == nil, "secret totem metadata must be discarded")
+assert(durationQueries == 0, "secret totem presence must not query its duration object")
+
+haveTotem = true
+totemName = "Test Totem"
+totemIcon = 12345
+state = resolve()
+assert(state.isActive == true, "a clean active totem should resolve active")
+assert(state.durObj == durationObject, "an active totem should preserve its DurationObject")
+assert(state.totemName == "Test Totem" and state.totemIcon == 12345,
+    "an active totem should preserve clean metadata")
+assert(durationQueries == 1, "an active totem should query duration exactly once")
+
+print("OK: cdm_spelldata_totem_state_test")

--- a/tests/unit/character_pane_combat_resize_immediate_test.lua
+++ b/tests/unit/character_pane_combat_resize_immediate_test.lua
@@ -1,5 +1,4 @@
--- tests/unit/character_pane_combat_resize_immediate_test.lua
--- Run: lua tests/unit/character_pane_combat_resize_immediate_test.lua
+local loadSource = loadstring or load
 
 local function readFile(path)
     local fh = assert(io.open(path, "rb"), "failed to open " .. path)
@@ -8,44 +7,175 @@ local function readFile(path)
     return text
 end
 
-local function assertContains(text, needle, reason)
-    assert(text:find(needle, 1, true), reason)
-end
-
-local function assertAbsent(text, needle, reason)
-    assert(not text:find(needle, 1, true), reason)
-end
-
 local source = readFile("modules/skinning/character_pane/character.lua")
 
-assertAbsent(
-    source,
-    "pendingCharScale",
-    "Character panel scale must apply immediately instead of waiting for combat end")
+local function slice(first, after)
+    local startAt = assert(source:find(first, 1, true), "missing " .. first)
+    local endAt = assert(source:find(after, startAt + #first, true), "missing " .. after)
+    return source:sub(startAt, endAt - 1)
+end
 
-assertAbsent(
-    source,
-    "pendingTabMode",
-    "Character bottom tab anchors must apply immediately instead of waiting for combat end")
-
-assertAbsent(
-    source,
-    "pendingCharacterLayout",
-    "Character pane layout must apply immediately instead of waiting for combat end")
-
-assertAbsent(
-    source,
-    "local function SafeSetCharScale",
-    "Character pane scale helper must not be named as a combat-deferred safe wrapper")
-
-assertContains(
-    source,
+local scaleTest = assert(loadSource([[
+local applied
+local CharacterFrame = { SetScale = function(_, scale) applied = scale end }
+local InCombatLockdown = function() return true end
+]] .. slice(
     "local function SetCharacterFrameScale(scale)",
-    "Character pane must keep scale application centralized")
+    "local function AreCharacterStatsSecretsDisabled()") .. [[
+return function()
+    SetCharacterFrameScale(1.3)
+    return applied
+end
+]], "@character.lua#SetCharacterFrameScale"))()
 
-assertContains(
-    source,
-    "CharacterFrame:SetScale(scale)",
-    "Character pane scale application must call SetScale directly")
+assert(scaleTest() == 1.3, "Character panel scale must apply during combat")
+
+local hideTest = assert(loadSource([[
+local hidden = 0
+local CharacterFrame = {
+    TopTileStreaks = { Hide = function() hidden = hidden + 1 end },
+}
+local GetSettings = function() return {} end
+local AnchorCharacterFrameBottomTabs = function() end
+local InCombatLockdown = function() return true end
+local frameState, EMPTY = {}, {}
+]] .. slice(
+    "local function HideBlizzardDecorations()",
+    "local function CreateCustomBackground()") .. [[
+return function()
+    HideBlizzardDecorations()
+    return hidden
+end
+]], "@character.lua#HideBlizzardDecorations"))()
+
+assert(hideTest() == 1, "Character panel decorations must be hidden during combat")
+
+local repositionTest = assert(loadSource([[
+local anchored = 0
+local function newSlot()
+    return {
+        SetScale = function() end,
+        ClearAllPoints = function() end,
+        SetPoint = function() anchored = anchored + 1 end,
+    }
+end
+local CharacterFrameBg = {}
+local CharacterHeadSlot, CharacterNeckSlot, CharacterShoulderSlot = newSlot(), newSlot(), newSlot()
+local CharacterBackSlot, CharacterChestSlot, CharacterShirtSlot = newSlot(), newSlot(), newSlot()
+local CharacterTabardSlot, CharacterWristSlot, CharacterHandsSlot = newSlot(), newSlot(), newSlot()
+local CharacterWaistSlot, CharacterLegsSlot, CharacterFeetSlot = newSlot(), newSlot(), newSlot()
+local CharacterFinger0Slot, CharacterFinger1Slot = newSlot(), newSlot()
+local CharacterTrinket0Slot, CharacterTrinket1Slot = newSlot(), newSlot()
+local CharacterMainHandSlot, CharacterSecondaryHandSlot = newSlot(), newSlot()
+local GetSettings = function() return {} end
+local InCombatLockdown = function() return true end
+]] .. slice(
+    "local function RepositionSlots()",
+    "local function PositionModelScene()") .. [[
+return function()
+    RepositionSlots()
+    return anchored
+end
+]], "@character.lua#RepositionSlots"))()
+
+assert(repositionTest() > 0, "Character equipment slots must be repositioned during combat")
+
+local layoutTest = assert(loadSource([[
+local calls = {}
+local function called(name)
+    calls[name] = (calls[name] or 0) + 1
+end
+local layoutApplied = false
+local ApplyCharacterPaneLayout
+local GetSettings = function() return { enabled = true } end
+local InCombatLockdown = function() return true end
+local HideBlizzardDecorations = function() called("decorations") end
+local CreateCustomBackground = function() called("background") end
+local SetupTitleArea = function() called("title") end
+local RunAfterCharacterPaneLayoutTick = function(callback) callback() end
+local RepositionSlots = function() called("slots") end
+local RefreshEquipmentSlotBorders = function() called("borders") end
+local PositionModelScene = function() called("model") end
+local PositionStatsPanelForLayout = function() called("stats") end
+]] .. slice(
+    "ApplyCharacterPaneLayout = function(force)",
+    "local function InitializeCharacterOverlays()") .. [[
+return function()
+    ApplyCharacterPaneLayout()
+    return calls
+end
+]], "@character.lua#ApplyCharacterPaneLayout"))()
+
+local calls = layoutTest()
+for _, name in ipairs({ "decorations", "background", "title", "slots", "borders", "model", "stats" }) do
+    assert(calls[name] == 1, "Character pane layout must apply " .. name .. " during combat")
+end
+
+local showNativeDecorations = assert(loadSource([[
+local shown = 0
+local function nativeDecoration()
+    return { Show = function() shown = shown + 1 end }
+end
+local CharacterFramePortrait = nativeDecoration()
+local CharacterFrameBg = nativeDecoration()
+local CharacterFrame = {
+    Background = nativeDecoration(),
+    NineSlice = nativeDecoration(),
+}
+local InCombatLockdown = function() return true end
+local statsPanel, customBg
+local slotOverlays, frameState, EMPTY = {}, {}, {}
+local RestoreCharacterPanePopouts = function() end
+local IsSkinningHandlingBackground = function() return false end
+local SetCharacterFrameScale = function() end
+local AdjustForNonCharacterTab = function() end
+]] .. slice(
+    "    local function HideCustomElements()",
+    "    if ReputationFrame then") .. [[
+return function()
+    HideCustomElements()
+    return shown
+end
+]], "@character.lua#HideCustomElements"))()
+
+assert(showNativeDecorations() == 4, "Native character decorations must be shown on other tabs during combat")
+
+local hideNativeDecorations = assert(loadSource([[
+local hidden = 0
+local onShow
+local function nativeDecoration()
+    return { Hide = function() hidden = hidden + 1 end }
+end
+local PaperDollFrame = { HookScript = function(_, _, callback) onShow = callback end }
+local CharacterFramePortrait = nativeDecoration()
+local CharacterFrameBg = nativeDecoration()
+local CharacterFrame = {
+    Background = nativeDecoration(),
+    NineSlice = nativeDecoration(),
+}
+local GetSettings = function() return { enabled = true, panelScale = 1 } end
+local InCombatLockdown = function() return true end
+local RestoreCharacterPanePopouts = function() end
+local SelectCharacterStatsSidebarTab = function() end
+local RestoreCharacterTabPositions = function() end
+local SetCharacterFrameScale = function() end
+local layoutApplied = true
+local IsSkinningHandlingBackground = function() return false end
+local customBg, statsPanel
+local MaskNativeStatsPane = function() end
+local slotOverlays, frameState, EMPTY = {}, {}, {}
+local ScheduleUpdate = function() end
+local allEquipmentSlots = {}
+local RunAfterCharacterPaneLayoutTick = function(callback) callback() end
+]] .. slice(
+    "    if PaperDollFrame then\n        PaperDollFrame:HookScript(\"OnShow\", function()",
+    "    if CharacterFrameTab1 and not") .. [[
+return function()
+    onShow()
+    return hidden
+end
+]], "@character.lua#PaperDollFrameOnShow"))()
+
+assert(hideNativeDecorations() == 4, "Native character decorations must be hidden on the character tab during combat")
 
 print("OK: character_pane_combat_resize_immediate_test")


### PR DESCRIPTION
## What changed

- Harden CDM aura, cooldown, item/slot, and totem boundaries against secret values.
- Preserve clean aura-presence metadata without memoizing opaque payloads.
- Apply character-pane scale, decoration, slot, model, and stats layout changes immediately during combat.
- Add focused regression coverage for the secret-value and combat-layout contracts.

## Why

Secret Blizzard values were crossing resolver boundaries into DurationObject construction, cached state, and metadata reads. Character-pane layout changes were deferred until combat ended, leaving the UI stale while protected operations were otherwise safe.

## Validation

- `bash tools/test.sh`
- All 9 gates passed: 842 unit files, strict taint clean, lint clean, generated search cache current, and i18n base current.
- `graphify update .` completed with no code-topology drift.
