### PR TITLE
fix: complete aura and CDM updates

### DIFF
--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -1146,12 +1146,12 @@ local function ShouldDeferContainerLayoutInCombat(trackerKey, settings, runtimeV
 
     local auraRuns = ns.CDMCustomAuraRuns
     local owner = containers[trackerKey]
-    local hasAuraMirrors = auraRuns and auraRuns.HasAuraMirrors
-        and auraRuns.HasAuraMirrors(owner)
-    if hasAuraMirrors then return true end
-    local usesAuraMirrors = auraRuns and auraRuns.HasPreparedAuraMirrors
-        and auraRuns.HasPreparedAuraMirrors(owner)
-    if usesAuraMirrors then return true end
+    local hasActiveOverlays = auraRuns and auraRuns.HasAuraOverlays
+        and auraRuns.HasAuraOverlays(owner)
+    if hasActiveOverlays then return true end
+    local hasPreparedOverlays = auraRuns and auraRuns.HasPreparedAuraOverlays
+        and auraRuns.HasPreparedAuraOverlays(owner)
+    if hasPreparedOverlays then return true end
     local hasActiveRuns = auraRuns and auraRuns.HasActiveRuns
         and auraRuns.HasActiveRuns(owner)
     if hasActiveRuns then

--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -105,6 +105,7 @@ function Runs.ShouldUseCooldownAuraOverlays(settings, viewerType)
     local swipeSettings = swipe and swipe.GetSettings and swipe.GetSettings()
     if swipeSettings and swipeSettings.showCooldownIconAuraPhase == false then return false end
     if (settings.iconDisplayMode or "always") ~= "always" then return false end
+    if settings.showActiveState == false or settings.hideNonUsable == true then return false end
     return settings.showOnlyWhenActive ~= true
         and settings.showOnlyOnCooldown ~= true
         and settings.showOnlyWhenOffCooldown ~= true
@@ -256,7 +257,7 @@ local function Profile(rowConfig)
         showEdge = showEdge,
         swipeTexture = "Interface\\Buttons\\WHITE8X8",
         swipeColor = swipeColor,
-        reverseSwipe = false,
+        reverseSwipe = true,
         swipeStyle = "radial",
         duration = {
             show = rowConfig.hideDurationText ~= true,

--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -4,12 +4,13 @@ local Runs = {}
 ns.CDMCustomAuraRuns = Runs
 
 local activeOwners = setmetatable({}, { __mode = "k" })
-local activeMirrorOwners = setmetatable({}, { __mode = "k" })
-local preparedMirrorOwners = setmetatable({}, { __mode = "k" })
+local activeAuraOverlayOwners = setmetatable({}, { __mode = "k" })
+local preparedAuraOverlayOwners = setmetatable({}, { __mode = "k" })
 local HELPFUL_FILTER = "HELPFUL|PLAYER|INCLUDE_NAME_PLATE_ONLY"
 local HARMFUL_FILTER = "HARMFUL|PLAYER"
+local PET_AURA_UNITS = { [1235391] = true }
 local ResolveRoute
-local mirrorManager
+local auraOverlayManagers = {}
 
 local function IsSecret(value)
     return issecretvalue and issecretvalue(value)
@@ -79,6 +80,42 @@ function Runs.HasAuraEntries(settings, viewerType)
     return false
 end
 
+local function IsCooldownAuraOverlayEntry(entry)
+    return type(entry) == "table"
+        and entry.enabled ~= false
+        and entry._isCustomEntry == true
+        and entry.kind == "cooldown"
+        and (entry.type == nil or entry.type == "spell")
+end
+
+function Runs.ShouldUseCooldownAuraOverlays(settings, viewerType)
+    if type(settings) ~= "table" or settings.containerType ~= "customBar" then return false end
+    if type(viewerType) ~= "string" or viewerType == "" then return false end
+    local swipe = ns._OwnedSwipe
+    local swipeSettings = swipe and swipe.GetSettings and swipe.GetSettings()
+    if swipeSettings and swipeSettings.showCooldownIconAuraPhase == false then return false end
+    if (settings.iconDisplayMode or "always") ~= "always" then return false end
+    return settings.showOnlyWhenActive ~= true
+        and settings.showOnlyOnCooldown ~= true
+        and settings.showOnlyWhenOffCooldown ~= true
+        and settings.showOnlyInCombat ~= true
+end
+
+function Runs.HasCooldownAuraOverlayEntries(settings, viewerType)
+    if not Runs.ShouldUseCooldownAuraOverlays(settings, viewerType) then return false end
+    local entries
+    if settings.specSpecific and ns.CDMSpellData and ns.CDMSpellData.GetSpecEntries then
+        entries = ns.CDMSpellData:GetSpecEntries(viewerType)
+    end
+    entries = type(entries) == "table" and entries or settings.entries
+    if type(entries) ~= "table" then return false end
+    for i = 1, #entries do
+        local entry = entries[i]
+        if entry and entry.enabled ~= false and entry.kind == "cooldown" then return true end
+    end
+    return false
+end
+
 local function CandidateIDs(entry)
     local out, seen = {}, {}
     local function add(value)
@@ -112,6 +149,16 @@ local function CandidateIDs(entry)
     return out
 end
 
+local function ResolveCooldownAuraUnit(entry)
+    local unit = entry and entry.auraUnit
+    if unit == "player" or unit == "pet" then return unit end
+    local ids = CandidateIDs(entry)
+    for i = 1, #ids do
+        if PET_AURA_UNITS[ids[i]] then return "pet" end
+    end
+    return "player"
+end
+
 ResolveRoute = function(entry)
     if type(entry) ~= "table" or entry.source ~= "blizzardCDM" then return nil end
     local selfAura = entry._selfAura
@@ -143,40 +190,6 @@ function Runs.ResolveRoute(entry)
     return ResolveRoute(entry)
 end
 
-local function IsAuraMirrorEntry(entry)
-    return type(entry) == "table"
-        and entry.enabled ~= false
-        and entry.kind ~= "aura"
-        and ResolveRoute(entry) == "SELF_HELPFUL"
-end
-
-function Runs.ShouldUseAuraMirrors(settings, viewerType)
-    if type(settings) ~= "table" or settings.containerType ~= "customBar" then return false end
-    if type(viewerType) ~= "string" or viewerType == "" then return false end
-    local swipe = ns._OwnedSwipe
-    local swipeSettings = swipe and swipe.GetSettings and swipe.GetSettings()
-    if swipeSettings and swipeSettings.showCooldownIconAuraPhase == false then return false end
-    if (settings.iconDisplayMode or "always") ~= "always" then return false end
-    return settings.showOnlyWhenActive ~= true
-        and settings.showOnlyOnCooldown ~= true
-        and settings.showOnlyWhenOffCooldown ~= true
-        and settings.showOnlyInCombat ~= true
-end
-
-function Runs.HasAuraMirrorEntries(settings, viewerType)
-    if not Runs.ShouldUseAuraMirrors(settings, viewerType) then return false end
-    local entries
-    if settings.specSpecific and ns.CDMSpellData and ns.CDMSpellData.GetSpecEntries then
-        entries = ns.CDMSpellData:GetSpecEntries(viewerType)
-    end
-    entries = type(entries) == "table" and entries or settings.entries
-    if type(entries) ~= "table" then return false end
-    for i = 1, #entries do
-        if IsAuraMirrorEntry(entries[i]) then return true end
-    end
-    return false
-end
-
 local function Profile(rowConfig)
     local size = rowConfig.size or 39
     local aspect = rowConfig.aspectRatioCrop or 1
@@ -195,6 +208,22 @@ local function Profile(rowConfig)
         local r, g, b, a = ns.Helpers.GetSkinBorderColor(rowConfig, "")
         borderColor = { r, g, b, a }
     end
+    local swipeSettings = ns._OwnedSwipe
+        and ns._OwnedSwipe.GetSettings
+        and ns._OwnedSwipe.GetSettings()
+    local showSwipe = not (swipeSettings and swipeSettings.showBuffSwipe == false)
+    local showEdge = showSwipe and not (swipeSettings and swipeSettings.showBuffEdge == false)
+    local swipeColor
+    if ns._CDM_ResolveModeColor and swipeSettings then
+        local r, g, b, a = ns._CDM_ResolveModeColor(swipeSettings, "aura")
+        swipeColor = { r, g, b, a }
+    elseif swipeSettings and swipeSettings.overlayColorMode == "custom"
+        and type(swipeSettings.overlayColor) == "table" then
+        local c = swipeSettings.overlayColor
+        swipeColor = { c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1 }
+    else
+        swipeColor = { 0.93, 0.77, 0, 0.45 }
+    end
     return {
         maxIcons = 1,
         iconSize = size,
@@ -210,7 +239,10 @@ local function Profile(rowConfig)
         borderSize = rowConfig.borderSize or 1,
         showBorder = (rowConfig.borderSize or 1) > 0,
         borderColor = borderColor,
-        hideSwipe = false,
+        hideSwipe = not showSwipe,
+        showEdge = showEdge,
+        swipeTexture = "Interface\\Buttons\\WHITE8X8",
+        swipeColor = swipeColor,
         reverseSwipe = false,
         swipeStyle = "radial",
         duration = {
@@ -237,13 +269,15 @@ local function Profile(rowConfig)
     }
 end
 
-local function GetMirrorManager()
-    if mirrorManager then return mirrorManager end
+local function GetAuraOverlayManager(unit)
+    unit = unit or "player"
+    if auraOverlayManagers[unit] then return auraOverlayManagers[unit] end
     local mirrors = ns.CDMManagedAuraMirrors
     if not (mirrors and mirrors.New) then return nil end
     local AuraSkin = ns.AuraSkin or (ns.Addon and ns.Addon.AuraSkin)
-    mirrorManager = mirrors.New({
+    local manager = mirrors.New({
         createFrame = CreateFrame,
+        unit = unit,
         isSecret = IsSecret,
         canCreate = function()
             return not (InCombatLockdown and InCombatLockdown())
@@ -259,64 +293,90 @@ local function GetMirrorManager()
         restyleFrame = AuraSkin and function(frame, rowConfig)
             return AuraSkin.WireButton(frame, Profile(rowConfig))
         end,
-        positionBase = function(baseIcon, host)
-            if host.SetFrameLevel and baseIcon.GetFrameLevel then
-                host:SetFrameLevel(baseIcon:GetFrameLevel() + 20)
-            end
-        end,
     })
-    return mirrorManager
+    auraOverlayManagers[unit] = manager
+    return manager
 end
 
-local function DisableAuraMirrors(owner)
-    if not owner or not activeMirrorOwners[owner] then return end
-    local manager = GetMirrorManager()
-    if manager and manager:BeginPass(owner) then manager:EndPass(owner) end
-    activeMirrorOwners[owner] = nil
-end
-
-function Runs.HasAuraMirrors(owner)
-    return owner and activeMirrorOwners[owner] == true
-end
-
-function Runs.HasPreparedAuraMirrors(owner)
-    return owner and preparedMirrorOwners[owner] == true
-end
-
-local function ApplyAuraMirrors(owner, settings, layoutPlan, inCombat, viewerType)
-    if owner and not inCombat then
-        preparedMirrorOwners[owner] = Runs.ShouldUseAuraMirrors(settings, viewerType)
-            and Runs.HasAuraMirrorEntries(settings, viewerType) or nil
+local function DisableCooldownAuraOverlays(owner)
+    if not owner or not activeAuraOverlayOwners[owner] then return end
+    for unit in pairs(auraOverlayManagers) do
+        local manager = GetAuraOverlayManager(unit)
+        if manager and manager:BeginPass(owner, false) then manager:EndPass(owner) end
     end
-    if inCombat then return Runs.HasAuraMirrors(owner) end
-    local manager = GetMirrorManager()
-    local eligible = owner and not inCombat and manager
-        and Runs.ShouldUseAuraMirrors(settings, viewerType)
+    activeAuraOverlayOwners[owner] = nil
+end
+
+function Runs.HasAuraOverlays(owner)
+    return owner and activeAuraOverlayOwners[owner] == true
+end
+
+function Runs.HasPreparedAuraOverlays(owner)
+    return owner and preparedAuraOverlayOwners[owner] == true
+end
+
+function Runs.RefreshCooldownAuraOverlays(unit)
+    for overlayUnit, manager in pairs(auraOverlayManagers) do
+        if not unit or overlayUnit == unit then
+            manager:Refresh()
+        end
+    end
+end
+
+local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, viewerType)
+    if owner and not inCombat then
+        preparedAuraOverlayOwners[owner] = Runs.ShouldUseCooldownAuraOverlays(settings, viewerType)
+            and Runs.HasCooldownAuraOverlayEntries(settings, viewerType) or nil
+    end
+    if inCombat then return Runs.HasAuraOverlays(owner) end
+
+    local eligible = owner
+        and Runs.ShouldUseCooldownAuraOverlays(settings, viewerType)
         and layoutPlan and layoutPlan.placements
     if not eligible then
-        if not inCombat then DisableAuraMirrors(owner) end
-        return inCombat and Runs.HasAuraMirrors(owner) or false
+        DisableCooldownAuraOverlays(owner)
+        return false
     end
-    if not manager:BeginPass(owner) then return Runs.HasAuraMirrors(owner) end
+    local managers = {}
+    for i = 1, #layoutPlan.placements do
+        local placement = layoutPlan.placements[i]
+        if IsCooldownAuraOverlayEntry(placement.icon and placement.icon._spellEntry) then
+            local unit = ResolveCooldownAuraUnit(placement.icon._spellEntry)
+            if not managers[unit] then
+                local manager = GetAuraOverlayManager(unit)
+                if manager and manager:BeginPass(owner) then managers[unit] = manager end
+            end
+        end
+    end
+    for unit, manager in pairs(auraOverlayManagers) do
+        if not managers[unit] and manager:BeginPass(owner, false) then
+            managers[unit] = manager
+        end
+    end
+    local managerCount = 0
+    for _ in pairs(managers) do managerCount = managerCount + 1 end
+    if managerCount == 0 then return Runs.HasAuraOverlays(owner) end
 
     local mirrored = 0
     for i = 1, #layoutPlan.placements do
         local placement = layoutPlan.placements[i]
         local icon = placement.icon
-        if IsAuraMirrorEntry(icon and icon._spellEntry) then
-            local record = manager:Acquire(owner, icon, icon._spellEntry, Profile(placement.rowConfig))
-            local rowConfig = placement.rowConfig
+        if IsCooldownAuraOverlayEntry(icon and icon._spellEntry) then
+            local rowConfig = placement.rowConfig or {}
             local width = rowConfig.size or 39
             local aspect = rowConfig.aspectRatioCrop or 1
             if aspect <= 0 then aspect = 1 end
-            if record and manager:Position(record, icon, owner, placement.x, placement.y,
+            local manager = managers[ResolveCooldownAuraUnit(icon._spellEntry)]
+            local record = manager and manager:Acquire(owner, icon, icon._spellEntry,
+                Profile(rowConfig))
+            if record and manager:PositionOverlay(record, icon, owner, placement.x, placement.y,
                 width, width / aspect, rowConfig) then
                 mirrored = mirrored + 1
             end
         end
     end
-    manager:EndPass(owner)
-    activeMirrorOwners[owner] = mirrored > 0 or nil
+    for _, manager in pairs(managers) do manager:EndPass(owner) end
+    activeAuraOverlayOwners[owner] = mirrored > 0 or nil
     return mirrored > 0
 end
 
@@ -557,11 +617,12 @@ local function AnchorPreparedRuns(owner, layoutPlan, runByIcon)
 end
 
 function Runs.Apply(owner, settings, layoutPlan, allIcons, inCombat, viewerType)
-    local mirrorsApplied = ApplyAuraMirrors(owner, settings, layoutPlan, inCombat, viewerType)
+    local overlaysApplied = ApplyCooldownAuraOverlays(
+        owner, settings, layoutPlan, inCombat, viewerType)
     if not (owner and Runs.ShouldUseSettings(settings, viewerType)
         and layoutPlan and layoutPlan.placements) then
         if not inCombat then Disable(owner) end
-        return mirrorsApplied
+        return overlaysApplied
     end
 
     local AuraSkin = ns.AuraSkin or (ns.Addon and ns.Addon.AuraSkin)
@@ -570,6 +631,7 @@ function Runs.Apply(owner, settings, layoutPlan, allIcons, inCombat, viewerType)
 
     if inCombat then
         return Runs.RelayoutPreparedInCombat(owner, settings, allIcons) ~= nil
+            or overlaysApplied
     end
 
     local runRecords = {}

--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -326,14 +326,6 @@ function Runs.HasPreparedAuraOverlays(owner)
     return owner and preparedAuraOverlayOwners[owner] == true
 end
 
-function Runs.RefreshCooldownAuraOverlays(unit)
-    for overlayUnit, manager in pairs(auraOverlayManagers) do
-        if not unit or overlayUnit == unit then
-            manager:Refresh()
-        end
-    end
-end
-
 local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, viewerType)
     if owner and not inCombat then
         ClearPreparedAuraOverlayIcons(owner)
@@ -386,8 +378,14 @@ local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, 
                 Profile(rowConfig))
             if record and manager:PositionOverlay(record, icon, owner, placement.x, placement.y,
                 width, width / aspect, rowConfig) then
-                icon._customAuraOverlayPrepared = true
-                preparedIcons[icon] = true
+                for j = 1, #(record.slots or {}) do
+                    local frame = record.slots[j].frame
+                    if frame and frame.IsShown and frame:IsShown() then
+                        icon._customAuraOverlayPrepared = true
+                        preparedIcons[icon] = true
+                        break
+                    end
+                end
                 mirrored = mirrored + 1
             end
         end

--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -121,7 +121,10 @@ function Runs.HasCooldownAuraOverlayEntries(settings, viewerType)
     if type(entries) ~= "table" then return false end
     for i = 1, #entries do
         local entry = entries[i]
-        if entry and entry.enabled ~= false and entry.kind == "cooldown" then return true end
+        if entry and entry.enabled ~= false and entry.kind == "cooldown"
+            and (entry.type == nil or entry.type == "spell") then
+            return true
+        end
     end
     return false
 end
@@ -378,14 +381,8 @@ local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, 
                 Profile(rowConfig))
             if record and manager:PositionOverlay(record, icon, owner, placement.x, placement.y,
                 width, width / aspect, rowConfig) then
-                for j = 1, #(record.slots or {}) do
-                    local frame = record.slots[j].frame
-                    if frame and frame.IsShown and frame:IsShown() then
-                        icon._customAuraOverlayPrepared = true
-                        preparedIcons[icon] = true
-                        break
-                    end
-                end
+                icon._customAuraOverlayPrepared = true
+                preparedIcons[icon] = true
                 mirrored = mirrored + 1
             end
         end

--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -6,11 +6,21 @@ ns.CDMCustomAuraRuns = Runs
 local activeOwners = setmetatable({}, { __mode = "k" })
 local activeAuraOverlayOwners = setmetatable({}, { __mode = "k" })
 local preparedAuraOverlayOwners = setmetatable({}, { __mode = "k" })
+local preparedAuraOverlayIcons = setmetatable({}, { __mode = "k" })
 local HELPFUL_FILTER = "HELPFUL|PLAYER|INCLUDE_NAME_PLATE_ONLY"
 local HARMFUL_FILTER = "HARMFUL|PLAYER"
 local PET_AURA_UNITS = { [1235391] = true }
 local ResolveRoute
 local auraOverlayManagers = {}
+
+local function ClearPreparedAuraOverlayIcons(owner)
+    local icons = owner and preparedAuraOverlayIcons[owner]
+    if not icons then return end
+    for icon in pairs(icons) do
+        icon._customAuraOverlayPrepared = nil
+    end
+    preparedAuraOverlayIcons[owner] = nil
+end
 
 local function IsSecret(value)
     return issecretvalue and issecretvalue(value)
@@ -299,6 +309,7 @@ local function GetAuraOverlayManager(unit)
 end
 
 local function DisableCooldownAuraOverlays(owner)
+    ClearPreparedAuraOverlayIcons(owner)
     if not owner or not activeAuraOverlayOwners[owner] then return end
     for unit in pairs(auraOverlayManagers) do
         local manager = GetAuraOverlayManager(unit)
@@ -324,6 +335,9 @@ function Runs.RefreshCooldownAuraOverlays(unit)
 end
 
 local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, viewerType)
+    if owner and not inCombat then
+        ClearPreparedAuraOverlayIcons(owner)
+    end
     if owner and not inCombat then
         preparedAuraOverlayOwners[owner] = Runs.ShouldUseCooldownAuraOverlays(settings, viewerType)
             and Runs.HasCooldownAuraOverlayEntries(settings, viewerType) or nil
@@ -358,6 +372,7 @@ local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, 
     if managerCount == 0 then return Runs.HasAuraOverlays(owner) end
 
     local mirrored = 0
+    local preparedIcons = {}
     for i = 1, #layoutPlan.placements do
         local placement = layoutPlan.placements[i]
         local icon = placement.icon
@@ -371,11 +386,14 @@ local function ApplyCooldownAuraOverlays(owner, settings, layoutPlan, inCombat, 
                 Profile(rowConfig))
             if record and manager:PositionOverlay(record, icon, owner, placement.x, placement.y,
                 width, width / aspect, rowConfig) then
+                icon._customAuraOverlayPrepared = true
+                preparedIcons[icon] = true
                 mirrored = mirrored + 1
             end
         end
     end
     for _, manager in pairs(managers) do manager:EndPass(owner) end
+    preparedAuraOverlayIcons[owner] = preparedIcons
     activeAuraOverlayOwners[owner] = mirrored > 0 or nil
     return mirrored > 0
 end

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -2364,6 +2364,10 @@ end
 function _resolverRuntimePolicy.ShouldSkipAuraPhaseForCooldownIcon(icon, entry)
     if not entry then return false end
     if IsAuraEntry(entry) then return false end
+    if entry._isCustomEntry == true and entry.kind == "cooldown"
+        and (entry.type == nil or entry.type == "spell") then
+        return true
+    end
     return _showCooldownIconAuraPhase == false
 end
 
@@ -4544,6 +4548,11 @@ do
         refreshCustomAuraTargets = function(identityChanged)
             if ns.CDMCustomAuraRuns and ns.CDMCustomAuraRuns.RefreshTargets then
                 ns.CDMCustomAuraRuns.RefreshTargets(identityChanged)
+            end
+        end,
+        refreshCustomCooldownAuraOverlays = function(unit)
+            if ns.CDMCustomAuraRuns and ns.CDMCustomAuraRuns.RefreshCooldownAuraOverlays then
+                ns.CDMCustomAuraRuns.RefreshCooldownAuraOverlays(unit)
             end
         end,
     }

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -2366,16 +2366,8 @@ function _resolverRuntimePolicy.ShouldSkipAuraPhaseForCooldownIcon(icon, entry)
     if IsAuraEntry(entry) then return false end
     if entry._isCustomEntry == true and entry.kind == "cooldown"
         and (entry.type == nil or entry.type == "spell") then
