### PR TITLE
fix: stop tainting native cooldown viewer timing

### DIFF
--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -3246,6 +3246,9 @@ function ownedEngine:Initialize()
         QUI.CooldownSwipe = ns._OwnedSwipe
         _G.QUI_RefreshCooldownSwipe = ns._OwnedSwipe.Apply
         _G.QUI_RefreshCooldownEffects = ns._OwnedSwipe.Apply
+        ns.QUI_RefreshCDMReanchor = function()
+            RefreshAll()
+        end
     end
 
     if ns.Registry then

--- a/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
@@ -13,10 +13,6 @@ function CDMReanchorAuraPhase.New(deps)
         _reentry = setmetatable({}, { __mode = "k" }),
         _edgeHooked = setmetatable({}, { __mode = "k" }),
         _edgeReentry = setmetatable({}, { __mode = "k" }),
-        _timingHooked = setmetatable({}, { __mode = "k" }),
-        _timingReentry = setmetatable({}, { __mode = "k" }),
-        _desatHooked = setmetatable({}, { __mode = "k" }),
-        _desatReentry = setmetatable({}, { __mode = "k" }),
         _keyByFrame = setmetatable({}, { __mode = "k" }),
     }, InstanceMT)
 end
@@ -27,24 +23,6 @@ function CDMReanchorAuraPhase:OnSwipeColor(frame, cd)
     local deps = self._deps
     if deps.reassertColor then ns.SafeCall("bulkhead", deps.reassertColor, frame, cd, self._keyByFrame[frame]) end
     self._reentry[cd] = false
-end
-
-function CDMReanchorAuraPhase:OnCooldownSet(frame, cd)
-    if not cd or self._timingReentry[cd] or self._reentry[cd] then return end
-    self._timingReentry[cd] = true
-    self._reentry[cd] = true
-    local deps = self._deps
-    if deps.reassertColor then ns.SafeCall("bulkhead", deps.reassertColor, frame, cd, self._keyByFrame[frame]) end
-    self._reentry[cd] = false
-    self._timingReentry[cd] = false
-end
-
-function CDMReanchorAuraPhase:OnDesaturated(frame, tex)
-    if not tex or self._desatReentry[tex] then return end
-    self._desatReentry[tex] = true
-    local deps = self._deps
-    if deps.reassertDesat then ns.SafeCall("bulkhead", deps.reassertDesat, frame, tex, self._keyByFrame[frame]) end
-    self._desatReentry[tex] = false
 end
 
 function CDMReanchorAuraPhase:OnDrawEdge(frame, cd)
@@ -68,21 +46,6 @@ function CDMReanchorAuraPhase:Hook(frame, containerKey)
         local function colorWork() this:OnSwipeColor(frame, cd) end
         hooksec(cd, "SetSwipeColor", function()
             securecall(colorWork)
-        end)
-    end
-    if cd and type(cd.SetCooldown) == "function" and not self._timingHooked[cd] then
-        self._timingHooked[cd] = true
-        local function timingWork() this:OnCooldownSet(frame, cd) end
-        hooksec(cd, "SetCooldown", function()
-            securecall(timingWork)
-        end)
-    end
-    local tex = frame.Icon
-    if tex and type(tex.SetDesaturated) == "function" and not self._desatHooked[tex] then
-        self._desatHooked[tex] = true
-        local function desatWork() this:OnDesaturated(frame, tex) end
-        hooksec(tex, "SetDesaturated", function()
-            securecall(desatWork)
         end)
     end
     if cd and type(cd.SetDrawEdge) == "function" and not self._edgeHooked[cd] then

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -182,8 +182,14 @@ function CDMReanchorBoot.BuildRuntime(env)
             if isBuffIconFrameKey(containerKey) or entry and (entry.isAura or entry.kind == "aura") then
                 return false
             end
+            local entryType = entry and entry.type
+            local itemBacked = entryType == "item"
+                or entryType == "slot"
+                or entryType == "trinket"
+                or entryType == "consumable"
+                or entryType == "macro"
             local linked = entry and entry.linkedSpellIDs
