### PR TITLE
fix: follow current season travel portals

### DIFF
--- a/modules/infobar/travel.lua
+++ b/modules/infobar/travel.lua
@@ -8,18 +8,6 @@ local ipairs = ipairs
 
 local HEARTHSTONE_ITEM_ID = 6948
 
-local TELEPORT_SPELLS = {
-    { 1254572, "Magisters' Terrace" },
-    { 1254559, "Maisara Caverns" },
-    { 1254563, "Nexus-Point Xenas" },
-    { 1254400, "Windrunner Spire" },
-    { 393273,  "Algeth'ar Academy" },
-    { 1254551, "Seat of the Triumvirate" },
-    { 159898,  "Skyreach" },
-    { 1254557, "Skyreach" },
-    { 1254555, "Pit of Saron" },
-}
-
 local HEARTH_TOYS = {
     54452,
     64488,
@@ -60,6 +48,28 @@ local function GetTravelDB()
     local db = QUICore.db and QUICore.db.profile
     return db and db.infobar
 end
+
+local function GetTeleportEntries()
+    local challengeMode = _G.C_ChallengeMode
+    local dungeonData = ns.DungeonData
+    if not challengeMode or not dungeonData then return {} end
+
+    local maps = challengeMode.GetMapTable and challengeMode.GetMapTable()
+    if type(maps) ~= "table" then return {} end
+
+    local entries, seen = {}, {}
+    for _, mapID in ipairs(maps) do
+        local spellID = dungeonData.GetTeleportSpellID(mapID)
+        if spellID and not seen[spellID] then
+            local name = challengeMode.GetMapUIInfo and challengeMode.GetMapUIInfo(mapID)
+            entries[#entries + 1] = { spellID, name }
+            seen[spellID] = true
+        end
+    end
+    return entries
+end
+
+ns.TravelData = { GetTeleportEntries = GetTeleportEntries }
 
 local function ResolveHearthAction()
     local db = GetTravelDB()
@@ -115,7 +125,7 @@ local function BuildFlyout(frame, slotFrame)
     bg:SetColorTexture(0, 0, 0, 0.9)
 
     local rows = 0
-    for _, entry in ipairs(TELEPORT_SPELLS) do
+    for _, entry in ipairs(GetTeleportEntries()) do
         local spellID, label = entry[1], entry[2]
         if IsSpellKnown(spellID) then
             rows = rows + 1
@@ -252,8 +262,9 @@ Datatexts:Register("travel", {
         if slotFrame._quiOnWidthDirty then slotFrame._quiOnWidthDirty() end
 
         frame:RegisterEvent("LEARNED_SPELL_IN_SKILL_LINE")
+        frame:RegisterEvent("CHALLENGE_MODE_MAPS_UPDATE")
         frame:SetScript("OnEvent", function(self, event)
-            if event == "LEARNED_SPELL_IN_SKILL_LINE" then
+            if event == "LEARNED_SPELL_IN_SKILL_LINE" or event == "CHALLENGE_MODE_MAPS_UPDATE" then
                 self._flyoutDirty = true
             elseif event == "PLAYER_REGEN_ENABLED" then
                 self:UnregisterEvent("PLAYER_REGEN_ENABLED")

--- a/tests/unit/infobar_travel_season_test.lua
+++ b/tests/unit/infobar_travel_season_test.lua
@@ -1,0 +1,33 @@
+local ROOT = (arg and arg[0] or ""):match("^(.*)tests[/\\]unit[/\\]") or "./"
+
+local registered
+local Datatexts = {
+    Register = function(_, id, definition)
+        registered = { id = id, definition = definition }
+    end,
+}
+local ns = {
+    Addon = { Datatexts = Datatexts },
+    DungeonData = {
+        GetTeleportSpellID = function(mapID)
+            return ({ [101] = 5001, [102] = 5002, [103] = 5002 })[mapID]
+        end,
+    },
+    L = setmetatable({}, { __index = function(_, key) return key end }),
+}
+
+local oldChallengeMode = _G.C_ChallengeMode
+_G.C_ChallengeMode = {
+    GetMapTable = function() return { 101, 102, 103, 999 } end,
+    GetMapUIInfo = function(mapID) return ({ [101] = "Current One", [102] = "Current Two" })[mapID] end,
+}
+
+assert(loadfile(ROOT .. "modules/infobar/travel.lua"))("QUI", ns)
+local entries = ns.TravelData.GetTeleportEntries()
+assert(registered and registered.id == "travel")
+assert(#entries == 2)
+assert(entries[1][1] == 5001 and entries[1][2] == "Current One")
+assert(entries[2][1] == 5002 and entries[2][2] == "Current Two")
+
+_G.C_ChallengeMode = oldChallengeMode
+print("ALL TESTS PASSED")


### PR DESCRIPTION
## What changed
- Build the Info Bar Travel flyout from the current Mythic+ challenge-map table.
- Reuse QUI's shared dungeon teleport mapping and deduplicate aliases.
- Rebuild the flyout after challenge-map updates and add regression coverage.

## Root cause
The Info Bar owned a hardcoded Midnight Season 1 portal list, so it continued showing those entries after the season changed.

## Validation
- `bash tools/test.sh` — all 9 gates passed.
- 846 unit tests, strict taint, compile, lint, profile, search-cache, and i18n checks passed.