-        local settings = ResolveTrackerSettingsNow
-            and ResolveTrackerSettingsNow(entry.viewerType)
-        local nativeOverlayEligible = settings
-            and settings.containerType == "customBar"
-            and (settings.iconDisplayMode or "always") == "always"
-            and settings.showOnlyWhenActive ~= true
-            and settings.showOnlyOnCooldown ~= true
-            and settings.showOnlyWhenOffCooldown ~= true
-            and settings.showOnlyInCombat ~= true
-        return nativeOverlayEligible == true or _showCooldownIconAuraPhase == false
+        return icon and icon._customAuraOverlayPrepared == true
+            or _showCooldownIconAuraPhase == false
     end
     return _showCooldownIconAuraPhase == false
 end

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -2366,7 +2366,16 @@ function _resolverRuntimePolicy.ShouldSkipAuraPhaseForCooldownIcon(icon, entry)
     if IsAuraEntry(entry) then return false end
     if entry._isCustomEntry == true and entry.kind == "cooldown"
         and (entry.type == nil or entry.type == "spell") then
-        return true
+        local settings = ResolveTrackerSettingsNow
+            and ResolveTrackerSettingsNow(entry.viewerType)
+        local nativeOverlayEligible = settings
+            and settings.containerType == "customBar"
+            and (settings.iconDisplayMode or "always") == "always"
+            and settings.showOnlyWhenActive ~= true
+            and settings.showOnlyOnCooldown ~= true
+            and settings.showOnlyWhenOffCooldown ~= true
+            and settings.showOnlyInCombat ~= true
+        return nativeOverlayEligible == true or _showCooldownIconAuraPhase == false
     end
     return _showCooldownIconAuraPhase == false
 end

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -4551,11 +4551,6 @@ do
                 ns.CDMCustomAuraRuns.RefreshTargets(identityChanged)
             end
         end,