-            return type(linked) == "table" and #linked > 0
+            return (itemBacked or type(linked) == "table" and #linked > 0)
                 and not isAuraPhaseEnabled()
         end,
         buildLayout = env.buildLayout,

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -106,11 +106,10 @@ function CDMReanchorBoot.BuildRuntime(env)
             if isAuraPhaseEnabled() then
                 local r, g, b, a = modeColor("aura")
                 cd:SetSwipeColor(r, g, b, a)
-            elseif cooldownShown(frame) then
-                local r, g, b, a = modeColor("cooldown")
-                cd:SetSwipeColor(r, g, b, a)
-            else
+            elseif swipeSettings().showCooldownSwipe == false then
                 cd:SetSwipeColor(0, 0, 0, 0)
+            else
+                return
             end
         elseif cooldownShown(frame) then
             local r, g, b, a = modeColor("cooldown")

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -178,8 +178,9 @@ function CDMReanchorBoot.BuildRuntime(env)
         getCurated = env.getCurated,
         getSettings = env.getSettings,
         getAdditional = MakeGetAdditional(env),
-        shouldReplaceNativeAuraPhase = function(frame)
-            return frame and frame.cooldownUseAuraDisplayTime == true
+        shouldReplaceNativeAuraPhase = function(_frame, entry)
+            local linked = entry and entry.linkedSpellIDs
+            return type(linked) == "table" and #linked > 0
                 and not isAuraPhaseEnabled()
         end,
         buildLayout = env.buildLayout,

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -85,55 +85,6 @@ function CDMReanchorBoot.BuildRuntime(env)
     local function isBuffIconFrameKey(key)
         return key == "buff" or key == "buffIcon"
     end
-    local function queryRealCooldownDurObj(frame)
-        local entry = runtime and runtime.GetEntryForFrame and runtime:GetEntryForFrame(frame)
-        if not entry then return nil end
-        local entryType = entry.type
-        if entryType == "item" or entryType == "trinket" or entryType == "slot"
-            or entryType == "macro" then
-            local R = ns.CDMResolvers
-            if R and R.BuildEntryItemDurationObject then
-                return R.BuildEntryItemDurationObject(entry)
-            end
-            return nil
-        end
-        local spellID
-        if entryType == "consumable" then
-            local Index = ns.CDMIndex
-            local indexEntry = Index and Index.GetByCategory and Index.GetByCategory(entry.id)
-            spellID = indexEntry and indexEntry.primarySpellID
-        else
-            spellID = entry.overrideSpellID or entry.spellID or entry.id
-        end
-        if _issecretvalue(spellID) or type(spellID) ~= "number" then return nil end
-        local Sources = ns.CDMSources
-        if not Sources then return nil end
-        local durObj
-        if Sources.QuerySpellCooldownDuration then
-            durObj = Sources.QuerySpellCooldownDuration(spellID, true)
-        end
-        if not durObj and Sources.QuerySpellChargeDuration then
-            durObj = Sources.QuerySpellChargeDuration(spellID)
-        end
-        return durObj
-    end
-    local function restyleAuraPhaseAsCooldown(frame, cd)
-        local durObj = queryRealCooldownDurObj(frame)
-        if cd.SetUseAuraDisplayTime then cd:SetUseAuraDisplayTime(false) end
-        if durObj and cd.SetCooldownFromDurationObject then
-            local clearIfZero = true
-            cd:SetCooldownFromDurationObject(durObj, clearIfZero)
-            if swipeSettings().showCooldownSwipe ~= false then
-                local r, g, b, a = modeColor("cooldown")
-                cd:SetSwipeColor(r, g, b, a)
-            else
-                cd:SetSwipeColor(0, 0, 0, 0)
-            end
-        else
-            if cd.Clear then cd:Clear() end
-            cd:SetSwipeColor(0, 0, 0, 0)
-        end
-    end
     local function reassertColor(frame, cd, containerKey)
         if not (cd and cd.SetSwipeColor) then return end
         if effectsHidden(containerKey) then
@@ -155,26 +106,17 @@ function CDMReanchorBoot.BuildRuntime(env)
             if isAuraPhaseEnabled() then
                 local r, g, b, a = modeColor("aura")
                 cd:SetSwipeColor(r, g, b, a)
+            elseif cooldownShown(frame) then
+                local r, g, b, a = modeColor("cooldown")
+                cd:SetSwipeColor(r, g, b, a)
             else
-                restyleAuraPhaseAsCooldown(frame, cd)
+                cd:SetSwipeColor(0, 0, 0, 0)
             end
         elseif cooldownShown(frame) then
             local r, g, b, a = modeColor("cooldown")
             cd:SetSwipeColor(r, g, b, a)
         else
             cd:SetSwipeColor(0, 0, 0, 0)
-        end
-    end
-    local function reassertDesat(frame, tex)
-        if not tex then return end
-        if frame.cooldownUseAuraDisplayTime ~= true or isAuraPhaseEnabled() then return end
-        local durObj = queryRealCooldownDurObj(frame)
-        if not durObj then return end
-        local curve = ns._CDM_GetCooldownDesatCurve and ns._CDM_GetCooldownDesatCurve()
-        if curve and durObj.EvaluateRemainingPercent and tex.SetDesaturation then
-            tex:SetDesaturation(durObj:EvaluateRemainingPercent(curve))
-        elseif tex.SetDesaturated then
-            tex:SetDesaturated(true)
         end
     end
     local function reassertEdge(_frame, cd, containerKey)
@@ -198,7 +140,6 @@ function CDMReanchorBoot.BuildRuntime(env)
         isAuraPhaseEnabled = isAuraPhaseEnabled,
         reassertColor = reassertColor,
         reassertEdge = reassertEdge,
-        reassertDesat = reassertDesat,
     })
     local pandemic = ns.CDMReanchorPandemic and ns.CDMReanchorPandemic.New({
         securecall = securecallfunction,

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -178,6 +178,10 @@ function CDMReanchorBoot.BuildRuntime(env)
         getCurated = env.getCurated,
         getSettings = env.getSettings,
         getAdditional = MakeGetAdditional(env),
+        shouldReplaceNativeAuraPhase = function(frame)
+            return frame and frame.cooldownUseAuraDisplayTime == true
+                and not isAuraPhaseEnabled()
+        end,
         buildLayout = env.buildLayout,
         buildBuffLayout = env.buildBuffLayout,
         frameIsActive = env.frameIsActive,

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -178,7 +178,10 @@ function CDMReanchorBoot.BuildRuntime(env)
         getCurated = env.getCurated,
         getSettings = env.getSettings,
         getAdditional = MakeGetAdditional(env),
-        shouldReplaceNativeAuraPhase = function(_frame, entry)
+        shouldReplaceNativeAuraPhase = function(_frame, entry, containerKey)
+            if isBuffIconFrameKey(containerKey) or entry and (entry.isAura or entry.kind == "aura") then
+                return false
+            end
             local linked = entry and entry.linkedSpellIDs
             return type(linked) == "table" and #linked > 0
                 and not isAuraPhaseEnabled()

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -182,15 +182,7 @@ function CDMReanchorBoot.BuildRuntime(env)
             if isBuffIconFrameKey(containerKey) or entry and (entry.isAura or entry.kind == "aura") then
                 return false
             end
-            local entryType = entry and entry.type
-            local itemBacked = entryType == "item"
-                or entryType == "slot"
-                or entryType == "trinket"
-                or entryType == "consumable"
-                or entryType == "macro"
-            local linked = entry and entry.linkedSpellIDs
-            return (itemBacked or type(linked) == "table" and #linked > 0)
-                and not isAuraPhaseEnabled()
+            return entry ~= nil and not isAuraPhaseEnabled()
         end,
         buildLayout = env.buildLayout,
         buildBuffLayout = env.buildBuffLayout,

--- a/QUI_CDM/cdm/cdm_reanchor_runtime.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_runtime.lua
@@ -303,6 +303,29 @@ function CDMReanchorRuntime:AssembleEntries(containerKey, frameMap, settings, pr
                     diag.mintFailed = diag.mintFailed + 1
                 end
             end
+        elseif m and deps.shouldReplaceNativeAuraPhase
+            and deps.shouldReplaceNativeAuraPhase(m.frame, e, containerKey) then
+            claimedFrames[m.frame] = nil
+            local nativePlacement = self._nativePlacementByFrame[m.frame]
+            if not nativePlacement or nativePlacement.containerKey == containerKey then
+                self._entryByFrame[m.frame] = nil
+                self._nativePlacementByFrame[m.frame] = nil
+                self._consumersByFrame[m.frame] = nil
+            end
+            if self._bridge and self._bridge.Sink then
+                self._bridge:Sink(m.frame)
+            end
+            local icon = deps.mintOwned and deps.mintOwned(e, containerKey) or nil
+            if icon then
+                diag.minted = diag.minted + 1
+                self:_TrackMintedOwned(containerKey, icon)
+                entries[#entries + 1] = {
+                    src = e, frame = icon, reanchored = false,
+                    _assignedRow = e._assignedRow,
+                }
+            else
+                diag.mintFailed = diag.mintFailed + 1
+            end
         elseif m then
             local hiddenPreview = editing and IsBuffIconKey(containerKey)
                 and deps.frameIsActive ~= nil

--- a/QUI_CDM/cdm/settings/containers_page.lua
+++ b/QUI_CDM/cdm/settings/containers_page.lua
@@ -459,6 +459,13 @@ local function RefreshSwipe()
     PokePreview()
 end
 
+local function RefreshCooldownIconAuraPhase()
+    RefreshSwipe()
+    if ns.QUI_RefreshCDMReanchor then
+        ns.QUI_RefreshCDMReanchor()
+    end
+end
+
 local function RefreshCooldownEffects()
     if _G.QUI_RefreshCooldownEffects then
         _G.QUI_RefreshCooldownEffects()
@@ -1944,7 +1951,7 @@ local function RenderEffectsSection(sectionHost, ctx)
     local buffSwipeCheckbox = gui:CreateFormCheckbox(swipeCard.frame, nil, "showBuffSwipe", effectsCtx.swipeDB, RefreshSwipe, {
         description = ns.L["Play a swipe animation on buff/debuff icons to represent remaining duration."],
     })
-    local cooldownIconAuraPhaseCheckbox = gui:CreateFormCheckbox(swipeCard.frame, nil, "showCooldownIconAuraPhase", effectsCtx.swipeDB, RefreshSwipe, {
+    local cooldownIconAuraPhaseCheckbox = gui:CreateFormCheckbox(swipeCard.frame, nil, "showCooldownIconAuraPhase", effectsCtx.swipeDB, RefreshCooldownIconAuraPhase, {
         description = ns.L["Let cooldown icons show their linked buff/debuff phase before switching to recharge or cooldown."],
     })
     local rechargeEdgeCheckbox = gui:CreateFormCheckbox(swipeCard.frame, nil, "showRechargeEdge", effectsCtx.swipeDB, RefreshSwipe, {

--- a/tests/unit/cdm_reanchor_auraphase_buffswipe_test.lua
+++ b/tests/unit/cdm_reanchor_auraphase_buffswipe_test.lua
@@ -230,7 +230,6 @@ local ap = AP.New({
     securecall = function(fn, ...) return fn(...) end,
     reassertColor = function(_, _, key) seen[#seen + 1] = { what = "color", key = key } end,
     reassertEdge = function(_, _, key) seen[#seen + 1] = { what = "edge", key = key } end,
-    reassertDesat = function(_, _, key) seen[#seen + 1] = { what = "desat", key = key } end,
 })
 local cdw = {
     SetSwipeColor = function() end,
@@ -249,14 +248,10 @@ assert(hookedFns.SetSwipeColor, "SetSwipeColor hook installed")()
 assert(seen[1] and seen[1].what == "color" and seen[1].key == "buff",
     "SetSwipeColor hook threads the container key into reassertColor")
 
-seen = {}
-assert(hookedFns.SetCooldown, "SetCooldown hook installed")()
-assert(seen[1] and seen[1].key == "buff", "SetCooldown hook threads the container key")
+assert(hookedFns.SetCooldown == nil, "native SetCooldown hook is not installed")
 
 seen = {}
-assert(hookedFns.SetDesaturated, "SetDesaturated hook installed")()
-assert(seen[1] and seen[1].what == "desat" and seen[1].key == "buff",
-    "SetDesaturated hook threads the container key")
+assert(hookedFns.SetDesaturated == nil, "native SetDesaturated hook is not installed")
 
 -- Proactive path: Reassert fires colour + edge with NO Blizzard write at all.
 seen = {}

--- a/tests/unit/cdm_reanchor_auraphase_restyle_test.lua
+++ b/tests/unit/cdm_reanchor_auraphase_restyle_test.lua
@@ -125,7 +125,7 @@ do
         "setting ON: native aura timing untouched")
 end
 
--- 2) Setting OFF + aura phase + spell CD active: re-bind to the real cooldown.
+-- 2) Setting OFF + aura phase: keep Blizzard's native timing untouched.
 do
     swipeStub.showCooldownIconAuraPhase = false
     fMatch.cooldownUseAuraDisplayTime = true
@@ -133,63 +133,39 @@ do
     durQueries = {}
     local cd = NewCd()
     reassertColor(fMatch, cd)
-    assert(durQueries[1] and durQueries[1].kind == "cd"
-        and durQueries[1].spellID == 500 and durQueries[1].ignoreGCD == true,
-        "setting OFF: queries the spell CD duration object (ignoreGCD)")
-    assert(#cd.auraDisplay == 1 and cd.auraDisplay[1] == false,
-        "setting OFF: widget leaves aura display mode")
-    assert(#cd.binds == 1 and cd.binds[1].durObj == cdDurObj and cd.binds[1].clearIfZero == true,
-        "setting OFF: re-binds the widget to the spell CD duration object")
+    assert(#durQueries == 0 and #cd.auraDisplay == 0 and #cd.binds == 0 and cd.cleared == 0,
+        "setting OFF: native timing remains untouched")
     local c = assert(lastColor(cd))
     assert(c[1] == 0 and c[2] == 0 and c[3] == 0 and c[4] == 0.8,
         "setting OFF: cooldown (fallback dark) colour")
     assert(cd.cleared == 0, "active CD: no clear")
 end
 
--- 3) Setting OFF + spell castable but a charge recharging: charge fallback.
-do
-    cdDurObj, chargeDurObj = nil, { chargeSentinel = true }
-    local cd = NewCd()
-    reassertColor(fMatch, cd)
-    assert(#cd.binds == 1 and cd.binds[1].durObj == chargeDurObj,
-        "setting OFF: nil spell CD falls back to the charge recharge duration object")
-end
-
--- 4) Setting OFF + no cooldown at all behind the buff: clear to ready.
-do
-    cdDurObj, chargeDurObj = nil, nil
-    local cd = NewCd()
-    reassertColor(fMatch, cd)
-    assert(cd.cleared == 1, "no CD behind the buff: widget cleared to ready")
-    assert(#cd.binds == 0, "no CD behind the buff: nothing re-bound")
-    local c = assert(lastColor(cd))
-    assert(c[4] == 0, "no CD behind the buff: alpha-0 colour")
-end
-
--- 5) Setting OFF + cooldown swipe disabled: re-bind still happens, colour alpha-0
---    (countdown text follows the re-bind; only the radial darkening is hidden).
+-- 3) Setting OFF + cooldown swipe disabled: only the visual colour is hidden.
 do
     swipeStub.showCooldownSwipe = false
     cdDurObj, chargeDurObj = { cdSentinel = true }, nil
     local cd = NewCd()
     reassertColor(fMatch, cd)
-    assert(#cd.binds == 1, "swipe disabled: re-bind still happens")
+    assert(#cd.binds == 0 and #cd.auraDisplay == 0 and cd.cleared == 0,
+        "swipe disabled: native timing remains untouched")
     local c = assert(lastColor(cd))
     assert(c[4] == 0, "swipe disabled: alpha-0 colour")
     swipeStub.showCooldownSwipe = true
 end
 
--- 6) Setting OFF + unclaimed frame (no curated entry): suppress outright.
+-- 4) Setting OFF + an unclaimed frame: no native timing write.
 do
     local orphan = { cooldownUseAuraDisplayTime = true }
     local cd = NewCd()
     reassertColor(orphan, cd)
-    assert(cd.cleared == 1 and #cd.binds == 0, "no entry: suppress (clear), never re-bind")
+    assert(cd.cleared == 0 and #cd.binds == 0 and #cd.auraDisplay == 0,
+        "no entry: no native timing writes")
     local c = assert(lastColor(cd))
-    assert(c[4] == 0, "no entry: alpha-0 colour")
+    assert(c[4] == 0.8, "no entry: cooldown colour remains visual-only")
 end
 
--- 7) Non-aura phase: unchanged cooldown-colour path, no timing writes.
+-- 5) Non-aura phase: unchanged cooldown-colour path, no timing writes.
 do
     fMatch.cooldownUseAuraDisplayTime = false
     local cd = NewCd()
@@ -200,127 +176,33 @@ do
         "non-aura phase: no timing writes")
 end
 
--- reassertDesat: Blizzard forces the icon BRIGHT in aura phase (RefreshData
--- writes desaturation AFTER the timing refresh), so the aura-phase-off restyle
--- must re-drive saturation from the SetDesaturated post-hook: real-CD duration
--- object through the shared step curve into SetDesaturation (dark while the CD
--- rolls, bright at zero). Leaves Blizzard's writes alone everywhere else.
-assert(type(capturedAuraDeps.reassertDesat) == "function",
-    "BuildRuntime wires reassertDesat into the aura-phase owner")
-local reassertDesat = capturedAuraDeps.reassertDesat
-
-local desatCurve = { curveSentinel = true }
-ns._CDM_GetCooldownDesatCurve = function() return desatCurve end
-local function NewTex()
-    local tex = { levels = {}, bools = {} }
-    tex.SetDesaturation = function(_, v) tex.levels[#tex.levels + 1] = v end
-    tex.SetDesaturated = function(_, v) tex.bools[#tex.bools + 1] = v end
-    return tex
-end
-local function NewDurObj()
-    return {
-        EvaluateRemainingPercent = function(_, curve)
-            assert(curve == desatCurve, "evaluates through the shared step curve")
-            return 0.42 -- opaque C-side handle stand-in
-        end,
-    }
-end
-
--- 8) Setting OFF + aura phase + real CD: curve-driven SetDesaturation.
-do
-    swipeStub.showCooldownIconAuraPhase = false
-    fMatch.cooldownUseAuraDisplayTime = true
-    cdDurObj, chargeDurObj = NewDurObj(), nil
-    local tex = NewTex()
-    reassertDesat(fMatch, tex)
-    assert(#tex.levels == 1 and tex.levels[1] == 0.42,
-        "aura-phase-off + real CD: curve value driven into SetDesaturation")
-    assert(#tex.bools == 0, "curve path never uses the boolean setter")
-end
-
--- 9) Setting OFF + no CD behind the buff: leave Blizzard's bright write.
-do
-    cdDurObj, chargeDurObj = nil, nil
-    local tex = NewTex()
-    reassertDesat(fMatch, tex)
-    assert(#tex.levels == 0 and #tex.bools == 0,
-        "no real CD: icon stays bright (matches clear-to-ready)")
-end
-
--- 10) Setting OFF + no CurveUtil: boolean fallback.
-do
-    ns._CDM_GetCooldownDesatCurve = nil
-    cdDurObj, chargeDurObj = NewDurObj(), nil
-    local tex = NewTex()
-    reassertDesat(fMatch, tex)
-    assert(#tex.bools == 1 and tex.bools[1] == true,
-        "no curve helper: falls back to SetDesaturated(true)")
-    ns._CDM_GetCooldownDesatCurve = function() return desatCurve end
-end
-
--- 11) Setting ON: never touches Blizzard's desaturation.
-do
-    swipeStub.showCooldownIconAuraPhase = true
-    cdDurObj = NewDurObj()
-    local tex = NewTex()
-    reassertDesat(fMatch, tex)
-    assert(#tex.levels == 0 and #tex.bools == 0, "setting ON: desaturation untouched")
-end
-
--- 12) Non-aura phase: never touches Blizzard's desaturation.
-do
-    swipeStub.showCooldownIconAuraPhase = false
-    fMatch.cooldownUseAuraDisplayTime = false
-    cdDurObj = NewDurObj()
-    local tex = NewTex()
-    reassertDesat(fMatch, tex)
-    assert(#tex.levels == 0 and #tex.bools == 0, "non-aura phase: desaturation untouched")
-end
-
--- 13) Item-backed entry (trinket/slot/item): entry.id is an ITEM/SLOT id, not a
---     spellID -- must route through the resolvers' item duration-object builder,
---     never the spell queries (which returned nil and cleared the trinket to a
---     bright "ready" icon during its proc).
+-- 6) Item-backed entry: native timing remains untouched.
 do
     curatedEntry.type = "trinket"
     curatedEntry.spellID = nil
     curatedEntry.id = 13 -- trinket slot, NOT a spellID
     fMatch.cooldownUseAuraDisplayTime = true
     swipeStub.showCooldownIconAuraPhase = false
-    local itemDurObj = { itemSentinel = true }
     local itemCalls = {}
     ns.CDMResolvers = {
         BuildEntryItemDurationObject = function(entry)
             itemCalls[#itemCalls + 1] = entry
-            return itemDurObj
+            return { itemSentinel = true }
         end,
     }
     durQueries = {}
     local cd = NewCd()
     reassertColor(fMatch, cd)
-    assert(#itemCalls == 1 and itemCalls[1] == curatedEntry,
-        "item entry: resolvers item duration-object builder consulted")
-    assert(#durQueries == 0, "item entry: spell duration queries never consulted")
-    assert(#cd.binds == 1 and cd.binds[1].durObj == itemDurObj,
-        "item entry: widget re-bound to the ITEM cooldown duration object")
-    assert(cd.cleared == 0, "item entry with rolling CD: never cleared to ready")
-    -- desat rides the same item durObj through the curve
-    itemDurObj.EvaluateRemainingPercent = function(_, curve)
-        assert(curve == desatCurve, "item durObj evaluates through the shared curve")
-        return 0.77
-    end
-    local tex = NewTex()
-    reassertDesat(fMatch, tex)
-    assert(#tex.levels == 1 and tex.levels[1] == 0.77,
-        "item entry: curve-driven desaturation from the item durObj")
+    assert(#itemCalls == 0 and #durQueries == 0 and #cd.binds == 0
+        and #cd.auraDisplay == 0 and cd.cleared == 0,
+        "item entry: no native timing source or write")
     ns.CDMResolvers = nil
     curatedEntry.type = nil
     curatedEntry.spellID = 500
     curatedEntry.id = nil
 end
 
--- 14) Consumable entry: entry.id is a SPELL CATEGORY id -- resolves through
---     CDMIndex.GetByCategory -> primarySpellID into the spell duration path.
+-- 7) Consumable entry: native timing remains untouched.
 do
     curatedEntry.type = "consumable"
     curatedEntry.spellID = nil
@@ -337,10 +219,8 @@ do
     durQueries = {}
     local cd = NewCd()
     reassertColor(fMatch, cd)
-    assert(durQueries[1] and durQueries[1].kind == "cd" and durQueries[1].spellID == 777,
-        "consumable: spell duration queried with the category's primarySpellID")
-    assert(#cd.binds == 1 and cd.binds[1].durObj == cdDurObj,
-        "consumable: widget re-bound to the category cooldown duration object")
+    assert(#durQueries == 0 and #cd.binds == 0 and #cd.auraDisplay == 0 and cd.cleared == 0,
+        "consumable: no native timing source or write")
     ns.CDMIndex = nil
     curatedEntry.type = nil
     curatedEntry.spellID = 500

--- a/tests/unit/cdm_reanchor_auraphase_restyle_test.lua
+++ b/tests/unit/cdm_reanchor_auraphase_restyle_test.lua
@@ -2,9 +2,8 @@
 -- Run: lua tests/unit/cdm_reanchor_auraphase_restyle_test.lua
 -- Locks the reassertColor contract for showCooldownIconAuraPhase on re-anchored
 -- NATIVE frames: setting ON -> aura colour over Blizzard's native aura timing;
--- setting OFF -> re-bind the widget to the spell's REAL cooldown via a duration
--- object (spell CD first, charge recharge fallback), or clear to ready when the
--- spell has no cooldown behind the buff. Colour honours showCooldownSwipe.
+-- setting OFF -> leave Blizzard's native aura presentation untouched. Colour
+-- honours showCooldownSwipe.
 local ns = {}
 -- Task 45f: cdm_reanchor*.lua route discarded-result pcall guards through
 -- ns.SafeCall. Additive stub (T1d/T1e precedent) — bare pcall passthrough.
@@ -125,7 +124,7 @@ do
         "setting ON: native aura timing untouched")
 end
 
