### PR TITLE
fix(objectives): enforce tracker max height

### DIFF
--- a/modules/skinning/gameplay/objectivetracker.lua
+++ b/modules/skinning/gameplay/objectivetracker.lua
@@ -444,12 +444,28 @@ end
 -- Keep this separate from Edit Mode's saved height field: that state belongs
 -- to Blizzard and can be restored independently by Edit Mode.
 -- <<< QUI_TEST_EXTRACT tracker_max_height
+local blizzardTrackerHeight = nil
+
+local function CaptureBlizzardTrackerHeight(trackerFrame)
+    if not trackerFrame or not trackerFrame.GetHeight then return end
+
+    local height = Helpers.SafeNumberOrNil(trackerFrame:GetHeight())
+    if height and height > 0 then
+        blizzardTrackerHeight = height
+    end
+end
+
 local function ApplyTrackerMaxHeight(settings)
     local TrackerFrame = _G.ObjectiveTrackerFrame
     if not TrackerFrame then return end
 
+    if not blizzardTrackerHeight then
+        CaptureBlizzardTrackerHeight(TrackerFrame)
+    end
+    if not blizzardTrackerHeight then return end
+
     local maxHeight = settings and settings.objectiveTrackerHeight or 600
-    TrackerFrame:SetHeight(maxHeight)
+    TrackerFrame:SetHeight(math.min(maxHeight, blizzardTrackerHeight))
 end
 -- <<< QUI_TEST_EXTRACT tracker_max_height
 
@@ -799,6 +815,14 @@ local function SkinObjectiveTracker()
     if not TrackerFrame then return end
 
     local sr, sg, sb, sa, bgr, bgg, bgb, bga = SkinBase.GetSkinColors()
+
+    if TrackerFrame.UpdateHeight and not SkinBase.GetFrameData(TrackerFrame, "updateHeightHooked") then
+        hooksecurefunc(TrackerFrame, "UpdateHeight", function(self)
+            CaptureBlizzardTrackerHeight(self)
+            DeferObjectiveTrackerPostLayoutUpdate()
+        end)
+        SkinBase.SetFrameData(TrackerFrame, "updateHeightHooked", true)
+    end
 
     ApplyLayoutSettingsSafely(settings)
 

--- a/modules/skinning/gameplay/objectivetracker.lua
+++ b/modules/skinning/gameplay/objectivetracker.lua
@@ -9,6 +9,7 @@ local SkinBase = ns.SkinBase
 local GetFontFlags = Helpers.GetGeneralFontOutline
 
 local pendingBackdropUpdate = false
+local pendingProtectedLayoutUpdate = false
 
 local function RunAfterFirstFrame(callback, delay)
     if ns.RunAfterFirstFrame then
@@ -437,6 +438,21 @@ local function ApplyMaxWidth(settings)
     end
 end
 
+-- ObjectiveTrackerContainerMixin passes its own frame height to every module
+-- as the available layout height. The backdrop cap below is only decorative;
+-- constraining this frame is what makes Blizzard truncate overflowing rows.
+-- Keep this separate from Edit Mode's saved height field: that state belongs
+-- to Blizzard and can be restored independently by Edit Mode.
+-- <<< QUI_TEST_EXTRACT tracker_max_height
+local function ApplyTrackerMaxHeight(settings)
+    local TrackerFrame = _G.ObjectiveTrackerFrame
+    if not TrackerFrame then return end
+
+    local maxHeight = settings and settings.objectiveTrackerHeight or 600
+    TrackerFrame:SetHeight(maxHeight)
+end
+-- <<< QUI_TEST_EXTRACT tracker_max_height
+
 local function UpdateBackdropAnchors()
     local TrackerFrame = _G.ObjectiveTrackerFrame
     local quiBackdrop = TrackerFrame and SkinBase.GetFrameData(TrackerFrame, "backdrop")
@@ -540,12 +556,17 @@ local function HidePOIButtonGlows()
     end
 end
 
-local function EnforceWidth()
+local function EnforceSize()
     local TrackerFrame = _G.ObjectiveTrackerFrame
     if not TrackerFrame then return end
 
     local settings = GetSettings()
     if not settings or not settings.skinObjectiveTracker then return end
+    if type(InCombatLockdown) == "function" and InCombatLockdown() then
+        pendingProtectedLayoutUpdate = true
+    else
+        ApplyTrackerMaxHeight(settings)
+    end
 
     local maxWidth
     if IsScenarioActive() then
@@ -571,7 +592,7 @@ end
 
 local function RunObjectiveTrackerPostLayoutUpdate()
     pendingBackdropUpdate = false