-        refreshCustomCooldownAuraOverlays = function(unit)
-            if ns.CDMCustomAuraRuns and ns.CDMCustomAuraRuns.RefreshCooldownAuraOverlays then
-                ns.CDMCustomAuraRuns.RefreshCooldownAuraOverlays(unit)
-            end
-        end,
     }
     runtimeRefresh = ns.CDMIconRuntimeRefresh and ns.CDMIconRuntimeRefresh.Create(callbacks)
 

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -131,6 +131,10 @@ local function isItemEntry(entry)
     return entryType == "item" or entryType == "trinket" or entryType == "slot"
 end
 
+local function isCustomCooldownEntry(entry)
+    return entry and entry._isCustomEntry == true and entry.kind == "cooldown"
+end
+
 local function resolveContainer(callbacks, entry, ncdm, ncdmContainers)
     if callbacks.resolveContainerDBAndType then
         return callbacks.resolveContainerDBAndType(entry, ncdm, ncdmContainers)
@@ -164,6 +168,20 @@ local function clearAuraDurationBinding(callbacks, icon)
         return false
     end
 
+    if callbacks.clearDurationBinding then
+        callbacks.clearDurationBinding(icon)
+    else
+        icon._lastDurObjKey = nil
+        icon._lastDurObj = nil
+        icon._lastResolvedMode = nil
+        icon._lastResolvedSourceID = nil
+        icon._lastResolvedSpellID = nil
+    end
+    return true
+end
+
+local function clearCustomCooldownDurationBinding(callbacks, icon, entry)
+    if not isCustomCooldownEntry(entry) then return false end
     if callbacks.clearDurationBinding then
         callbacks.clearDurationBinding(icon)
     else
@@ -313,6 +331,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
     function controller:ApplyAuraScope(options)
         options = options or {}
         local includeItems = options.includeItems == true
+        local includeCustomCooldowns = options.includeCustomCooldowns == true
         local skipSelfAuraFn = options.skipSelfAuraIcons == true
             and callbacks.isDefinitivelySelfAuraIcon
             or nil
@@ -325,11 +344,22 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                 if entry
                     and (isAuraEntry(callbacks, entry)
                         or icon._auraActive == true
-                        or (includeItems and isItemEntry(entry)))
+                        or (includeItems and isItemEntry(entry))
+                        or (includeCustomCooldowns and isCustomCooldownEntry(entry)))
                     and not (skipSelfAuraFn and skipSelfAuraFn(icon)) then
