### PR TITLE
fix: harden tooltip and custom cooldown taint paths

### DIFF
--- a/QUI_CDM/cdm/cdm_icon_policies.lua
+++ b/QUI_CDM/cdm/cdm_icon_policies.lua
@@ -1862,14 +1862,16 @@ function CDMIconCustomBarPolicy.Create(callbacks)
             else
                 icon.Cooldown:SetSwipeColor(0, 0, 0, 0)
             end
-        elseif icon._customBarActive and icon._lastAuraDurObj and containerDB.showAuraSwipe == true
+        elseif (icon._customBarActive or icon._resolvedCooldownMode == "aura")
+            and icon._lastAuraDurObj and containerDB.showAuraSwipe == true
             and ns.CDMRenderers and ns.CDMRenderers.ApplyDurationObjectCooldown then
             icon.Cooldown:SetDrawEdge(false)
             icon.Cooldown:SetSwipeTexture("Interface\\Buttons\\WHITE8X8")
             icon.Cooldown:SetSwipeColor(0, 0, 0, 0.6)
             icon.Cooldown:SetDrawSwipe(true)
             ns.CDMRenderers.ApplyDurationObjectCooldown(icon.Cooldown, icon._lastAuraDurObj, true, false)
-        elseif not icon._customBarActive then
+        elseif not icon._customBarActive
+            and not (cooldownState and cooldownState.isOnCooldown == true) then
             icon.Cooldown:SetDrawSwipe(false)
             icon.Cooldown:SetDrawEdge(false)
             icon.Cooldown:SetSwipeColor(0, 0, 0, 0)

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -1149,6 +1149,9 @@ ApplyResolvedCooldown = function(icon, preResolvedState)
     local shouldScheduleExpiry = hasNumericCooldown == true
         and (mode == "aura"
             or (cdActive == true and (mode == "cooldown" or mode == "item-cooldown")))
+    if addonCD.Show then
+        addonCD:Show()
+    end
     local sameDurationBinding = DurationBindingMatches(icon, mode, keySource, durObj)
     if sameDurationBinding then
         if shouldScheduleExpiry then
@@ -2777,6 +2780,13 @@ local function UpdateIconCooldownOwned(icon)
         end
     end
 
+    if resolvedApplied
+        and icon._hasCooldownActive == true
+        and icon._resolvedCooldownMode ~= "inactive"
+        and icon.Cooldown.Show then
+        icon.Cooldown:Show()
+    end
+
     local _cachedChargeInfo = nil
     local _cachedChargeInfoQueried = false
 
@@ -3061,6 +3071,7 @@ local function BuildSpellEntryFromCustom(entry, idx, viewerType)
         _isCustomEntry = true,
         _sourceSpecID = entry._sourceSpecID,
         source = entry.source,