--- 2) Setting OFF + aura phase: keep Blizzard's native timing untouched.
+-- 2) Setting OFF + aura phase: exclude native aura presentation from the setting.
 do
     swipeStub.showCooldownIconAuraPhase = false
     fMatch.cooldownUseAuraDisplayTime = true
@@ -133,12 +132,8 @@ do
     durQueries = {}
     local cd = NewCd()
     reassertColor(fMatch, cd)
-    assert(#durQueries == 0 and #cd.auraDisplay == 0 and #cd.binds == 0 and cd.cleared == 0,
-        "setting OFF: native timing remains untouched")
-    local c = assert(lastColor(cd))
-    assert(c[1] == 0 and c[2] == 0 and c[3] == 0 and c[4] == 0.8,
-        "setting OFF: cooldown (fallback dark) colour")
-    assert(cd.cleared == 0, "active CD: no clear")
+    assert(#durQueries == 0 and #cd.colors == 0 and #cd.auraDisplay == 0 and #cd.binds == 0 and cd.cleared == 0,
+        "setting OFF: native aura presentation remains untouched")
 end
 
 -- 3) Setting OFF + cooldown swipe disabled: only the visual colour is hidden.
@@ -159,10 +154,8 @@ do
     local orphan = { cooldownUseAuraDisplayTime = true }
     local cd = NewCd()
     reassertColor(orphan, cd)