-                    clearAuraDurationBinding(callbacks, icon)
+                    if not clearCustomCooldownDurationBinding(callbacks, icon, entry) then
+                        clearAuraDurationBinding(callbacks, icon)
+                    end
                     if controller:ApplyAuraScopedResolvedCooldown(icon, entry, editMode, ncdm, ncdmContainers, inCombatState) then
                         if includeItems and isItemEntry(entry) then
+                            local containerDB = select(1, resolveContainer(callbacks, entry, ncdm, ncdmContainers))
+                            if callbacks.updateContainerVisibility then
+                                callbacks.updateContainerVisibility(icon, entry, containerDB, editMode, inCombatState)
+                            end
+                            if callbacks.syncCooldownBling then
+                                callbacks.syncCooldownBling(icon)
+                            end
+                        elseif includeCustomCooldowns and isCustomCooldownEntry(entry) then
                             local containerDB = select(1, resolveContainer(callbacks, entry, ncdm, ncdmContainers))
                             if callbacks.updateContainerVisibility then
                                 callbacks.updateContainerVisibility(icon, entry, containerDB, editMode, inCombatState)
@@ -647,6 +677,12 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                     and iconAuraInstanceID == nil then
                     matches = true
                 end
+                if not matches
+                    and hasRemovedIDs
+                    and isSelfAuraUnit(unit)
+                    and isCustomCooldownEntry(entry) then
+                    matches = true
+                end
                 if not matches and wakeAuraEntries and isAuraEntry(callbacks, entry) then
                     matches = true
                 end
@@ -661,7 +697,9 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                         editMode, ncdm, ncdmContainers, inCombatState = beginBatch(callbacks, "auraDelta")
                         batchStarted = true
                     end
-                    clearAuraDurationBinding(callbacks, icon)
+                    if not clearCustomCooldownDurationBinding(callbacks, icon, entry) then
+                        clearAuraDurationBinding(callbacks, icon)
+                    end
                     if controller:ApplyAuraScopedResolvedCooldown(icon, entry, editMode, ncdm, ncdmContainers, inCombatState) then
                         refreshed = refreshed + 1
                     end
@@ -979,7 +1017,11 @@ function CDMIconRuntimeRefresh.Create(callbacks)
 
         if not updateInfo or updateInfo.isFullUpdate then
             if callbacks.setBarsDirty then callbacks.setBarsDirty(true) end
-            controller:ApplyAuraScope({ includeItems = unit == "player", skipSelfAuraIcons = unit == "target" })
+            controller:ApplyAuraScope({
+                includeItems = unit == "player",
+                includeCustomCooldowns = isSelfAuraUnit(unit),
+                skipSelfAuraIcons = unit == "target",
+            })
             if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end
         else
             local refreshed = controller:ApplyAuraInstances(unit, updateInfo) or 0
@@ -987,6 +1029,10 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                 if callbacks.setBarsDirty then callbacks.setBarsDirty(true) end
                 if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end
             end
+        end
+
+        if callbacks.refreshCustomCooldownAuraOverlays and isSelfAuraUnit(unit) then
+            callbacks.refreshCustomCooldownAuraOverlays(unit)
         end
 
         if callbacks.eventTracePrint then

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -1025,10 +1025,6 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             end
         end
 
-        if callbacks.refreshCustomCooldownAuraOverlays and isSelfAuraUnit(unit) then
-            callbacks.refreshCustomCooldownAuraOverlays(unit)
-        end
-
         if callbacks.eventTracePrint then
             callbacks.eventTracePrint("aura-post", "UNIT_AURA", unit, nil, nil,
                 callbacks.eventTraceAuraInfo and callbacks.eventTraceAuraInfo(unit, updateInfo))

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -677,12 +677,6 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                     and iconAuraInstanceID == nil then
                     matches = true
                 end
-                if not matches
-                    and hasRemovedIDs
-                    and isSelfAuraUnit(unit)
-                    and isCustomCooldownEntry(entry) then
-                    matches = true
-                end
                 if not matches and wakeAuraEntries and isAuraEntry(callbacks, entry) then
                     matches = true
                 end

--- a/QUI_CDM/cdm/cdm_managed_aura_mirrors.lua
+++ b/QUI_CDM/cdm/cdm_managed_aura_mirrors.lua
@@ -63,7 +63,7 @@ function CDMManagedAuraMirrors:_GetPool(ownerContainer, allowCreate)
         "CustomAuraContainerTemplate")
     if not auraContainer then return nil end
     if auraContainer.SetSize then auraContainer:SetSize(1, 1) end