-    EnforceWidth()
+    EnforceSize()
     UpdateBackdropAnchors()
     HidePOIButtonGlows()
     StyleExistingProgressBars()
@@ -588,7 +609,6 @@ local function ScheduleBackdropUpdate()
     DeferObjectiveTrackerPostLayoutUpdate()
 end
 
-local pendingProtectedLayoutUpdate = false
 local protectedLayoutEventFrame = CreateFrame("Frame")
 protectedLayoutEventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 protectedLayoutEventFrame:SetScript("OnEvent", function()
@@ -598,6 +618,7 @@ protectedLayoutEventFrame:SetScript("OnEvent", function()
     local settings = GetSettings()
     if not settings or not settings.skinObjectiveTracker then return end
 
+    ApplyTrackerMaxHeight(settings)
     ApplyMaxWidth(settings)
     ScheduleBackdropUpdate()
 end)
@@ -618,6 +639,7 @@ local function ApplyLayoutSettingsSafely(settings)
         return false
     end
 
+    ApplyTrackerMaxHeight(settings)
     ApplyMaxWidth(settings)
     return true
 end
@@ -849,7 +871,7 @@ local function SkinObjectiveTracker()
     if not SkinBase.GetFrameData(TrackerFrame, "sizeChangedHooked") then
         TrackerFrame:HookScript("OnSizeChanged", function()
             C_Timer.After(0, function()
-                EnforceWidth()
+                EnforceSize()
                 UpdateBackdropAnchors()
             end)
         end)

--- a/tests/unit/objectivetracker_widget_pool_retreat_test.lua
+++ b/tests/unit/objectivetracker_widget_pool_retreat_test.lua
@@ -28,10 +28,16 @@ assert(src:find("ScenarioObjectiveTracker = true", 1, true)
     "objectivetracker.lua must list both widget-pool trackers")
 
 local heightChunk = table.concat({
-    "local _G = ...",
+    "local _G, Helpers = ...",
     extract("tracker_max_height"),
-    "return ApplyTrackerMaxHeight",
+    "return ApplyTrackerMaxHeight, CaptureBlizzardTrackerHeight",
 }, "\n")
+
+local fakeHelpers = {
+    SafeNumberOrNil = function(value)
+        return type(value) == "number" and value or nil
+    end,
+}
 
 local tracker = { height = 800, updateHeightCalls = 0, topModulePadding = 38 }
 function tracker:SetHeight(height)
@@ -45,7 +51,8 @@ function tracker:UpdateHeight()
 end
 
 local fakeGlobals = { ObjectiveTrackerFrame = tracker }
-local applyHeight = assert(loadstring(heightChunk, "tracker_max_height"))(fakeGlobals)
+local applyHeight, captureBlizzardHeight = assert(loadstring(heightChunk, "tracker_max_height"))(
+    fakeGlobals, fakeHelpers)
 
 local containerSrc = readAll(
     "tests/framexml/Interface/AddOns/Blizzard_ObjectiveTracker/" ..
@@ -72,6 +79,31 @@ assert(tracker.editModeHeight == nil,
 applyHeight(nil)
 assert(tracker.height == 600, "missing settings must retain the 600px default")
 
+tracker.height = 300
+captureBlizzardHeight(tracker)
+applyHeight({ objectiveTrackerHeight = 600 })
+assert(tracker.height == 300,
+    "a smaller Blizzard layout height must remain smaller than the configured maximum")
+
+tracker.height = 800
+captureBlizzardHeight(tracker)
+applyHeight({ objectiveTrackerHeight = 600 })
+assert(tracker.height == 600,
+    "the tracker must expand to its configured cap when Blizzard later reports more room")
+
+local shortTracker = { height = 300 }
+function shortTracker:SetHeight(height)
+    self.height = height
+end
+function shortTracker:GetHeight()
+    return self.height
+end
+local applyShortHeight = assert(loadstring(heightChunk, "tracker_short_height"))(
+    { ObjectiveTrackerFrame = shortTracker }, fakeHelpers)
+applyShortHeight({ objectiveTrackerHeight = 600 })
+assert(shortTracker.height == 300,
+    "configured max height must not enlarge a tracker beyond Blizzard's available height")
+
 fakeGlobals.ObjectiveTrackerFrame = nil
 assert(pcall(applyHeight, { objectiveTrackerHeight = 300 }),
     "height enforcement must tolerate the tracker not being loaded yet")
@@ -82,5 +114,7 @@ local postLayout = assert(src:match(
     "post-layout objective tracker block must exist")
 assert(postLayout:find("EnforceSize()", 1, true),
     "post-layout updates must reassert both configured dimensions after Blizzard relayout")
+assert(src:find('hooksecurefunc(TrackerFrame, "UpdateHeight"', 1, true),
+    "height enforcement must capture Blizzard's available height from its owner lifecycle")
 
 print("OK: objectivetracker_widget_pool_retreat_test")

--- a/tests/unit/objectivetracker_widget_pool_retreat_test.lua
+++ b/tests/unit/objectivetracker_widget_pool_retreat_test.lua
@@ -1,3 +1,5 @@
+local loadstring = loadstring or load
+
 local function readAll(path)
     local f = assert(io.open(path, "rb"))
     local data = f:read("*a"); f:close()
@@ -5,6 +7,13 @@ local function readAll(path)
 end
 
 local src = readAll("modules/skinning/gameplay/objectivetracker.lua")
+
+local function extract(name)
+    local sentinel = "-- <<< QUI_TEST_EXTRACT " .. name
+    local first = assert(src:find(sentinel, 1, true), "start sentinel must exist: " .. name)
+    local second = assert(src:find(sentinel, first + #sentinel, true), "end sentinel must exist: " .. name)
+    return src:sub(first + #sentinel, second - 1)
+end
 
 assert(not src:find("editModeHeight", 1, true),
     "objectivetracker.lua must not write ObjectiveTrackerFrame.editModeHeight")
@@ -17,5 +26,61 @@ assert(src:find("local function IsWidgetPoolBlock", 1, true),
 assert(src:find("ScenarioObjectiveTracker = true", 1, true)
     and src:find("UIWidgetObjectiveTracker = true", 1, true),
     "objectivetracker.lua must list both widget-pool trackers")
+
+local heightChunk = table.concat({
+    "local _G = ...",
+    extract("tracker_max_height"),
+    "return ApplyTrackerMaxHeight",
+}, "\n")
+
+local tracker = { height = 800, updateHeightCalls = 0, topModulePadding = 38 }
+function tracker:SetHeight(height)
+    self.height = height
+end
+function tracker:GetHeight()
+    return self.height
+end
+function tracker:UpdateHeight()
+    self.updateHeightCalls = self.updateHeightCalls + 1
+end
+
+local fakeGlobals = { ObjectiveTrackerFrame = tracker }
+local applyHeight = assert(loadstring(heightChunk, "tracker_max_height"))(fakeGlobals)
+
+local containerSrc = readAll(
+    "tests/framexml/Interface/AddOns/Blizzard_ObjectiveTracker/" ..
+    "Blizzard_ObjectiveTrackerContainer.lua")
+local getAvailableHeightSrc = assert(containerSrc:match(
+    "function ObjectiveTrackerContainerMixin:GetAvailableHeight%(%)\n.-\nend"),
+    "local FrameXML must expose the objective tracker available-height calculation")
+local getAvailableHeight = assert(loadstring(table.concat({
+    "local ObjectiveTrackerContainerMixin = {}",
+    getAvailableHeightSrc,
+    "return ObjectiveTrackerContainerMixin.GetAvailableHeight",
+}, "\n"), "objective_tracker_available_height"))()
+
+applyHeight({ objectiveTrackerHeight = 420 })
+assert(tracker.height == 420,
+    "configured max height must constrain ObjectiveTrackerFrame, which owns module truncation")
+assert(getAvailableHeight(tracker) == 382,
+    "Blizzard modules must receive the constrained height as their available layout space")
+assert(tracker.updateHeightCalls == 0,
+    "QUI must not ask Blizzard to restore its Edit Mode height after applying the constraint")
+assert(tracker.editModeHeight == nil,
+    "height enforcement must not mutate Blizzard's Edit Mode height state")
+
+applyHeight(nil)
+assert(tracker.height == 600, "missing settings must retain the 600px default")
+
+fakeGlobals.ObjectiveTrackerFrame = nil
+assert(pcall(applyHeight, { objectiveTrackerHeight = 300 }),
+    "height enforcement must tolerate the tracker not being loaded yet")
+
+local postLayout = assert(src:match(
+    "local function RunObjectiveTrackerPostLayoutUpdate%(%)" ..
+    ".-local function DeferObjectiveTrackerPostLayoutUpdate%(%)"),
+    "post-layout objective tracker block must exist")
+assert(postLayout:find("EnforceSize()", 1, true),
+    "post-layout updates must reassert both configured dimensions after Blizzard relayout")
 
 print("OK: objectivetracker_widget_pool_retreat_test")


### PR DESCRIPTION
- Constrain ObjectiveTrackerFrame height so Blizzard truncates overflowing rows
- Preserve Edit Mode height state and defer protected updates during combat
- Add regression coverage for configured and default height behavior