-    assert(cd.cleared == 0 and #cd.binds == 0 and #cd.auraDisplay == 0,
-        "no entry: no native timing writes")
-    local c = assert(lastColor(cd))
-    assert(c[4] == 0.8, "no entry: cooldown colour remains visual-only")
+    assert(cd.cleared == 0 and #cd.colors == 0 and #cd.binds == 0 and #cd.auraDisplay == 0,
+        "no entry: native aura presentation remains untouched")
 end
 
 -- 5) Non-aura phase: unchanged cooldown-colour path, no timing writes.

--- a/tests/unit/cdm_reanchor_auraphase_test.lua
+++ b/tests/unit/cdm_reanchor_auraphase_test.lua
@@ -1,10 +1,8 @@
 -- tests/unit/cdm_reanchor_auraphase_test.lua
 -- Run: lua tests/unit/cdm_reanchor_auraphase_test.lua
 -- Locks the hook contract of the re-anchor swipe colour owner.
--- :Hook installs SetSwipeColor / SetDrawEdge / SetCooldown post-hooks (never
--- RefreshSpellCooldownInfo). :OnSwipeColor -> reassertColor re-asserts the QUI
--- colour from non-secret state; :OnCooldownSet re-asserts AFTER Blizzard's
--- timing write so the aura-phase-off re-bind survives the refresh.
+-- :Hook installs only taint-safe visual post-hooks (never
+-- RefreshSpellCooldownInfo or native timing/desaturation hooks).
 
 local ns = {}
 -- Task 45f: cdm_reanchor_auraphase.lua routes discarded-result pcall guards