+        linkedSpellID = entry.linkedSpellID,
         linkedSpellIDs = entry.linkedSpellIDs,
         _selfAura = selfAura,
     }

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -1497,6 +1497,8 @@ local function ResolveAuraRuntimeStateForContext(context, entry, sid, entryIsAur
     p.entryName = entry.name
     p.entryKind = entry.kind
     p.entryType = entry.type
+    p.entryLinkedSpellID = entry.linkedSpellID
+    p.entryLinkedSpellIDs = entry.linkedSpellIDs
     p.entryIsAura = entryIsAura
     p.entryTexture = CDMResolvers.GetEntryTexture(entry)
     p.viewerType = context.containerKey or entry.viewerType

--- a/QUI_CDM/cdm/cdm_spelldata.lua
+++ b/QUI_CDM/cdm/cdm_spelldata.lua
@@ -1074,8 +1074,32 @@ local function GetLinkedSpellIDsForSpellID(spellID)
     local linked
     if IsUsableTableKey(cooldownID) then
         local info = catalog.GetCooldownInfo(cooldownID)
-        if info and type(info.linkedSpellIDs) == "table" then
-            linked = info.linkedSpellIDs
+        if info then
+            if type(info.linkedSpellIDs) == "table" then
+                linked = info.linkedSpellIDs
+            end
+            local activeLinkedID = info.linkedSpellID
+            if IsUsableSpellIDKey(activeLinkedID) then
+                if not linked then
+                    linked = { activeLinkedID }
+                else
+                    local found = false
+                    for _, linkedID in ipairs(linked) do
+                        if linkedID == activeLinkedID then
+                            found = true
+                            break
+                        end
+                    end
+                    if not found then
+                        local withActive = {}
+                        for i, linkedID in ipairs(linked) do
+                            withActive[i] = linkedID
+                        end
+                        withActive[#withActive + 1] = activeLinkedID
+                        linked = withActive
+                    end
+                end
+            end
         end
     end
     _linkedSpellIDCache[spellID] = linked or false
@@ -1319,6 +1343,7 @@ end
 
 local _resolveAuraScratch = {
     spellID = nil, entrySpellID = nil, entryID = nil, entryName = nil,
+    entryLinkedSpellID = nil, entryLinkedSpellIDs = nil,
     entryIsAura = false, entryTexture = nil, viewerType = nil,
     debugAura = false, isBuiltinAuraViewer = false,
 
@@ -1334,6 +1359,7 @@ local _scratchProbeSeen     = {}
 local function WipeResolveAuraScratch()
     local s = _resolveAuraScratch
     s.spellID = nil; s.entrySpellID = nil; s.entryID = nil; s.entryName = nil
+    s.entryLinkedSpellID = nil; s.entryLinkedSpellIDs = nil
     s.entryIsAura = false; s.entryTexture = nil; s.viewerType = nil
     s.debugAura = false; s.isBuiltinAuraViewer = false
     s.hasCooldownAuraID = false
@@ -1381,6 +1407,17 @@ local function ResolveAuraAppendMappedAuraIDs(id)
     end
 end
 
+local function ResolveAuraAppendLinkedSpellIDs(id)
+    local linked = GetLinkedSpellIDsForSpellID(id)
+    if not linked then return end
+    for _, linkedID in ipairs(linked) do
+        if IsUsableTableKey(linkedID) then
+            _resolveAuraScratch.hasMappedAuraID = true
+        end
+        ResolveAuraAppendID(linkedID)
+    end
+end
+
 local function ResolveAuraTryCaptured(preferredUnits, allowGlobalFallback, phaseName)
     local s = _resolveAuraScratch
     local captured = GetCapturedAuraForLookup(_scratchCandidateIDs, s.entryName,
@@ -1419,6 +1456,8 @@ local function ResolveAuraRuntimeStateImpl(params)
     local entrySpellID = params.entrySpellID
     local entryID = params.entryID
     local entryName = params.entryName
+    local entryLinkedSpellID = params.entryLinkedSpellID
+    local entryLinkedSpellIDs = params.entryLinkedSpellIDs
     local entryKind = params.entryKind
     local entryIsAura = params.entryIsAura == true or entryKind == "aura"
     local entryTexture = params.entryTexture
@@ -1430,6 +1469,8 @@ local function ResolveAuraRuntimeStateImpl(params)
     s.entrySpellID = entrySpellID
     s.entryID = entryID
     s.entryName = entryName
+    s.entryLinkedSpellID = entryLinkedSpellID
+    s.entryLinkedSpellIDs = entryLinkedSpellIDs
     s.entryIsAura = entryIsAura
     s.entryTexture = entryTexture
     s.viewerType = viewerType
@@ -1505,6 +1546,21 @@ local function ResolveAuraRuntimeStateImpl(params)
             ResolveAuraAppendMappedAuraIDs(entrySpellID)
             ResolveAuraAppendMappedAuraIDs(entryID)
         end
+        ResolveAuraAppendLinkedSpellIDs(auraSpellID)
+        ResolveAuraAppendLinkedSpellIDs(entrySpellID)
+        ResolveAuraAppendLinkedSpellIDs(entryID)
+        if IsUsableSpellIDKey(entryLinkedSpellID) then
+            s.hasMappedAuraID = true
+            ResolveAuraAppendID(entryLinkedSpellID)
+        end
+        if type(entryLinkedSpellIDs) == "table" then
+            for _, linkedID in ipairs(entryLinkedSpellIDs) do
+                if IsUsableSpellIDKey(linkedID) then
+                    s.hasMappedAuraID = true
+                    ResolveAuraAppendID(linkedID)
+                end
+            end
+        end
         if entryIsAura then
             ResolveAuraAppendCooldownAuraIDFor(auraSpellID)
             ResolveAuraAppendCooldownAuraIDFor(entrySpellID)
@@ -1568,7 +1624,8 @@ local function ResolveAuraRuntimeStateImpl(params)
     if childAuraInstID then
         local alive, durObj = ResolveAuraInstanceDurationState(r, auraUnit, childAuraInstID, r.auraData)
         if alive or r.auraData then
-            AuraStateDebug(debugAura, "phase3.2-duration", "unit=", auraUnit, "inst=", childAuraInstID)
+            AuraStateDebug(debugAura, "phase3.2-duration", "unit=", auraUnit, "inst=", childAuraInstID,
+                "durObj=", durObj and "yes" or "no", "unknown=", r.durationStateUnknown and "yes" or "no")
             isActive = true
             r.durObj = durObj
         end

--- a/modules/skinning/system/tooltips.lua
+++ b/modules/skinning/system/tooltips.lua
@@ -391,6 +391,9 @@ local function IsInternalEmbeddedItemRoot(root, tooltip)
 end
 
 local function IsInternalEmbeddedItemTooltipFrame(tooltip)
+    if tooltip == EmbeddedItemTooltip then
+        return true
+    end
     if IsInternalEmbeddedItemRoot(GameTooltip and GameTooltip.ItemTooltip, tooltip) then
         return true
     end
@@ -856,27 +859,6 @@ local function SetupBackdropStyleHooks()
         end)
     end
 
-    if EmbeddedItemTooltip then
-        hooksecurefunc(EmbeddedItemTooltip, "Show", function(self)
-            if not IsEnabled() then return end
-            if IsEmbedded(self) then
-                if HasActiveMoneyFrame(GameTooltip) then return end
-                HideNineSlice(self)
-                if self.SetBackdrop then SafeCall("best-effort-style", self.SetBackdrop, self, nil) end
-                local sf = styleFrames[self]
-                if sf then sf:Hide() end
-            else
-                OnTooltipShow(self)
-            end
-        end)
-        if IsEnabled() then
-            HideNineSlice(EmbeddedItemTooltip)
-            if EmbeddedItemTooltip.SetBackdrop then
-                SafeCall("best-effort-style", EmbeddedItemTooltip.SetBackdrop, EmbeddedItemTooltip, nil)
-            end
-        end
-    end
-
 end
 
 local function SetupPostProcessor()
@@ -967,12 +949,6 @@ local function RefreshAllColors()
         if not (tooltip.IsForbidden and tooltip:IsForbidden())
             and tooltip.IsShown and tooltip:IsShown() then
             StyleTooltip(tooltip)
-        end
-    end
-    if EmbeddedItemTooltip and IsEnabled() and IsEmbedded(EmbeddedItemTooltip) then
-        HideNineSlice(EmbeddedItemTooltip)
-        if EmbeddedItemTooltip.SetBackdrop then
-            SafeCall("best-effort-style", EmbeddedItemTooltip.SetBackdrop, EmbeddedItemTooltip, nil)
         end
     end
     ApplyAuraTooltipStyle()

--- a/tests/unit/cdm_icon_custom_bar_policy_test.lua
+++ b/tests/unit/cdm_icon_custom_bar_policy_test.lua
@@ -15,8 +15,14 @@ Enum = {
 }
 
 local ns = {}
+local auraDurationApplied
 local loadChunk = dofile("tests/helpers/load_cdm_consolidated_chunk.lua")
 loadChunk("QUI_CDM/cdm/cdm_icon_policies.lua", "cdm_icon_custom_bar_policy.lua")("QUI", ns)
+ns.CDMRenderers = {
+    ApplyDurationObjectCooldown = function(_, durObj)
+        auraDurationApplied = durObj
+    end,
+}
 
 local policyModule = assert(ns.CDMIconCustomBarPolicy, "CDMIconCustomBarPolicy should be exported")
 
@@ -169,6 +175,7 @@ trackerSettings.custom = {
     visibilityMode = "onCooldown",
     hideNonUsable = true,
     showRechargeSwipe = true,
+    showAuraSwipe = true,
     activeGlowEnabled = true,
 }
 
@@ -290,6 +297,37 @@ assert(swipeWrites[3].op == "texture",
     "recharge swipe style should restore the owned swipe texture")
 assert(swipeWrites[4].op == "color" and swipeWrites[4].a == 0.6,
     "recharge swipe style should tint the recharge swipe")
+
+local realCooldownIcon, realCooldownWrites = makeIcon({
+    type = "spell", id = 101, spellID = 101, viewerType = "custom",
+})
+policy:ApplySwipeStyle(realCooldownIcon, trackerSettings.custom, {
+    isOnCooldown = true,
+    hasCharges = false,
+    rechargeActive = false,
+})
+for _, write in ipairs(realCooldownWrites) do
+    assert(not (write.op == "swipe" and write.value == false),
+        "custom-bar policy must preserve the real cooldown swipe")
+end
+
+local combatAuraDuration = { token = "combat-aura-duration" }
+local combatAuraIcon, combatAuraWrites = makeIcon({
+    type = "spell", id = 101, spellID = 101, viewerType = "custom",
+})
+combatAuraIcon._resolvedCooldownMode = "aura"
+combatAuraIcon._lastAuraDurObj = combatAuraDuration
+policy:ApplySwipeStyle(combatAuraIcon, trackerSettings.custom, {
+    isOnCooldown = false,
+    hasCharges = false,
+    rechargeActive = false,
+})
+assert(combatAuraWrites[1].op == "edge" and combatAuraWrites[1].value == false,
+    "resolved aura mode should keep the aura swipe path in combat")
+assert(combatAuraWrites[4].op == "swipe" and combatAuraWrites[4].value == true,
+    "resolved aura mode should draw its swipe without custom active-state truth")
+assert(auraDurationApplied == combatAuraDuration,
+    "resolved aura mode should rebind its cached DurationObject")
 
 local activeIcon = makeIcon({ type = "spell", id = 101, spellID = 101, viewerType = "custom" })
 activeSpells[101] = { true, 1, 2, "spell-active" }

--- a/tests/unit/cdm_icons_gcd_style_test.lua
+++ b/tests/unit/cdm_icons_gcd_style_test.lua
@@ -507,6 +507,9 @@ local realCooldownIcon = {
         SetCooldownFromDurationObject = noop,
         SetReverse = noop,
         SetSwipeTexture = noop,
+        Show = function(self)
+            self.shown = true
+        end,
     },
     Icon = {
         SetDesaturated = function(_, value)
@@ -530,6 +533,7 @@ local realCooldownIcon = {
 applied = ns.CDMIcons.ApplyResolvedCooldown(realCooldownIcon)
 
 assert(applied == true, "real cooldown duration should be applied")
+assert(realCooldownIcon.Cooldown.shown == true, "active cooldown should show its cooldown child")
 assert(realCooldownIcon._hasCooldownActive == true, "real cooldown should remain active when the resolved API state is cooldown")
 assert(realCooldownIcon._hasRealCooldownActive == true, "real cooldown flag should remain active when the resolved API state is cooldown")
 assert(desaturated == true, "real cooldown should stay desaturated when the resolved API state is cooldown")

--- a/tests/unit/cdm_spelldata_aura_boundary_test.lua
+++ b/tests/unit/cdm_spelldata_aura_boundary_test.lua
@@ -58,7 +58,35 @@ local ns = {
     CDMShared = {
         IsRuntimeEnabled = function() return true end,
     },
-    CDMSources = {},
+    CDMSources = {
+        QueryUnitAuraBySpellID = function(unit, spellID)
+            if unit == "player" and spellID == 8001 then
+                return {
+                    auraInstanceID = 9001,
+                    spellId = spellID,
+                    duration = 10,
+                    expirationTime = 11,
+                    isHelpful = true,
+                    sourceUnit = "player",
+                }
+            end
+        end,
+    },
+    CDMIndex = {
+        Version = function() return 1 end,
+        Get = function(spellID)
+            if spellID == 7001 then
+                return { cooldownID = 9002 }
+            end
+        end,
+    },
+    CDMCatalog = {
+        GetCooldownInfo = function(cooldownID)
+            if cooldownID == 9002 then
+                return { linkedSpellID = 8001 }
+            end
+        end,
+    },
     CDMIcons = {
         HandleRuntimeRefresh = function()
             auraRefreshes = auraRefreshes + 1
@@ -118,6 +146,29 @@ auraFrame.script(auraFrame, "UNIT_AURA", "player", {
 local captured = ns.CDMSpellData.GetCapturedAuraForLookup({ 7001 }, nil, { "player" }, false)
 assert(captured and captured.auraInstanceID == 9001,
     "clean added aura payloads should also be keyed by recent cast spellID")
+
+local resolvedAura = ns.CDMAuraRuntime.ResolveState({
+    spellID = 7001,
+    entrySpellID = 7001,
+    entryID = 7001,
+    entryKind = "cooldown",
+    entryType = "spell",
+    viewerType = "custom",
+})
+assert(resolvedAura.isActive == true and resolvedAura.resolvedAuraSpellID == 8001,
+    "cooldown aura resolution should probe linked spell IDs for custom entries")
+
+local directEntryAura = ns.CDMAuraRuntime.ResolveState({
+    spellID = 7002,
+    entrySpellID = 7002,
+    entryID = 7002,
+    entryLinkedSpellID = 8001,
+    entryKind = "cooldown",
+    entryType = "spell",
+    viewerType = "custom",
+})
+assert(directEntryAura.isActive == true and directEntryAura.resolvedAuraSpellID == 8001,
+    "custom entry linkedSpellID should resolve without a catalog mapping")
 
 inCombat = true
 local ok, err = pcall(function()


### PR DESCRIPTION
## What changed

- Leave the `EmbeddedItemTooltip` root unhooked and unstyled, matching the EllesmereUI reference boundary.
- Preserve active custom cooldown swipes and rebind/show cooldown children when resolved cooldown state is active.
- Carry catalog and entry linked spell IDs into aura resolution so custom cooldown entries can resolve their live aura phase.

## Why

The tooltip root was entering QUI styling through a tainted `Show()` path. Custom cooldown entries could also lose their active visual state or miss linked aura variants.

## Validation

- `bash tools/test.sh`
- 845 unit tests passed
- strict taint analysis passed with no findings
- compile, profile, lint, search-cache, and i18n gates passed