-    if auraContainer.SetUnit then auraContainer:SetUnit("player") end
+    if auraContainer.SetUnit then auraContainer:SetUnit(self._deps.unit or "player") end
     if auraContainer.SetEnabled then auraContainer:SetEnabled(true) end
     if auraContainer.Show then auraContainer:Show() end
     pool = {
@@ -77,8 +77,9 @@ function CDMManagedAuraMirrors:_GetPool(ownerContainer, allowCreate)
     return pool
 end
 
-function CDMManagedAuraMirrors:BeginPass(ownerContainer)
-    local canCreate = not self._deps.canCreate or self._deps.canCreate(ownerContainer)
+function CDMManagedAuraMirrors:BeginPass(ownerContainer, allowCreate)
+    local canCreate = allowCreate ~= false
+        and (not self._deps.canCreate or self._deps.canCreate(ownerContainer))
     local pool = self:_GetPool(ownerContainer, canCreate)
     if not pool then return false end
     pool.generation = pool.generation + 1
@@ -224,6 +225,37 @@ function CDMManagedAuraMirrors:Position(record, baseIcon, ownerContainer, x, y, 
         end
     end
     return true
+end
+
+function CDMManagedAuraMirrors:PositionOverlay(record, baseIcon, ownerContainer, x, y, w, h, rowConfig)
+    if not (record and record.host and baseIcon) then return false end
+    local canMutate = self._deps.canMutate
+    if canMutate and not canMutate(record.host) then return false end
+    local host = record.host
+    host:ClearAllPoints()
+    host:SetPoint("CENTER", baseIcon, "CENTER")
+    if host.SetSize and w and h then host:SetSize(w, h) end
+    if host.SetFrameLevel and baseIcon.GetFrameLevel then
+        host:SetFrameLevel(baseIcon:GetFrameLevel() + 20)
+    end
+    if host.Show then host:Show() end
+    local restyleFrame = self._deps.restyleFrame
+    if restyleFrame and not (self._deps.aurasAreSecret and self._deps.aurasAreSecret()) then
+        for i = 1, #record.slots do
+            local slot = record.slots[i]
+            if slot.frame then restyleFrame(slot.frame, rowConfig or record.profile or {}) end
+        end
+    end
+    return true
+end
+
+function CDMManagedAuraMirrors:Refresh()
+    for _, pool in pairs(self._pools) do
+        local auraContainer = pool.auraContainer
+        if auraContainer and auraContainer.UpdateAllAuras then
+            auraContainer:UpdateAllAuras()
+        end
+    end
 end
 
 function CDMManagedAuraMirrors:EndPass(ownerContainer)

--- a/core/aura_skin.lua
+++ b/core/aura_skin.lua
@@ -409,7 +409,7 @@ local function styleButton(button, profile)
 
     local cd = button._quiCooldown
     local wantsLinear = profile.swipeStyle == "horizontal" or profile.swipeStyle == "vertical"
-    if wantsLinear and button.SetDurationBar then
+    if wantsLinear and button.SetDurationBar and profile.hideSwipe ~= true then
         if cd and cd.SetDrawSwipe then cd:SetDrawSwipe(false) end
         local fill = button._quiDurationBar
         if not fill and InCombatLockdown() then
@@ -431,7 +431,21 @@ local function styleButton(button, profile)
     else
         if button._quiDurationBar then button._quiDurationBar:Hide() end
         if cd then
-            cd:SetDrawSwipe(profile.hideSwipe ~= true)
+            if cd.SetSwipeTexture and profile.swipeTexture then
+                cd:SetSwipeTexture(profile.swipeTexture)
+            end
+            local showSwipe = profile.hideSwipe ~= true
+            cd:SetDrawSwipe(showSwipe)
+            if cd.SetDrawEdge then
+                cd:SetDrawEdge(showSwipe and profile.showEdge ~= false)
+            end
+            if cd.SetDrawBling then
+                cd:SetDrawBling(showSwipe)
+            end
+            if profile.swipeColor and cd.SetSwipeColor then
+                local c = profile.swipeColor
+                cd:SetSwipeColor(c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1)
+            end
             cd:SetReverse(profile.reverseSwipe == true)
             cd:SetHideCountdownNumbers(true)
         end

--- a/core/aura_skin.lua
+++ b/core/aura_skin.lua
@@ -411,6 +411,8 @@ local function styleButton(button, profile)
     local wantsLinear = profile.swipeStyle == "horizontal" or profile.swipeStyle == "vertical"
     if wantsLinear and button.SetDurationBar and profile.hideSwipe ~= true then
         if cd and cd.SetDrawSwipe then cd:SetDrawSwipe(false) end
+        if cd and cd.SetDrawEdge then cd:SetDrawEdge(false) end
+        if cd and cd.SetDrawBling then cd:SetDrawBling(false) end
         local fill = button._quiDurationBar
         if not fill and InCombatLockdown() then
             return

--- a/tests/unit/aura_skin_linear_swipe_test.lua
+++ b/tests/unit/aura_skin_linear_swipe_test.lua
@@ -54,6 +54,8 @@ local function Stub()
     function t:SetFont() end
     function t:SetHideCountdownNumbers() end
     function t:SetDrawSwipe() end
+    function t:SetDrawEdge() end
+    function t:SetDrawBling() end
     function t:SetReverse() end
     function t:SetText() end
     function t:CreateTexture() return Stub() end
@@ -94,7 +96,11 @@ local function MakeButton()
     local b = Stub()
     b._cooldown = Stub()
     b._cooldown._drawSwipe = "UNSET"
+    b._cooldown._drawEdge = "UNSET"
+    b._cooldown._drawBling = "UNSET"
     function b._cooldown:SetDrawSwipe(v) self._drawSwipe = v end
+    function b._cooldown:SetDrawEdge(v) self._drawEdge = v end
+    function b._cooldown:SetDrawBling(v) self._drawBling = v end
     b._durationBarCalls = 0
     b._lastDurationBar = nil
     b._lastDurationBarOptions = nil
@@ -192,6 +198,13 @@ check("vertical swipeStyle orients the SAME fill VERTICAL",
 check("no second StatusBar child was created on re-style (fill is cached)",
     #createdStatusBars == 1)
 
+AuraSkin.Restyle(container, { iconSize = 20, swipeStyle = "horizontal", hideSwipe = true })
+check("hideSwipe hides a linear duration bar", fill1 ~= nil and fill1._shown == false)
+check("hideSwipe disables the Cooldown swipe for a linear strip",
+    button1._cooldown._drawSwipe == false)
+check("hideSwipe disables the Cooldown edge and bling",
+    button1._cooldown._drawEdge == false and button1._cooldown._drawBling == false)
+
 -- (3) Switching BACK to radial must hide the linear fill and restore the
 -- Cooldown's radial swipe.
 local profileRadial = { iconSize = 20, swipeStyle = "radial" }
@@ -199,6 +212,8 @@ AuraSkin.Restyle(container, profileRadial)
 check("switching back to radial hides the linear fill", fill1 ~= nil and fill1._shown == false)
 check("switching back to radial re-enables the Cooldown radial swipe",
     button1._cooldown._drawSwipe == true)
+check("switching back to radial re-enables the Cooldown edge and bling",
+    button1._cooldown._drawEdge == true and button1._cooldown._drawBling == true)
 
 if fails > 0 then error(fails .. " failure(s) in aura_skin_linear_swipe_test") end
 print("OK: aura_skin_linear_swipe_test (all checks passed)")

--- a/tests/unit/aura_skin_linear_swipe_test.lua
+++ b/tests/unit/aura_skin_linear_swipe_test.lua
@@ -171,6 +171,10 @@ AuraSkin.Configure(container, profileHorizontal, groups)
 local button1 = container._capturedButton
 check("radial swipe disabled when linear style requested",
     button1 ~= nil and button1._cooldown._drawSwipe == false)
+check("radial edge disabled when linear style requested",
+    button1 ~= nil and button1._cooldown._drawEdge == false)
+check("radial bling disabled when linear style requested",
+    button1 ~= nil and button1._cooldown._drawBling == false)
 check("SetDurationBar was called", button1._durationBarCalls >= 1)
 check("SetDurationBar direction defaults to RemainingTime",
     button1._lastDurationBarOptions ~= nil

--- a/tests/unit/cdm_custom_aura_runs_test.lua
+++ b/tests/unit/cdm_custom_aura_runs_test.lua
@@ -501,7 +501,9 @@ ns.CDMManagedAuraMirrors.New = function(deps)
         Acquire = function(_, _, _, entry)
             overlayCalls.acquire = overlayCalls.acquire + 1
             acquiredUnits[entry.id] = deps.unit
-            return { entry = entry }
+            return { entry = entry, slots = {
+                { frame = { IsShown = function() return true end } },
+            } }
         end,
         PositionOverlay = function()
             overlayCalls.position = overlayCalls.position + 1

--- a/tests/unit/cdm_custom_aura_runs_test.lua
+++ b/tests/unit/cdm_custom_aura_runs_test.lua
@@ -540,6 +540,14 @@ playerOverlayIcon._spellEntry = {
 assert(ns.CDMCustomAuraRuns.ShouldUseCooldownAuraOverlays(overlaySettings, "custom") == true
     and ns.CDMCustomAuraRuns.HasCooldownAuraOverlayEntries(overlaySettings, "custom") == true,
     "always-visible custom cooldowns must opt into native aura overlays")
+assert(ns.CDMCustomAuraRuns.ShouldUseCooldownAuraOverlays(CopySettings({
+        showActiveState = false,
+    }), "custom") == false,
+    "disabled active-state rendering must not create native aura overlays")
+assert(ns.CDMCustomAuraRuns.ShouldUseCooldownAuraOverlays(CopySettings({
+        hideNonUsable = true,
+    }), "custom") == false,
+    "non-usable filtering must not create ghostable native aura overlays")
 assert(ns.CDMCustomAuraRuns.HasCooldownAuraOverlayEntries(CopySettings({
         iconDisplayMode = "always",
         showOnlyWhenActive = false,
@@ -584,7 +592,8 @@ local runsFile = assert(io.open("QUI_CDM/cdm/cdm_custom_aura_runs.lua", "rb"))
 local runsSource = runsFile:read("*a")
 runsFile:close()
 assert(runsSource:find("ApplyCooldownAuraOverlays", 1, true)
-    and runsSource:find("PositionOverlay", 1, true),
+    and runsSource:find("PositionOverlay", 1, true)
+    and runsSource:find("reverseSwipe = true", 1, true),
     "cooldown entries must use the native aura overlay path")
 local skinFile = assert(io.open("core/aura_skin.lua", "rb"))
 local skinSource = skinFile:read("*a")

--- a/tests/unit/cdm_custom_aura_runs_test.lua
+++ b/tests/unit/cdm_custom_aura_runs_test.lua
@@ -79,7 +79,11 @@ local ns = {
     },
     CDMManagedAuraMirrors = {
         ResolveCandidateIDs = function(entry)
-            return { entry.spellID or entry.id }
+            local ids = { entry.spellID or entry.id }
+            if entry.linkedSpellIDs then
+                for i = 1, #entry.linkedSpellIDs do ids[#ids + 1] = entry.linkedSpellIDs[i] end
+            end
+            return ids
         end,
     },
     CDMSpellData = {
@@ -95,7 +99,15 @@ local ns = {
         QuerySpellHarmful = function(spellID) return spellID == 444 or spellID == 666 end,
     },
     _OwnedSwipe = {
-        GetSettings = function() return { showCooldownIconAuraPhase = true } end,
+        GetSettings = function()
+            return {
+                showCooldownIconAuraPhase = true,
+                showBuffSwipe = true,
+                showBuffEdge = true,
+                overlayColorMode = "custom",
+                overlayColor = { 0.1, 0.2, 0.3, 0.4 },
+            }
+        end,
     },
 }
 
@@ -253,6 +265,12 @@ assert(configured[1].profile.opacity == 0.45
     and configured[1].profile.duration.font == "duration.ttf"
     and configured[1].profile.stack.font == "stack.ttf",
     "the secure aura must inherit row opacity, crop, and resolved fonts")
+assert(configured[1].profile.hideSwipe == false
+    and configured[1].profile.showEdge == true
+    and configured[1].profile.swipeTexture == "Interface\\Buttons\\WHITE8X8"
+    and configured[1].profile.swipeColor[1] == 0.1
+    and configured[1].profile.swipeColor[4] == 0.4,
+    "the secure aura must inherit CDM aura-swipe visibility, edge, texture, and color settings")
 assert(auraProxy.shown == false and auraProxy._quiManagedAuraProxy == true,
     "the addon aura proxy must not paint the live aura")
 assert(ns.CDMCustomAuraRuns.ResolveRoute({
@@ -471,65 +489,97 @@ assert(#created == fixedCreated and #configured == fixedConfigured
     and fixedProxy._quiManagedAuraProxy == nil and fixedProxy.clickButton == fixedClickButton,
     "fixed-slot fallback must preserve the visible slot and click surface")
 
-local mirrorCalls = { begin = 0, acquire = 0, position = 0, finish = 0 }
-ns.CDMManagedAuraMirrors.New = function()
+local overlayCalls = { begin = 0, acquire = 0, position = 0, finish = 0 }
+local overlayUnits, acquiredUnits = {}, {}
+ns.CDMManagedAuraMirrors.New = function(deps)
+    overlayUnits[deps.unit] = true
     return {
         BeginPass = function()
-            mirrorCalls.begin = mirrorCalls.begin + 1
+            overlayCalls.begin = overlayCalls.begin + 1
             return true
         end,
-        Acquire = function()
-            mirrorCalls.acquire = mirrorCalls.acquire + 1
-            return {}
+        Acquire = function(_, _, _, entry)
+            overlayCalls.acquire = overlayCalls.acquire + 1
+            acquiredUnits[entry.id] = deps.unit
+            return { entry = entry }
         end,
-        Position = function()
-            mirrorCalls.position = mirrorCalls.position + 1
+        PositionOverlay = function()
+            overlayCalls.position = overlayCalls.position + 1
             return true
         end,
         EndPass = function()
-            mirrorCalls.finish = mirrorCalls.finish + 1
+            overlayCalls.finish = overlayCalls.finish + 1
         end,
     }
 end
-local mirrorSettings = CopySettings({
+local overlaySettings = CopySettings({
     iconDisplayMode = "always",
     showOnlyWhenActive = false,
-    entries = { { id = 222, kind = "cooldown", source = "blizzardCDM" } },
+    entries = { { id = 1233448, kind = "cooldown" } },
 })
-local mirrorOwner = Frame("mirror-owner")
-local mirrorIcon = Frame("mirror-icon")
-mirrorIcon._spellEntry = {
-    id = 222, spellID = 222, kind = "cooldown", source = "blizzardCDM",
+local overlayOwner = Frame("overlay-owner")
+local overlayIcon = Frame("overlay-icon")
+local playerOverlayIcon = Frame("player-overlay-icon")
+overlayIcon._spellEntry = {
+    id = 1233448,
+    spellID = 1233448,
+    kind = "cooldown",
+    type = "spell",
+    _isCustomEntry = true,
+    linkedSpellIDs = { 1235391 },
 }
-assert(ns.CDMCustomAuraRuns.ShouldUseAuraMirrors(mirrorSettings, "custom") == true
-    and ns.CDMCustomAuraRuns.HasAuraMirrorEntries(mirrorSettings, "custom") == true,
-    "always-visible catalogued cooldown bars must opt into aura mirrors")
-assert(ns.CDMCustomAuraRuns.Apply(mirrorOwner, mirrorSettings, {
+playerOverlayIcon._spellEntry = {
+    id = 222,
+    spellID = 222,
+    kind = "cooldown",
+    type = "spell",
+    _isCustomEntry = true,
+}
+assert(ns.CDMCustomAuraRuns.ShouldUseCooldownAuraOverlays(overlaySettings, "custom") == true
+    and ns.CDMCustomAuraRuns.HasCooldownAuraOverlayEntries(overlaySettings, "custom") == true,
+    "always-visible custom cooldowns must opt into native aura overlays")
+assert(ns.CDMCustomAuraRuns.Apply(overlayOwner, overlaySettings, {
         metrics = { iconWidth = 30 },
-        placements = { { icon = mirrorIcon, rowConfig = row, x = 0, y = 0 } },
+        placements = {
+            { icon = overlayIcon, rowConfig = row, x = 0, y = 0 },
+            { icon = playerOverlayIcon, rowConfig = row, x = 32, y = 0 },
+        },
     }, nil, nil, "custom") == true,
-    "always-visible cooldown entries must retain the base icon while applying an aura mirror")
-assert(mirrorCalls.begin == 1 and mirrorCalls.acquire == 1
-    and mirrorCalls.position == 1 and mirrorCalls.finish == 1
-    and ns.CDMCustomAuraRuns.HasAuraMirrors(mirrorOwner) == true
-    and ns.CDMCustomAuraRuns.HasPreparedAuraMirrors(mirrorOwner) == true,
-    "the aura mirror must be pooled and positioned over the owned cooldown icon")
+    "custom cooldowns must retain the base icon while applying a native aura overlay")
+assert(overlayCalls.begin == 2 and overlayCalls.acquire == 2
+    and overlayCalls.position == 2 and overlayCalls.finish == 2
+    and overlayUnits.pet == true and overlayUnits.player == true
+    and acquiredUnits[1233448] == "pet" and acquiredUnits[222] == "player"
+    and ns.CDMCustomAuraRuns.HasAuraOverlays(overlayOwner) == true
+    and ns.CDMCustomAuraRuns.HasPreparedAuraOverlays(overlayOwner) == true,
+    "native aura overlays must be pooled and positioned over the cooldown icon")
+assert(ns.CDMCustomAuraRuns.Apply(overlayOwner, overlaySettings, nil, nil, true, "custom") == true
+    and overlayCalls.begin == 2,
+    "combat updates must keep the prepared native aura overlay without rebuilding it")
+ns._OwnedSwipe.GetSettings = function() return { showCooldownIconAuraPhase = false } end
+assert(ns.CDMCustomAuraRuns.Apply(overlayOwner, overlaySettings, {
+        metrics = { iconWidth = 30 },
+        placements = {
+            { icon = overlayIcon, rowConfig = row, x = 0, y = 0 },
+            { icon = playerOverlayIcon, rowConfig = row, x = 32, y = 0 },
+        },
+    }, nil, nil, "custom") == false
+    and ns.CDMCustomAuraRuns.HasAuraOverlays(overlayOwner) == false,
+    "disabling cooldown aura phases must park the native overlay")
+ns._OwnedSwipe.GetSettings = function() return { showCooldownIconAuraPhase = true } end
+
 local runsFile = assert(io.open("QUI_CDM/cdm/cdm_custom_aura_runs.lua", "rb"))
 local runsSource = runsFile:read("*a")
 runsFile:close()
-assert(runsSource:find("AuraSkin.WireButton(frame, Profile(rowConfig))", 1, true),
-    "mirror restyling must pass a complete aura profile")
-ns._OwnedSwipe.GetSettings = function() return { showCooldownIconAuraPhase = false } end
-assert(ns.CDMCustomAuraRuns.ShouldUseAuraMirrors(mirrorSettings, "custom") == false
-    and ns.CDMCustomAuraRuns.HasAuraMirrorEntries(mirrorSettings, "custom") == false,
-    "the cooldown aura-phase setting must disable custom-bar aura mirrors")
-assert(ns.CDMCustomAuraRuns.Apply(mirrorOwner, mirrorSettings, {
-        metrics = { iconWidth = 30 },
-        placements = { { icon = mirrorIcon, rowConfig = row, x = 0, y = 0 } },
-    }, nil, nil, "custom") == false
-    and ns.CDMCustomAuraRuns.HasAuraMirrors(mirrorOwner) == false
-    and ns.CDMCustomAuraRuns.HasPreparedAuraMirrors(mirrorOwner) == false,
-    "disabling cooldown aura phases must park existing custom-bar mirrors")
+assert(runsSource:find("ApplyCooldownAuraOverlays", 1, true)
+    and runsSource:find("PositionOverlay", 1, true),
+    "cooldown entries must use the native aura overlay path")
+local skinFile = assert(io.open("core/aura_skin.lua", "rb"))
+local skinSource = skinFile:read("*a")
+skinFile:close()
+assert(skinSource:find("profile.showEdge", 1, true)
+    and skinSource:find("profile.swipeColor", 1, true),
+    "native aura buttons must apply the CDM aura swipe edge and color settings")
 
 assert(ns.CDMCustomAuraRuns.Apply(owner, settings, plan, nil, nil, "custom") == true)
 local containersFile = assert(io.open("QUI_CDM/cdm/cdm_containers.lua", "rb"))

--- a/tests/unit/cdm_custom_aura_runs_test.lua
+++ b/tests/unit/cdm_custom_aura_runs_test.lua
@@ -550,6 +550,8 @@ assert(overlayCalls.begin == 2 and overlayCalls.acquire == 2
     and overlayCalls.position == 2 and overlayCalls.finish == 2
     and overlayUnits.pet == true and overlayUnits.player == true
     and acquiredUnits[1233448] == "pet" and acquiredUnits[222] == "player"
+    and overlayIcon._customAuraOverlayPrepared == true
+    and playerOverlayIcon._customAuraOverlayPrepared == true
     and ns.CDMCustomAuraRuns.HasAuraOverlays(overlayOwner) == true
     and ns.CDMCustomAuraRuns.HasPreparedAuraOverlays(overlayOwner) == true,
     "native aura overlays must be pooled and positioned over the cooldown icon")
@@ -564,6 +566,8 @@ assert(ns.CDMCustomAuraRuns.Apply(overlayOwner, overlaySettings, {
             { icon = playerOverlayIcon, rowConfig = row, x = 32, y = 0 },
         },
     }, nil, nil, "custom") == false
+    and overlayIcon._customAuraOverlayPrepared == nil
+    and playerOverlayIcon._customAuraOverlayPrepared == nil
     and ns.CDMCustomAuraRuns.HasAuraOverlays(overlayOwner) == false,
     "disabling cooldown aura phases must park the native overlay")
 ns._OwnedSwipe.GetSettings = function() return { showCooldownIconAuraPhase = true } end

--- a/tests/unit/cdm_custom_aura_runs_test.lua
+++ b/tests/unit/cdm_custom_aura_runs_test.lua
@@ -540,6 +540,12 @@ playerOverlayIcon._spellEntry = {
 assert(ns.CDMCustomAuraRuns.ShouldUseCooldownAuraOverlays(overlaySettings, "custom") == true
     and ns.CDMCustomAuraRuns.HasCooldownAuraOverlayEntries(overlaySettings, "custom") == true,
     "always-visible custom cooldowns must opt into native aura overlays")
+assert(ns.CDMCustomAuraRuns.HasCooldownAuraOverlayEntries(CopySettings({
+        iconDisplayMode = "always",
+        showOnlyWhenActive = false,
+        entries = { { id = 1233448, kind = "cooldown", type = "item" } },
+    }), "custom") == false,
+    "item cooldown entries must not claim native spell aura overlays")
 assert(ns.CDMCustomAuraRuns.Apply(overlayOwner, overlaySettings, {
         metrics = { iconWidth = 30 },
         placements = {

--- a/tests/unit/cdm_icon_linked_aura_signature_test.lua
+++ b/tests/unit/cdm_icon_linked_aura_signature_test.lua
@@ -126,6 +126,7 @@ skipSource = skipSource:gsub(
 local skipEnv = setmetatable({
     IsAuraEntry = function(entry) return entry and entry.kind == "aura" end,
     _showCooldownIconAuraPhase = false,
+    ResolveTrackerSettingsNow = function() return nil end,
 }, { __index = globals })
 local skipChunk = assert(loadstring(skipSource,
     "@cdm_icon_renderer.lua#ShouldSkipAuraPhaseForCooldownIcon"))
@@ -137,6 +138,23 @@ assert(shouldSkipAuraPhase({}, {
     "custom spell cooldowns must skip the forbidden Lua aura resolver")
 assert(shouldSkipAuraPhase({}, { kind = "aura" }) == false,
     "explicit aura entries must retain the native aura resolver path")
+skipEnv._showCooldownIconAuraPhase = true
+skipEnv.ResolveTrackerSettingsNow = function()
+    return { containerType = "customBar", iconDisplayMode = "always" }
+end
+assert(shouldSkipAuraPhase({}, {
+        kind = "cooldown", type = "spell", _isCustomEntry = true,
+        viewerType = "custom",
+    }) == true,
+    "always-visible custom cooldowns must use the native aura overlay path")
+skipEnv.ResolveTrackerSettingsNow = function()
+    return { containerType = "customBar", iconDisplayMode = "always", showOnlyWhenActive = true }
+end
+assert(shouldSkipAuraPhase({}, {
+        kind = "cooldown", type = "spell", _isCustomEntry = true,
+        viewerType = "custom",
+    }) == false,
+    "filtered custom cooldowns must retain Lua aura resolution without a native overlay")
 
 local placeSource = sliceBetween(
     icons,

--- a/tests/unit/cdm_icon_linked_aura_signature_test.lua
+++ b/tests/unit/cdm_icon_linked_aura_signature_test.lua
@@ -117,6 +117,27 @@ assert(builtManualAura._useManagedAura == nil
 assert(builtManualAura.source == nil and builtAura.source == "blizzardCDM",
     "runtime entries must preserve provenance for safe route selection")
 
+local skipSource = sliceBetween(
+    icons,
+    "function _resolverRuntimePolicy.ShouldSkipAuraPhaseForCooldownIcon(icon, entry)",
+    "function _resolverRuntimePolicy.ShouldUseBuffSwipeForIcon")
+skipSource = skipSource:gsub(
+    "^function _resolverRuntimePolicy.ShouldSkipAuraPhaseForCooldownIcon", "return function", 1)
+local skipEnv = setmetatable({
+    IsAuraEntry = function(entry) return entry and entry.kind == "aura" end,
+    _showCooldownIconAuraPhase = false,
+}, { __index = globals })
+local skipChunk = assert(loadstring(skipSource,
+    "@cdm_icon_renderer.lua#ShouldSkipAuraPhaseForCooldownIcon"))
+setfenv(skipChunk, skipEnv)
+local shouldSkipAuraPhase = skipChunk()
+assert(shouldSkipAuraPhase({}, {
+        kind = "cooldown", type = "spell", _isCustomEntry = true,
+    }) == true,
+    "custom spell cooldowns must skip the forbidden Lua aura resolver")
+assert(shouldSkipAuraPhase({}, { kind = "aura" }) == false,
+    "explicit aura entries must retain the native aura resolver path")
+
 local placeSource = sliceBetween(
     icons,
     "function CDMIcons.ShouldContainerLayoutPlaceIcon(icon, entry, containerDB, inCombat)",

--- a/tests/unit/cdm_icon_linked_aura_signature_test.lua
+++ b/tests/unit/cdm_icon_linked_aura_signature_test.lua
@@ -126,7 +126,6 @@ skipSource = skipSource:gsub(
 local skipEnv = setmetatable({
     IsAuraEntry = function(entry) return entry and entry.kind == "aura" end,
     _showCooldownIconAuraPhase = false,
-    ResolveTrackerSettingsNow = function() return nil end,
 }, { __index = globals })
 local skipChunk = assert(loadstring(skipSource,
     "@cdm_icon_renderer.lua#ShouldSkipAuraPhaseForCooldownIcon"))
@@ -139,22 +138,18 @@ assert(shouldSkipAuraPhase({}, {
 assert(shouldSkipAuraPhase({}, { kind = "aura" }) == false,
     "explicit aura entries must retain the native aura resolver path")
 skipEnv._showCooldownIconAuraPhase = true
-skipEnv.ResolveTrackerSettingsNow = function()
-    return { containerType = "customBar", iconDisplayMode = "always" }
-end
 assert(shouldSkipAuraPhase({}, {
         kind = "cooldown", type = "spell", _isCustomEntry = true,
-        viewerType = "custom",
-    }) == true,
-    "always-visible custom cooldowns must use the native aura overlay path")
-skipEnv.ResolveTrackerSettingsNow = function()
-    return { containerType = "customBar", iconDisplayMode = "always", showOnlyWhenActive = true }
-end
-assert(shouldSkipAuraPhase({}, {
-        kind = "cooldown", type = "spell", _isCustomEntry = true,
-        viewerType = "custom",
     }) == false,
-    "filtered custom cooldowns must retain Lua aura resolution without a native overlay")
+    "custom cooldowns must retain Lua aura resolution until an overlay is positioned")
+assert(shouldSkipAuraPhase({}, {
+        kind = "cooldown", type = "spell", _isCustomEntry = true,
+    }) == false,
+    "custom cooldowns must retain Lua aura resolution for unsupported aura routes")
+assert(shouldSkipAuraPhase({ _customAuraOverlayPrepared = true }, {
+        kind = "cooldown", type = "spell", _isCustomEntry = true,
+    }) == true,
+    "custom cooldowns may skip Lua aura resolution after their native overlay is positioned")
 
 local placeSource = sliceBetween(
     icons,

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -134,6 +134,7 @@ local durationKeyClears = 0
 local stableClears = 0
 local spellCacheInvalidations = {}
 local barAuraRefreshMarks = {}
+local customOverlayRefreshes = 0
 -- Names the isDefinitivelySelfAuraIcon stub reports as PROVABLE player
 -- self-auras. Populated by the target-scope test.
 local selfAuraNames = {}
@@ -213,6 +214,9 @@ local controller = module.Create({
     refreshCustomAuraTargets = function(refreshAll)
         targetRouteRefreshes = targetRouteRefreshes + 1
         if refreshAll then targetRouteFullRefreshes = targetRouteFullRefreshes + 1 end
+    end,
+    refreshCustomCooldownAuraOverlays = function()
+        customOverlayRefreshes = customOverlayRefreshes + 1
     end,
     scheduleUpdate = function(fast, mode, reason)
         schedules[#schedules + 1] = {
@@ -424,6 +428,8 @@ controller:Handle("UNIT_AURA", "player", {
     },
 })
 assert(auraApplied.item == 1, "aura delta should match item entries through item-use aura mapping")
+assert(customOverlayRefreshes == 0,
+    "UNIT_AURA should rely on native container incremental handling without a manual overlay rebuild")
 
 reset(auraApplied)
 controller:Handle("UNIT_AURA", "player", {

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -96,9 +96,17 @@ local idleIcon = makeIcon("idle", {
     type = "spell",
     viewerType = "essential",
 })
+local customCooldownIcon = makeIcon("customCooldown", {
+    id = 707,
+    spellID = 707,
+    kind = "cooldown",
+    type = "spell",
+    viewerType = "custom",
+    _isCustomEntry = true,
+})
 
 local iconPools = {
-    essential = { spellIcon, otherSpellIcon, itemIcon, mirrorAuraIcon, idleIcon },
+    essential = { spellIcon, otherSpellIcon, itemIcon, mirrorAuraIcon, idleIcon, customCooldownIcon },
     buff = { auraIcon },
 }
 
@@ -424,6 +432,13 @@ controller:Handle("UNIT_AURA", "player", {
     },
 })
 assert(auraApplied.item == 1, "secret player added aura identity should still wake item aura entries")
+
+reset(auraApplied)
+controller:Handle("UNIT_AURA", "player", {
+    removedAuraInstanceIDs = { 9005 },
+})
+assert(auraApplied.customCooldown == nil,
+    "unrelated removed auras must not refresh custom cooldown bindings")
 
 reset(auraApplied)
 controller:Handle("UNIT_AURA", "target", {

--- a/tests/unit/cdm_icons_aura_delta_targeting_test.lua
+++ b/tests/unit/cdm_icons_aura_delta_targeting_test.lua
@@ -564,9 +564,6 @@ assert(itemAuraAppliedDuration == itemCooldownDur,
 assert(itemAuraReverse == false,
     "removed item aura should leave aura/reverse cooldown mode")
 
-customCooldownAppliedDuration = nil
-customCooldownReverse = nil
-customCooldownApplyCount = 0
 resolveCounts.customCooldown = 0
 
 icons.HandleRuntimeRefresh("UNIT_AURA", "pet", {
@@ -574,14 +571,8 @@ icons.HandleRuntimeRefresh("UNIT_AURA", "pet", {
     removedAuraInstanceIDs = { 901 },
 })
 
-assert(resolveCounts.customCooldown == 1,
-    "removed pet aura should re-resolve custom cooldown icons without a stored aura instance ID")
-assert(customCooldownAppliedDuration == customCooldownDur,
-    "removed pet aura should bind the custom cooldown DurationObject")
-assert(customCooldownReverse == false,
-    "removed pet aura should keep the custom icon on cooldown mode")
-assert(customCooldownApplyCount == 1,
-    "removed pet aura should refresh the custom cooldown once")
+assert(resolveCounts.customCooldown == 0,
+    "removed unrelated pet auras must not re-resolve custom cooldown icons")
 
 customCooldownAppliedDuration = nil
 customCooldownReverse = nil

--- a/tests/unit/cdm_icons_aura_delta_targeting_test.lua
+++ b/tests/unit/cdm_icons_aura_delta_targeting_test.lua
@@ -42,6 +42,10 @@ local itemAuraReverse
 local itemAuraApplyCount = 0
 local itemAuraActive = true
 local itemAuraPublishesInstanceID = true
+local customCooldownDur = { token = "custom-cooldown-duration" }
+local customCooldownAppliedDuration
+local customCooldownApplyCount = 0
+local customCooldownReverse
 local runtimeBatches = 0
 local buffAuraResolutionUnit = "player"
 local buffAuraResolutionInstanceID = 621
@@ -133,6 +137,25 @@ itemAuraIcon.Cooldown.SetCooldownFromDurationObject = function(_, durObj)
 end
 itemAuraIcon.Cooldown.SetReverse = function(_, reverse)
     itemAuraReverse = reverse
+end
+
+local customCooldownIcon = makeIcon("customCooldown", 1233448)
+customCooldownIcon._spellEntry = {
+    id = 1233448,
+    spellID = 1233448,
+    name = "customCooldown",
+    kind = "cooldown",
+    viewerType = "custom",
+    type = "spell",
+    _isCustomEntry = true,
+    linkedSpellIDs = { 1235391 },
+}
+customCooldownIcon.Cooldown.SetCooldownFromDurationObject = function(_, durObj)
+    customCooldownApplyCount = customCooldownApplyCount + 1
+    customCooldownAppliedDuration = durObj
+end
+customCooldownIcon.Cooldown.SetReverse = function(_, reverse)
+    customCooldownReverse = reverse
 end
 
 local ns = {
@@ -284,6 +307,19 @@ local ns = {
                     hasRenderableCooldown = true,
                 }
             end
+            if name == "customCooldown" then
+                return {
+                    mode = "cooldown",
+                    active = true,
+                    isActive = true,
+                    durObj = customCooldownDur,
+                    sourceID = "cooldown:1233448",
+                    spellID = 1233448,
+                    isOnCooldown = true,
+                    hasDurationObject = true,
+                    hasRenderableCooldown = true,
+                }
+            end
             return {
                 mode = "inactive",
                 active = false,
@@ -295,7 +331,7 @@ local ns = {
         _iconPools = {
             essential = { matchingIcon, unrelatedIcon, nonMirrorIcon, itemAuraIcon },
             buff = { buffAuraIcon },
-            custom = { customAuraIcon },
+            custom = { customAuraIcon, customCooldownIcon },
         },
         _recyclePool = {},
         _FinalizeImports = noop,
@@ -344,7 +380,7 @@ end
 assert(loadfile("QUI_CDM/cdm/cdm_icon_renderer.lua"))("QUI", ns)
 ns.CDMIconFactory._iconPools.essential = { matchingIcon, unrelatedIcon, nonMirrorIcon, itemAuraIcon }
 ns.CDMIconFactory._iconPools.buff = { buffAuraIcon }
-ns.CDMIconFactory._iconPools.custom = { customAuraIcon }
+ns.CDMIconFactory._iconPools.custom = { customAuraIcon, customCooldownIcon }
 
 local icons = assert(ns.CDMIcons, "CDMIcons should be exported")
 runtimeBatches = 0
@@ -527,6 +563,39 @@ assert(itemAuraAppliedDuration == itemCooldownDur,
     "removed item aura should bind the item cooldown DurationObject")
 assert(itemAuraReverse == false,
     "removed item aura should leave aura/reverse cooldown mode")
+
+customCooldownAppliedDuration = nil
+customCooldownReverse = nil
+customCooldownApplyCount = 0
+resolveCounts.customCooldown = 0
+
+icons.HandleRuntimeRefresh("UNIT_AURA", "pet", {
+    isFullUpdate = false,
+    removedAuraInstanceIDs = { 901 },
+})
+
+assert(resolveCounts.customCooldown == 1,
+    "removed pet aura should re-resolve custom cooldown icons without a stored aura instance ID")
+assert(customCooldownAppliedDuration == customCooldownDur,
+    "removed pet aura should bind the custom cooldown DurationObject")
+assert(customCooldownReverse == false,
+    "removed pet aura should keep the custom icon on cooldown mode")
+assert(customCooldownApplyCount == 1,
+    "removed pet aura should refresh the custom cooldown once")
+
+customCooldownAppliedDuration = nil
+customCooldownReverse = nil
+customCooldownApplyCount = 0
+resolveCounts.customCooldown = 0
+
+icons.HandleRuntimeRefresh("UNIT_AURA", "pet", nil)
+
+assert(resolveCounts.customCooldown == 1,
+    "unknown/full pet aura refreshes should re-resolve custom cooldown icons")
+assert(customCooldownAppliedDuration == customCooldownDur,
+    "unknown/full pet aura refreshes should bind the custom cooldown DurationObject")
+assert(customCooldownReverse == false,
+    "unknown/full pet aura refreshes should keep the custom icon on cooldown mode")
 
 itemAuraActive = true
 itemAuraPublishesInstanceID = true

--- a/tests/unit/cdm_managed_aura_mirrors_test.lua
+++ b/tests/unit/cdm_managed_aura_mirrors_test.lua
@@ -29,8 +29,10 @@ local function createFrame(kind, _, parent)
         local c = frameBase()
         c.filters = {}
         c.added = {}
+        c.refreshes = 0
         c.SetUnit = function(self, unit) self.unit = unit end
         c.SetEnabled = function(self, enabled) self.enabled = enabled end
+        c.UpdateAllAuras = function(self) self.refreshes = self.refreshes + 1 end
         c.AddAuraSlot = function(self, key, filter, options)
             local button = frameBase()
             options.initializeFrame(button)
@@ -66,6 +68,12 @@ assert(record and #record.slots == 3, "one exact managed slot is created per uni
 assert(#createdAuraContainers == 1 and #createdHosts == 1, "container and stable placement host are pooled")
 assert(createdAuraContainers[1].unit == "player" and createdAuraContainers[1].enabled == true,
     "managed aura source is the enabled player unit")
+local petManager = M.New({ createFrame = createFrame, unit = "pet" })
+local petOwner = {}
+assert(petManager:BeginPass(petOwner) == true
+    and createdAuraContainers[2].unit == "pet",
+    "managed aura sources must support pet-unit overlays")
+petManager:EndPass(petOwner)
 assert(record.slots[1].spellID == 101 and record.slots[2].spellID == 100
     and record.slots[3].spellID == 102, "candidate priority is override, primary, linked")
 assert(record.slots[1].frame.allPoints == record.host and record.slots[1].frame.mouse == false,
@@ -77,6 +85,18 @@ assert(manager:Position(record, base, owner, 4, -5, 30, 20, { size = 30 }) == tr
 assert(record.host.points[1][2] == owner and record.host.size[1] == 30 and record.host.size[2] == 20,
     "host receives the layout rect")
 assert(base.host == record.host, "owned base follows the stable host")
+
+local overlayBase = frameBase()
+assert(manager:PositionOverlay(record, overlayBase, owner, 0, 0, 30, 20, { size = 30 }) == true,
+    "overlay placement must position the native aura host without moving the base icon")
+assert(record.host.points[1][2] == overlayBase and record.host.size[1] == 30
+    and record.host.size[2] == 20 and record.host.level == 30,
+    "overlay placement must anchor and layer the native aura host above the base icon")
+assert(overlayBase.host == nil, "overlay placement must leave the owned cooldown icon untouched")
+
+manager:Refresh()
+assert(createdAuraContainers[1].refreshes == 1,
+    "aura overlay refresh should forward UNIT_AURA changes to the native container")
 
 manager:EndPass(owner)
 assert(record.parked == false, "used record remains live at pass end")


### PR DESCRIPTION
## What changed

- Honors aura swipe hiding across linear, radial, edge, and bling cooldown layers.
- Completes pending CDM aura routing, rendering, refresh, and mirror updates with regression coverage.

## Validation

- `bash tools/test.sh` — all 9 gates passed.