@@ -100,12 +98,8 @@ do
     assert(calls == 2, "G13: nil cooldown frame must be a no-op")
 end
 
--- Timing post-hook: :Hook ALSO installs a SetCooldown hook. Blizzard's refresh
--- recolours BEFORE it re-binds timing (CooldownViewer.lua:1166 vs :1169), so the
--- aura-phase-off re-bind must re-assert from the LAST timing write to survive.
--- Desat post-hook: :Hook ALSO installs a SetDesaturated hook on the icon TEXTURE
--- (frame.Icon): RefreshData writes desaturation AFTER the timing refresh
--- (:1269 vs :1271), so the aura-phase-off saturation must re-assert from there.
+-- Native CDM timing and desaturation setters are untainted-only. QUI leaves
+-- Blizzard's timing and saturation state alone.
 do
     local hooked = {}
     local texHooked = {}
@@ -118,60 +112,16 @@ do
         end,
         reassertColor = function() end,
         reassertEdge = function() end,
-        reassertDesat = function() end,
         isAuraPhaseEnabled = function() return true end,
     })
     local frame = { GetCooldownFrame = function() return cd end, Icon = tex }
     inst:Hook(frame)
-    assert(hooked["SetCooldown"] == true, "Hook must install a SetCooldown timing post-hook")
-    assert(texHooked["SetDesaturated"] == true,
-        "Hook must install a SetDesaturated post-hook on the icon texture")
+    assert(hooked["SetCooldown"] == nil,
+        "Hook must not install an untainted-only SetCooldown hook")
+    assert(texHooked["SetDesaturated"] == nil,
+        "Hook must not install an untainted-only SetDesaturated hook")
     assert(hooked["RefreshSpellCooldownInfo"] == nil,
         "still NEVER hooks RefreshSpellCooldownInfo (secret-value taint)")
-end
-
--- :OnCooldownSet -> reassertColor once, guarded against BOTH its own re-fire and
--- the colour hook: the reassert's SetSwipeColor re-fires OnSwipeColor, which must
--- no-op while the timing re-assert is in flight (no double restyle per refresh).
-do
-    local calls = 0
-    local inst
-    local deps = {
-        reassertColor = function(f, cdw)
-            calls = calls + 1
-            inst:OnSwipeColor(f, cdw)   -- simulate the reassert's SetSwipeColor re-firing the colour hook
-            inst:OnCooldownSet(f, cdw)  -- and a nested SetCooldown re-fire
-        end,
-    }
-    inst = M.New(deps)
-    local f, cdw = {}, {}
-    inst:OnCooldownSet(f, cdw)
-    assert(calls == 1, "OnCooldownSet calls reassertColor once (both guards held)")
-    inst:OnCooldownSet(f, cdw)
-    assert(calls == 2, "guards clear after each call so later refreshes re-assert")
-    inst:OnCooldownSet(f, nil)
-    assert(calls == 2, "nil cooldown frame must be a no-op")
-end
-
--- :OnDesaturated -> reassertDesat once (re-entry guarded so the reassert's own
--- boolean SetDesaturated fallback, which re-fires the hook, cannot recurse).
-do
-    local calls = 0
-    local inst
-    local deps = {
-        reassertDesat = function(f, texArg)
-            calls = calls + 1
-            inst:OnDesaturated(f, texArg)  -- simulate the fallback's SetDesaturated re-firing
-        end,
-    }
-    inst = M.New(deps)
-    local f, tex = {}, {}
-    inst:OnDesaturated(f, tex)
-    assert(calls == 1, "OnDesaturated calls reassertDesat once (re-entry guarded)")
-    inst:OnDesaturated(f, tex)
-    assert(calls == 2, "guard clears after each call so later re-asserts fire")
-    inst:OnDesaturated(f, nil)
-    assert(calls == 2, "nil texture must be a no-op")
 end
 
 print("OK: cdm_reanchor_auraphase_test")

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -227,4 +227,17 @@ assert(type(facade.DrainPendingCombatRefresh) == "function",
 -- calling it with no deferred keys is a safe no-op
 facade:DrainPendingCombatRefresh()
 
+-- Item/category-backed cooldown entries are stable aura-capable entries even
+-- when Blizzard does not expose linkedSpellIDs on the curated entry.
+swipeStub.showCooldownIconAuraPhase = false
+local shouldReplace = capturedRuntimeDeps.shouldReplaceNativeAuraPhase
+for _, entryType in ipairs({ "item", "slot", "trinket", "consumable", "macro" }) do
+    assert(shouldReplace({}, { type = entryType }, "essential") == true,
+        entryType .. "-backed cooldown replaces native aura phase")
+end
+assert(shouldReplace({}, { type = "spell" }, "essential") == false,
+    "unlinked spell cooldown remains native")
+assert(shouldReplace({}, { type = "item" }, "buff") == false,
+    "item-backed BuffIcon entry remains native")
+
 print("OK: cdm_reanchor_boot_buildruntime_test")

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -227,17 +227,17 @@ assert(type(facade.DrainPendingCombatRefresh) == "function",
 -- calling it with no deferred keys is a safe no-op
 facade:DrainPendingCombatRefresh()
 
--- Item/category-backed cooldown entries are stable aura-capable entries even
--- when Blizzard does not expose linkedSpellIDs on the curated entry.
 swipeStub.showCooldownIconAuraPhase = false
 local shouldReplace = capturedRuntimeDeps.shouldReplaceNativeAuraPhase
 for _, entryType in ipairs({ "item", "slot", "trinket", "consumable", "macro" }) do
     assert(shouldReplace({}, { type = entryType }, "essential") == true,
         entryType .. "-backed cooldown replaces native aura phase")
 end
-assert(shouldReplace({}, { type = "spell" }, "essential") == false,
-    "unlinked spell cooldown remains native")
+assert(shouldReplace({}, { type = "spell" }, "essential") == true,
+    "ordinary spell cooldown replaces native aura phase")
 assert(shouldReplace({}, { type = "item" }, "buff") == false,
     "item-backed BuffIcon entry remains native")
+assert(shouldReplace({}, { type = "spell", kind = "aura" }, "essential") == false,
+    "explicit aura entry remains native")
 
 print("OK: cdm_reanchor_boot_buildruntime_test")

--- a/tests/unit/cdm_reanchor_runtime_directanchor_assemble_test.lua
+++ b/tests/unit/cdm_reanchor_runtime_directanchor_assemble_test.lua
@@ -104,6 +104,28 @@ do
         "disabled native aura phase renders the owned cooldown icon")
     assert(minted == 1 and sinks[1] == nativeFrame and claimed[nativeFrame] == nil,
         "disabled native aura phase sinks the native aura widget")
+
+    local buffEntry = {
+        name = "Native buff", kind = "aura", linkedSpellIDs = { 12345 },
+    }
+    local buffFrame = { cooldownUseAuraDisplayTime = true }
+    local buffRuntime = R.New({
+        bridge = { Sink = function() error("buff native frame must stay native") end },
+        wiring = {
+            MatchCuratedToFrames = function()
+                return { { entry = buffEntry, frame = buffFrame } }, {}, { [buffFrame] = true }
+            end,
+        },
+        getCurated = function() return { buffEntry } end,
+        getAdditional = function() return {} end,
+        shouldReplaceNativeAuraPhase = function(_frame, entry, key)
+            return key ~= "buff" and entry.kind ~= "aura"
+        end,
+        mintOwned = function() error("buff aura entry must not mint") end,
+    })
+    local buffEntries = buffRuntime:AssembleEntries("buff", {})
+    assert(#buffEntries == 1 and buffEntries[1].reanchored == true,
+        "disabled aura phase leaves dedicated buff icons native")
 end
 
 -- Active-only BuffIcon must not treat a missing native frame as active. Cold login

--- a/tests/unit/cdm_reanchor_runtime_directanchor_assemble_test.lua
+++ b/tests/unit/cdm_reanchor_runtime_directanchor_assemble_test.lua
@@ -78,7 +78,9 @@ do
 end
 
 do
-    local nativeEntry = { name = "Native cooldown", _assignedRow = 2 }
+    local nativeEntry = {
+        name = "Native cooldown", _assignedRow = 2, linkedSpellIDs = { 12345 },
+    }
     local nativeFrame = { cooldownUseAuraDisplayTime = true }
     local ownedIcon = { f = "owned-cooldown" }
     local sinks, minted = {}, 0
@@ -91,8 +93,8 @@ do
         },
         getCurated = function() return { nativeEntry } end,
         getAdditional = function() return {} end,
-        shouldReplaceNativeAuraPhase = function(frame)
-            return frame.cooldownUseAuraDisplayTime == true
+        shouldReplaceNativeAuraPhase = function(_frame, entry)
+            return type(entry.linkedSpellIDs) == "table" and #entry.linkedSpellIDs > 0
         end,
         mintOwned = function() minted = minted + 1; return ownedIcon end,
     })

--- a/tests/unit/cdm_reanchor_runtime_directanchor_assemble_test.lua
+++ b/tests/unit/cdm_reanchor_runtime_directanchor_assemble_test.lua
@@ -77,6 +77,33 @@ do
     assert(#minted == 0, "essential frameless miss must not mint an owned fallback")
 end
 
+do
+    local nativeEntry = { name = "Native cooldown", _assignedRow = 2 }
+    local nativeFrame = { cooldownUseAuraDisplayTime = true }
+    local ownedIcon = { f = "owned-cooldown" }
+    local sinks, minted = {}, 0
+    local runtime = R.New({
+        bridge = { Sink = function(_, frame) sinks[#sinks + 1] = frame end },
+        wiring = {
+            MatchCuratedToFrames = function()
+                return { { entry = nativeEntry, frame = nativeFrame } }, {}, { [nativeFrame] = true }
+            end,
+        },
+        getCurated = function() return { nativeEntry } end,
+        getAdditional = function() return {} end,
+        shouldReplaceNativeAuraPhase = function(frame)
+            return frame.cooldownUseAuraDisplayTime == true
+        end,
+        mintOwned = function() minted = minted + 1; return ownedIcon end,
+    })
+
+    local entries, claimed = runtime:AssembleEntries("essential", {})
+    assert(#entries == 1 and entries[1].frame == ownedIcon and entries[1].reanchored == false,
+        "disabled native aura phase renders the owned cooldown icon")
+    assert(minted == 1 and sinks[1] == nativeFrame and claimed[nativeFrame] == nil,
+        "disabled native aura phase sinks the native aura widget")
+end
+
 -- Active-only BuffIcon must not treat a missing native frame as active. Cold login
 -- can classify configured buff entries as frameless before Blizzard creates live
 -- BuffIcon children; those unknown entries stay hidden unless QUI layout mode


### PR DESCRIPTION
## What changed

- Remove native `SetCooldown` and `SetDesaturated` post-hooks from re-anchored CDM frames.
- Stop rewriting Blizzard-owned cooldown timing and desaturation from QUI.
- Keep taint-safe swipe-color and draw-edge styling.
- Update regression tests for the native-frame ownership boundary.

## Why

The previous aura-phase override called untainted-only cooldown timing/desaturation APIs from `QUI_CDM`. That tainted Blizzard `CooldownViewer` continuations and produced forbidden-table errors during target and aura refreshes.

## Validation

`bash tools/test.sh` passed all 9 gates: compile, strict taint, profile tests, 847 unit tests, tooling/i18n, lint, generated-cache, and i18n freshness.
