### PR TITLE
fix: keep GCD-only icons out of cooldown visibility

### DIFF
--- a/QUI_CDM/cdm/cdm_icon_policies.lua
+++ b/QUI_CDM/cdm/cdm_icon_policies.lua
@@ -911,7 +911,8 @@ function CDMIconVisibilityPolicy.Create(callbacks)
             local cooldownState = callbacks.resolveCooldownActivityState
                 and callbacks.resolveCooldownActivityState(icon, entry, containerDB)
                 or {}
-            local effectiveOnCD = cooldownState.isOnCooldown or cooldownState.rechargeActive
+            local effectiveOnCD = cooldownState.gcdOnly ~= true
+                and (cooldownState.isOnCooldown or cooldownState.rechargeActive)
 
             if containerDB.showOnlyOnCooldown and not effectiveOnCD then
                 return true
@@ -1729,7 +1730,8 @@ function CDMIconCustomBarPolicy.Create(callbacks)
 
         if layoutVisible then
             if mode == "onCooldown" then
-                layoutVisible = cooldown.isOnCooldown or cooldown.rechargeActive
+                layoutVisible = cooldown.gcdOnly ~= true
+                    and (cooldown.isOnCooldown or cooldown.rechargeActive)
             elseif mode == "active" then
                 layoutVisible = isActive
             elseif mode == "offCooldown" then

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -864,7 +864,7 @@ end
 
 local _iconCooldownStateContextOptions = {}
 
-local function BuildIconCooldownStateContext(icon, entry, runtimeSpellID, useBuffSwipe, skipAuraPhase, totemSlot)
+local function BuildIconCooldownStateContext(icon, entry, runtimeSpellID, useBuffSwipe, skipAuraPhase, totemSlot, trustIsOnGCD)
     local builder = Resolvers and Resolvers.BuildCooldownStateContext
     if not builder then return nil end
 
@@ -874,6 +874,7 @@ local function BuildIconCooldownStateContext(icon, entry, runtimeSpellID, useBuf
     options.useBuffSwipe = useBuffSwipe
     options.skipAuraPhase = skipAuraPhase == true
     options.showGCDSwipe = IsGCDSwipeEnabled()
+    options.trustIsOnGCD = trustIsOnGCD == true
     options.lastChargeRuntimeSpellID = icon and icon._lastChargeRuntimeSpellID
     return builder(icon, entry, runtimeSpellID, options)
 end
@@ -886,7 +887,7 @@ function _resolverRuntimePolicy.ResolvedAuraStateIsActive(state)
     return state.isActive == true
 end
 
-function _resolverRuntimePolicy.ResolveResolvedStateForIcon(icon, entry, runtimeSpellID, useBuffSwipe, skipAuraPhase)
+function _resolverRuntimePolicy.ResolveResolvedStateForIcon(icon, entry, runtimeSpellID, useBuffSwipe, skipAuraPhase, trustIsOnGCD)
     if not (Resolvers.ResolveCooldownState and icon and entry) then
         return nil
     end
@@ -897,14 +898,15 @@ function _resolverRuntimePolicy.ResolveResolvedStateForIcon(icon, entry, runtime
     end
 
     local context = BuildIconCooldownStateContext(
-        icon, entry, runtimeSpellID, useBuffSwipe, skipAuraPhase, totemSlot)
+        icon, entry, runtimeSpellID, useBuffSwipe, skipAuraPhase, totemSlot, trustIsOnGCD)
     if not context then return nil end
 
     return Resolvers.ResolveCooldownState(context)
 end
 
-function _resolverRuntimePolicy.ResolveAuraFactsForIcon(icon, entry, runtimeSpellID, useBuffSwipe)
-    local state = _resolverRuntimePolicy.ResolveResolvedStateForIcon(icon, entry, runtimeSpellID, useBuffSwipe, false)
+function _resolverRuntimePolicy.ResolveAuraFactsForIcon(icon, entry, runtimeSpellID, useBuffSwipe, trustIsOnGCD)
+    local state = _resolverRuntimePolicy.ResolveResolvedStateForIcon(
+        icon, entry, runtimeSpellID, useBuffSwipe, false, trustIsOnGCD)
     if not state then return nil end
     if state.auraResolved == true or state.mode == "aura" or state.auraActive ~= nil then
         return state
@@ -956,13 +958,14 @@ function _resolverRuntimePolicy.StoreIconRuntimeState(icon, mode, sourceID, spel
 end
 
 -- with verified non-secret numeric item timing. SetCooldownFromDurationObject
-ApplyResolvedCooldown = function(icon, preResolvedState)
+ApplyResolvedCooldown = function(icon, preResolvedState, trustIsOnGCD)
     local addonCD = icon and icon.Cooldown
     if not addonCD then return false end
 
     local entry = icon._spellEntry
     local useBuffSwipe = _resolverRuntimePolicy.ShouldUseBuffSwipeForIcon(icon, entry)
     local skipAuraPhase = _resolverRuntimePolicy.ShouldSkipAuraPhaseForCooldownIcon(icon, entry)
+    trustIsOnGCD = trustIsOnGCD == true
     local measure = measureFn
     local stateContext
     local resolvedState = preResolvedState
@@ -973,10 +976,10 @@ ApplyResolvedCooldown = function(icon, preResolvedState)
             stateContext = measure(
                 "CDM_applyBuildContext",
                 BuildIconCooldownStateContext,
-                icon, entry, icon._runtimeSpellID, useBuffSwipe, skipAuraPhase)
+                icon, entry, icon._runtimeSpellID, useBuffSwipe, skipAuraPhase, nil, trustIsOnGCD)
         else
             stateContext = BuildIconCooldownStateContext(
-                icon, entry, icon._runtimeSpellID, useBuffSwipe, skipAuraPhase)
+                icon, entry, icon._runtimeSpellID, useBuffSwipe, skipAuraPhase, nil, trustIsOnGCD)
         end
         if not stateContext then return false end
 
@@ -1002,10 +1005,10 @@ ApplyResolvedCooldown = function(icon, preResolvedState)
                 aliasContext = measure(
                     "CDM_applyBuildContext",
                     BuildIconCooldownStateContext,
-                    icon, entry, aliasID, useBuffSwipe, skipAuraPhase)
+                    icon, entry, aliasID, useBuffSwipe, skipAuraPhase, nil, trustIsOnGCD)
             else
                 aliasContext = BuildIconCooldownStateContext(
-                    icon, entry, aliasID, useBuffSwipe, skipAuraPhase)
+                    icon, entry, aliasID, useBuffSwipe, skipAuraPhase, nil, trustIsOnGCD)
             end
             local aliasState
             if aliasContext and measure then
@@ -2424,7 +2427,7 @@ local function ClearItemIconInactive(icon, entry, itemID)
         nil)
 end
 
-local function UpdateIconCooldownOwned(icon)
+local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
     if not icon or not icon._spellEntry then return end
 
     local entry = icon._spellEntry
@@ -2455,7 +2458,9 @@ local function UpdateIconCooldownOwned(icon)
                 return
             end
 
-            local r = _resolverRuntimePolicy.ResolveAuraFactsForIcon(icon, entry, auraSpellID, true)
+            local r = _resolverRuntimePolicy.ResolveAuraFactsForIcon(
+                icon, entry, auraSpellID, true,
+                trustIsOnGCD)
             if not r then
                 if entry.type == "item" or entry.type == "trinket" or entry.type == "slot" then
                     local _auraNilItemID
@@ -2704,7 +2709,7 @@ local function UpdateIconCooldownOwned(icon)
         end
     end
 
-    local resolvedApplied = ApplyResolvedCooldown(icon, preResolvedCooldownState) == true
+    local resolvedApplied = ApplyResolvedCooldown(icon, preResolvedCooldownState, trustIsOnGCD) == true
     local resolvedState = ns.CDMRuntimeStore and ns.CDMRuntimeStore.GetFrameState
         and ns.CDMRuntimeStore.GetFrameState(icon) or nil
     local startTime = resolvedState and resolvedState.start
@@ -3006,9 +3011,9 @@ local function UpdateIconCooldownOwned(icon)
     end
 end
 
-UpdateIconCooldown = function(icon)
+UpdateIconCooldown = function(icon, trustIsOnGCD)
     if icon and icon._spellEntry and icon._spellEntry._useManagedAura then return end
-    return UpdateIconCooldownOwned(icon)
+    return UpdateIconCooldownOwned(icon, trustIsOnGCD)
 end
 
 local function IsCustomBarEntryUsableOnCurrentClass(entry, viewerType)
@@ -3869,7 +3874,7 @@ local function RefreshAllIcon(icon, context)
     end
 end
 
-local function UpdateCooldownOnlyIcon(icon, entry)
+local function UpdateCooldownOnlyIcon(icon, entry, context)
     if ns._cdmPollSkipIdle ~= false
         and icon._resolvedCooldownMode == "inactive"
         and icon._hasCooldownActive ~= true
@@ -3880,7 +3885,7 @@ local function UpdateCooldownOnlyIcon(icon, entry)
         return
     end
     if durationBindingStats then durationBindingStats.pollIdleResolved = durationBindingStats.pollIdleResolved + 1 end
-    UpdateIconCooldown(icon)
+    UpdateIconCooldown(icon, context and context.trustIsOnGCD == true)
 end
 
 local function CreateIconRefreshWalker()
@@ -3937,7 +3942,7 @@ function CDMIcons:UpdateAllCooldowns()
     DrainLayoutDirty()
 end
 
-function CDMIcons:UpdateCooldownOnly()
+function CDMIcons:UpdateCooldownOnly(trustIsOnGCD)
     local editMode, ncdm, ncdmContainers, inCombat = PrepareCooldownUpdateBatch()
     local allowStackTextWrites = ConsumeStackTextWriteRequest()
     SetRefreshBatchStackTextWrites(allowStackTextWrites)
@@ -3948,6 +3953,7 @@ function CDMIcons:UpdateCooldownOnly()
         ncdm = ncdm,
         ncdmContainers = ncdmContainers,
         inCombat = inCombat,
+        trustIsOnGCD = trustIsOnGCD == true,
     }
     if Resolvers and Resolvers.SetResolveCallerTag then Resolvers.SetResolveCallerTag("cooldownOnly") end
     local walker = GetIconRefreshWalker()
@@ -3960,7 +3966,7 @@ function CDMIcons:UpdateCooldownOnly()
                 if entry then
                     local containerDB, cType = ResolveContainerDBAndType(entry, ncdm, ncdmContainers)
                     if cType ~= "aura" and cType ~= "auraBar" then
-                        UpdateCooldownOnlyIcon(icon, entry)
+                        UpdateCooldownOnlyIcon(icon, entry, context)
                         UpdateCooldownContainerVisibility(icon, entry, containerDB, editMode, inCombat)
                     end
                 end
@@ -4020,7 +4026,7 @@ function CDMIcons:UpdateRuntimeForType(viewerType)
             if entry then
                 local containerDB, cType = ResolveContainerDBAndType(entry, ncdm, ncdmContainers)
                 if cType ~= "aura" and cType ~= "auraBar" then
-                    UpdateCooldownOnlyIcon(icon, entry)
+                        UpdateCooldownOnlyIcon(icon, entry, context)
                     UpdateCooldownContainerVisibility(icon, entry, containerDB, editMode, inCombat)
                 end
             end
@@ -4048,8 +4054,18 @@ function CDMIcons.OnIconRowConfigApplied(icon, rowConfig)
     ConfigureIcon(icon, rowConfig)
 end
 
+local function BindCooldownDoneRefresh(icon)
+    local cooldown = icon and icon.Cooldown
+    if not cooldown or not cooldown.SetScript or icon._quiCooldownDoneBound then return end
+    cooldown:SetScript("OnCooldownDone", function()
+        CDMIcons:UpdateCooldownOnly()
+    end)
+    icon._quiCooldownDoneBound = true
+end
+
 function CDMIcons.OnFactoryIconCreated(icon, entry)
     if not icon then return end
+    BindCooldownDoneRefresh(icon)
     UpdateIconProfessionQuality(icon)
 end
 
@@ -4258,8 +4274,8 @@ local function CreateIconUpdateScheduler()
         updateAllCooldowns = function()
             CDMIcons:UpdateAllCooldowns()
         end,
-        updateCooldownOnly = function()
-            CDMIcons:UpdateCooldownOnly()
+        updateCooldownOnly = function(trustIsOnGCD)
+            CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true)
         end,
         getBars = function()
             return ns.CDMBars
@@ -4447,6 +4463,9 @@ do
         setStackTextWrites = SetRefreshBatchStackTextWrites,
         applyResolvedCooldown = ApplyResolvedCooldown,
         updateIconCooldown = UpdateIconCooldown,
+        updateCooldownOnly = function(trustIsOnGCD)
+            CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true)
+        end,
         applyAuraScopedResolvedCooldown = function(icon, entry, editMode, ncdm, ncdmContainers, inCombat)
             return _resolverRuntimePolicy.ApplyAuraScopedResolvedCooldown(
                 icon, entry, editMode, ncdm, ncdmContainers, inCombat)
@@ -4565,9 +4584,10 @@ function CDMIcons.HandleRuntimeRefresh(event, arg1, arg2, arg3, arg4)
     return _resolverRuntimePolicy.HandleRuntimeRefresh(event, arg1, arg2, arg3, arg4)
 end
 
-local function OnCDMCooldownChanged(_, spellID, baseSpellID, kind)
+local function OnCDMCooldownChanged(_, spellID, baseSpellID, kind, category, startRecoveryCategory, itemID)
     if runtimeRefresh then
-        return runtimeRefresh:HandleCooldownChanged(_, spellID, baseSpellID, kind)
+        return runtimeRefresh:HandleCooldownChanged(
+            _, spellID, baseSpellID, kind, category, startRecoveryCategory, itemID)
     end
 end
 

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -2435,7 +2435,7 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
     local auraCountAppliedThisTick = false
     local preResolvedCooldownState = nil
 
-    local _runtimeSid = entry.spellID or entry.overrideSpellID or entry.id
+    local _runtimeSid = entry._runtimeSpellID or entry.spellID or entry.overrideSpellID or entry.id
     if _runtimeSid and not IsAuraEntry(entry) then
         local ovId = QueryOverrideSpell(_runtimeSid)
         if ovId then _runtimeSid = ovId end

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -3875,7 +3875,8 @@ local function RefreshAllIcon(icon, context)
 end
 
 local function UpdateCooldownOnlyIcon(icon, entry, context)
-    if ns._cdmPollSkipIdle ~= false
+    if context and context.forceResolveIdle ~= true
+        and ns._cdmPollSkipIdle ~= false
         and icon._resolvedCooldownMode == "inactive"
         and icon._hasCooldownActive ~= true
         and entry
@@ -3942,7 +3943,7 @@ function CDMIcons:UpdateAllCooldowns()
     DrainLayoutDirty()
 end
 
-function CDMIcons:UpdateCooldownOnly(trustIsOnGCD)
+function CDMIcons:UpdateCooldownOnly(trustIsOnGCD, forceResolveIdle)
     local editMode, ncdm, ncdmContainers, inCombat = PrepareCooldownUpdateBatch()
     local allowStackTextWrites = ConsumeStackTextWriteRequest()
     SetRefreshBatchStackTextWrites(allowStackTextWrites)
@@ -3954,6 +3955,7 @@ function CDMIcons:UpdateCooldownOnly(trustIsOnGCD)
         ncdmContainers = ncdmContainers,
         inCombat = inCombat,
         trustIsOnGCD = trustIsOnGCD == true,
+        forceResolveIdle = forceResolveIdle == true,
     }
     if Resolvers and Resolvers.SetResolveCallerTag then Resolvers.SetResolveCallerTag("cooldownOnly") end
     local walker = GetIconRefreshWalker()
@@ -4054,11 +4056,17 @@ function CDMIcons.OnIconRowConfigApplied(icon, rowConfig)
     ConfigureIcon(icon, rowConfig)
 end
 
+local CDM_UPDATE_COOLDOWN = "cooldown"
+local CDM_UPDATE_FULL = "full"
+local updateScheduler
+local ScheduleCDMUpdate
+local pendingCooldownForceResolveIdle = false
+
 local function BindCooldownDoneRefresh(icon)
     local cooldown = icon and icon.Cooldown
     if not cooldown or not cooldown.SetScript or icon._quiCooldownDoneBound then return end
     cooldown:SetScript("OnCooldownDone", function()
-        CDMIcons:UpdateCooldownOnly()
+        ScheduleCDMUpdate(true, CDM_UPDATE_COOLDOWN, "cooldown_done")
     end)
     icon._quiCooldownDoneBound = true
 end
@@ -4248,10 +4256,6 @@ cdEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_STOP", "player")
 cdEventFrame:RegisterEvent("COOLDOWN_VIEWER_TABLE_HOTFIXED")
 cdEventFrame:RegisterEvent("COOLDOWN_VIEWER_SPELL_OVERRIDE_UPDATED")
 
-local CDM_UPDATE_COOLDOWN = "cooldown"
-local CDM_UPDATE_FULL = "full"
-local updateScheduler
-
 local function CreateIconUpdateScheduler()
     local module = ns.CDMIconUpdateScheduler
     if not (module and module.Create) then return nil end
@@ -4274,8 +4278,10 @@ local function CreateIconUpdateScheduler()
         updateAllCooldowns = function()
             CDMIcons:UpdateAllCooldowns()
         end,
-        updateCooldownOnly = function(trustIsOnGCD)
-            CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true)
+        updateCooldownOnly = function()
+            local forceResolveIdle = pendingCooldownForceResolveIdle
+            pendingCooldownForceResolveIdle = false
+            CDMIcons:UpdateCooldownOnly(false, forceResolveIdle)
         end,
         getBars = function()
             return ns.CDMBars
@@ -4301,7 +4307,10 @@ local function NoteFullUpdateSchedule(reason)
     end
 end
 
-local function ScheduleCDMUpdate(fast, mode, reason)
+ScheduleCDMUpdate = function(fast, mode, reason)
+    if mode == CDM_UPDATE_COOLDOWN then
+        pendingCooldownForceResolveIdle = true
+    end
     if mode == CDM_UPDATE_FULL then
         NoteFullUpdateSchedule(reason)
     end
@@ -4464,7 +4473,7 @@ do
         applyResolvedCooldown = ApplyResolvedCooldown,
         updateIconCooldown = UpdateIconCooldown,
         updateCooldownOnly = function(trustIsOnGCD)
-            CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true)
+            CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true, true)
         end,
         applyAuraScopedResolvedCooldown = function(icon, entry, editMode, ncdm, ncdmContainers, inCombat)
             return _resolverRuntimePolicy.ApplyAuraScopedResolvedCooldown(

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -18,6 +18,12 @@ end
 local UPDATE_COOLDOWN = "cooldown"
 local UPDATE_FULL = "full"
 
+local function IsGlobalRecoveryCategory(category)
+    local spellCooldownConsts = _G.Constants and _G.Constants.SpellCooldownConsts
+    return spellCooldownConsts
+        and category == spellCooldownConsts.GLOBAL_RECOVERY_CATEGORY
+end
+
 local runtimeRefreshStats
 local measureFn
 
@@ -540,7 +546,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         end
     end
 
-    function controller:ApplySpellID(eventSpellID, eventBaseSpellID)
+    function controller:ApplySpellID(eventSpellID, eventBaseSpellID, trustIsOnGCD)
         local spellIDs = controller.applySpellIDScratch
         wipe(spellIDs)
         local hasSpellIDs = addSpellIdentifierToSet(callbacks, spellIDs, eventSpellID)
@@ -569,9 +575,9 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                                 setStackTextWrites(callbacks, true)
                                 stackTextWritesEnabled = true
                             end
-                            callbacks.updateIconCooldown(icon)
+                            callbacks.updateIconCooldown(icon, trustIsOnGCD == true)
                         elseif callbacks.applyResolvedCooldown then
-                            callbacks.applyResolvedCooldown(icon)
+                            callbacks.applyResolvedCooldown(icon, nil, trustIsOnGCD == true)
                         end
                         if callbacks.updateContainerVisibility then
                             callbacks.updateContainerVisibility(icon, entry, containerDB, editMode, inCombatState)
@@ -838,7 +844,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
 
     function controller:QueueResolvedCooldownForSpellID(eventSpellID, eventBaseSpellID)
         if not inCombat() then
-            controller:ApplySpellID(eventSpellID, eventBaseSpellID)
+            controller:ApplySpellID(eventSpellID, eventBaseSpellID, false)
             return
         end
 
@@ -1051,7 +1057,11 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             if isPlayerUnit then
                 if normalizeSpellIdentifier(callbacks, arg3) ~= nil then
                     if runtimeRefreshStats then runtimeRefreshStats.unitSpellcastCooldownSkips = runtimeRefreshStats.unitSpellcastCooldownSkips + 1 end
-                    controller:QueueResolvedCooldownForSpellID(arg3, nil) -- @secret-safe: reached only when normalizeSpellIdentifier(callbacks, arg3) ~= nil, and that helper probes isSecretValue and returns nil for secrets — arg3 proven readable here
+                    if callbacks.scheduleUpdate then
+                        callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "unit_spellcast")
+                    else
+                        controller:QueueResolvedCooldownForSpellID(arg3, nil) -- @secret-safe: reached only when normalizeSpellIdentifier(callbacks, arg3) ~= nil, and that helper probes isSecretValue and returns nil for secrets — arg3 proven readable here
+                    end
                 elseif callbacks.scheduleUpdate then
                     if runtimeRefreshStats then runtimeRefreshStats.unitSpellcastCooldownFallbacks = runtimeRefreshStats.unitSpellcastCooldownFallbacks + 1 end
                     callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "unit_spellcast")
@@ -1165,7 +1175,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         return controller:HandleFrameEvent(event, arg1, arg2, arg3, arg4, frame) -- @secret-safe: HandleFrameEvent probes isSecretValue(arg1) before the unit compare and normalizes arg3 through the secret-probing normalizeSpellIdentifier (round-13 hand-audit)
     end
 
-    function controller:HandleCooldownChanged(_, spellID, baseSpellID, kind)
+    function controller:HandleCooldownChanged(_, spellID, baseSpellID, kind, category, startRecoveryCategory)
         if not isRuntimeEnabled(callbacks) then return end
         if kind == "scanner_item" then
             controller:ApplyItemScope()
@@ -1174,9 +1184,14 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         elseif kind == "scanner_spell" then
             controller:ApplySpellScope()
         elseif kind == "refresh" then
+            if IsGlobalRecoveryCategory(startRecoveryCategory)
+                and callbacks.updateCooldownOnly then
+                callbacks.updateCooldownOnly(true)
+                return
+            end
             local comparableSpellID = normalizeSpellIdentifier(callbacks, spellID) ~= nil
             if comparableSpellID then
-                controller:ApplySpellID(spellID, baseSpellID)
+                controller:ApplySpellID(spellID, baseSpellID, true)
             elseif callbacks.scheduleUpdate then
                 if runtimeRefreshStats then runtimeRefreshStats.refreshAllCooldownFallbacks = runtimeRefreshStats.refreshAllCooldownFallbacks + 1 end
                 callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "refresh_all")
@@ -1184,7 +1199,11 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         elseif kind == "cast_start" then
             if normalizeSpellIdentifier(callbacks, spellID) ~= nil then
                 if runtimeRefreshStats then runtimeRefreshStats.castStartCooldownSkips = runtimeRefreshStats.castStartCooldownSkips + 1 end
-                controller:QueueResolvedCooldownForSpellID(spellID, baseSpellID)
+                if callbacks.scheduleUpdate then
+                    callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_start")
+                else
+                    controller:QueueResolvedCooldownForSpellID(spellID, baseSpellID)
+                end
             elseif callbacks.scheduleUpdate then
                 if runtimeRefreshStats then runtimeRefreshStats.castStartCooldownFallbacks = runtimeRefreshStats.castStartCooldownFallbacks + 1 end
                 callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_start")
@@ -1195,7 +1214,11 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             end
             controller:InvalidateGCDOnlyBindings()
             controller:InvalidateSpellCooldownBinding(spellID)
-            controller:ApplySpellID(spellID, nil)
+            if callbacks.scheduleUpdate then
+                callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_succeeded")
+            else
+                controller:ApplySpellID(spellID, nil, false)
+            end
             if callbacks.requestStackTextUpdate then
                 callbacks.requestStackTextUpdate()
             end

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -18,7 +18,10 @@ end
 local UPDATE_COOLDOWN = "cooldown"
 local UPDATE_FULL = "full"
 
-local function IsGlobalRecoveryCategory(category)
+local function IsGlobalRecoveryCategory(category, isSecretValue)
+    if isSecretValue and isSecretValue(category) then
+        return false, true
+    end
     local spellCooldownConsts = _G.Constants and _G.Constants.SpellCooldownConsts
     return spellCooldownConsts
         and category == spellCooldownConsts.GLOBAL_RECOVERY_CATEGORY
@@ -1180,7 +1183,9 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         elseif kind == "scanner_spell" then
             controller:ApplySpellScope()
         elseif kind == "refresh" then
-            if IsGlobalRecoveryCategory(startRecoveryCategory)
+            local isGlobalRecovery, isOpaqueCategory = IsGlobalRecoveryCategory(
+                startRecoveryCategory, callbacks.isSecretValue)
+            if (isGlobalRecovery or isOpaqueCategory)
                 and callbacks.updateCooldownOnly then
                 local comparableSpellID = normalizeSpellIdentifier(callbacks, spellID) ~= nil
                 if comparableSpellID then

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -1186,7 +1186,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         elseif kind == "refresh" then
             if IsGlobalRecoveryCategory(startRecoveryCategory)
                 and callbacks.updateCooldownOnly then
-                callbacks.updateCooldownOnly(true)
+                callbacks.updateCooldownOnly(true, true)
                 return
             end
             local comparableSpellID = normalizeSpellIdentifier(callbacks, spellID) ~= nil

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -1057,11 +1057,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             if isPlayerUnit then
                 if normalizeSpellIdentifier(callbacks, arg3) ~= nil then
                     if runtimeRefreshStats then runtimeRefreshStats.unitSpellcastCooldownSkips = runtimeRefreshStats.unitSpellcastCooldownSkips + 1 end
-                    if callbacks.scheduleUpdate then
-                        callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "unit_spellcast")
-                    else
-                        controller:QueueResolvedCooldownForSpellID(arg3, nil) -- @secret-safe: reached only when normalizeSpellIdentifier(callbacks, arg3) ~= nil, and that helper probes isSecretValue and returns nil for secrets — arg3 proven readable here
-                    end
+                    controller:QueueResolvedCooldownForSpellID(arg3, nil) -- @secret-safe: reached only when normalizeSpellIdentifier(callbacks, arg3) ~= nil, and that helper probes isSecretValue and returns nil for secrets — arg3 proven readable here
                 elseif callbacks.scheduleUpdate then
                     if runtimeRefreshStats then runtimeRefreshStats.unitSpellcastCooldownFallbacks = runtimeRefreshStats.unitSpellcastCooldownFallbacks + 1 end
                     callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "unit_spellcast")
@@ -1186,6 +1182,10 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         elseif kind == "refresh" then
             if IsGlobalRecoveryCategory(startRecoveryCategory)
                 and callbacks.updateCooldownOnly then
+                local comparableSpellID = normalizeSpellIdentifier(callbacks, spellID) ~= nil
+                if comparableSpellID then
+                    controller:ApplySpellID(spellID, baseSpellID, true)
+                end
                 callbacks.updateCooldownOnly(true, true)
                 return
             end
@@ -1199,11 +1199,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         elseif kind == "cast_start" then
             if normalizeSpellIdentifier(callbacks, spellID) ~= nil then
                 if runtimeRefreshStats then runtimeRefreshStats.castStartCooldownSkips = runtimeRefreshStats.castStartCooldownSkips + 1 end
-                if callbacks.scheduleUpdate then
-                    callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_start")
-                else
-                    controller:QueueResolvedCooldownForSpellID(spellID, baseSpellID)
-                end
+                controller:QueueResolvedCooldownForSpellID(spellID, baseSpellID)
             elseif callbacks.scheduleUpdate then
                 if runtimeRefreshStats then runtimeRefreshStats.castStartCooldownFallbacks = runtimeRefreshStats.castStartCooldownFallbacks + 1 end
                 callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_start")
@@ -1214,10 +1210,10 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             end
             controller:InvalidateGCDOnlyBindings()
             controller:InvalidateSpellCooldownBinding(spellID)
-            if callbacks.scheduleUpdate then
-                callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_succeeded")
-            else
+            if normalizeSpellIdentifier(callbacks, spellID) ~= nil then
                 controller:ApplySpellID(spellID, nil, false)
+            elseif callbacks.scheduleUpdate then
+                callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "cast_succeeded")
             end
             if callbacks.requestStackTextUpdate then
                 callbacks.requestStackTextUpdate()

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -549,12 +549,18 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         end
     end
 
-    function controller:ApplySpellID(eventSpellID, eventBaseSpellID, trustIsOnGCD)
+    function controller:ApplySpellID(eventSpellID, eventBaseSpellID, trustIsOnGCD,
+        eventCategory, eventItemID)
         local spellIDs = controller.applySpellIDScratch
         wipe(spellIDs)
         local hasSpellIDs = addSpellIdentifierToSet(callbacks, spellIDs, eventSpellID)
         hasSpellIDs = addSpellIdentifierToSet(callbacks, spellIDs, eventBaseSpellID) or hasSpellIDs
+        hasSpellIDs = addSpellIdentifierToSet(callbacks, spellIDs, eventCategory) or hasSpellIDs
+        hasSpellIDs = addSpellIdentifierToSet(callbacks, spellIDs, eventItemID) or hasSpellIDs
         if not hasSpellIDs then return false end
+
+        local normalizedCategory = normalizeSpellIdentifier(callbacks, eventCategory)
+        local normalizedItemID = normalizeSpellIdentifier(callbacks, eventItemID)
 
         local batchStarted = false
         local refreshed = false
@@ -565,6 +571,11 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             for _, icon in ipairs(pool) do
                 local entry = icon and icon._spellEntry
                 if entryMatchesSpellIdentifierSet(callbacks, icon, entry, spellIDs, hasSpellIDs) then
+                    if normalizedCategory and normalizedItemID
+                        and entry and entry.type == "consumable"
+                        and spellIdentifierSetHas(callbacks, spellIDs, entry.id) then
+                        entry.itemID = normalizedItemID
+                    end
                     if not batchStarted then
                         editMode, ncdm, ncdmContainers, inCombatState = beginBatch(callbacks, "spellID")
                         batchStarted = true
@@ -1174,7 +1185,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         return controller:HandleFrameEvent(event, arg1, arg2, arg3, arg4, frame) -- @secret-safe: HandleFrameEvent probes isSecretValue(arg1) before the unit compare and normalizes arg3 through the secret-probing normalizeSpellIdentifier (round-13 hand-audit)
     end
 
-    function controller:HandleCooldownChanged(_, spellID, baseSpellID, kind, category, startRecoveryCategory)
+    function controller:HandleCooldownChanged(_, spellID, baseSpellID, kind, category, startRecoveryCategory, itemID)
         if not isRuntimeEnabled(callbacks) then return end
         if kind == "scanner_item" then
             controller:ApplyItemScope()
@@ -1189,15 +1200,25 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                 and callbacks.updateCooldownOnly then
                 local comparableSpellID = normalizeSpellIdentifier(callbacks, spellID) ~= nil
                 if comparableSpellID then
-                    controller:ApplySpellID(spellID, baseSpellID, true)
+                    controller:ApplySpellID(spellID, baseSpellID, true, category, itemID)
                 end
                 callbacks.updateCooldownOnly(true, true)
                 return
             end
-            local comparableSpellID = normalizeSpellIdentifier(callbacks, spellID) ~= nil
-            if comparableSpellID then
-                controller:ApplySpellID(spellID, baseSpellID, true)
-            elseif callbacks.scheduleUpdate then
+            local normalizedCategory = normalizeSpellIdentifier(callbacks, category)
+            local normalizedItemID = normalizeSpellIdentifier(callbacks, itemID)
+            local categoryOpaque = category ~= nil and normalizedCategory == nil
+            local itemOpaque = itemID ~= nil and normalizedItemID == nil
+            if categoryOpaque or itemOpaque then
+                if callbacks.scheduleUpdate then
+                    if runtimeRefreshStats then runtimeRefreshStats.refreshAllCooldownFallbacks = runtimeRefreshStats.refreshAllCooldownFallbacks + 1 end
+                    callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "refresh_all")
+                end
+                return
+            end
+            local refreshed = controller:ApplySpellID(
+                spellID, baseSpellID, true, normalizedCategory, normalizedItemID)
+            if not refreshed and callbacks.scheduleUpdate then
                 if runtimeRefreshStats then runtimeRefreshStats.refreshAllCooldownFallbacks = runtimeRefreshStats.refreshAllCooldownFallbacks + 1 end
                 callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "refresh_all")
             end

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -571,10 +571,13 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             for _, icon in ipairs(pool) do
                 local entry = icon and icon._spellEntry
                 if entryMatchesSpellIdentifierSet(callbacks, icon, entry, spellIDs, hasSpellIDs) then
-                    if normalizedCategory and normalizedItemID
-                        and entry and entry.type == "consumable"
-                        and spellIdentifierSetHas(callbacks, spellIDs, entry.id) then
+                    local entryCategory = normalizeSpellIdentifier(callbacks, entry and entry.id)
+                    if normalizedCategory and entryCategory == normalizedCategory
+                        and entry and entry.type == "consumable" then
                         entry.itemID = normalizedItemID
+                        entry._runtimeSpellID = normalizeSpellIdentifier(callbacks, eventSpellID)
+                            or normalizeSpellIdentifier(callbacks, eventBaseSpellID)
+                        entry._runtimeBaseSpellID = normalizeSpellIdentifier(callbacks, eventBaseSpellID)
                     end
                     if not batchStarted then
                         editMode, ncdm, ncdmContainers, inCombatState = beginBatch(callbacks, "spellID")

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -141,7 +141,7 @@ _runtimeFrame:SetScript("OnEvent", function(_, evt, arg1, arg2, arg3, arg4, arg5
     end
 
     if evt == "SPELL_UPDATE_COOLDOWN" then
-        publish("CDM:COOLDOWN_CHANGED", arg1, arg2, "refresh")
+        publish("CDM:COOLDOWN_CHANGED", arg1, arg2, "refresh", arg3, arg4, arg5)
     elseif evt == "SPELL_UPDATE_CHARGES" or evt == "SPELL_UPDATE_USES" then
         publish("CDM:CHARGES_CHANGED", arg1, arg2)
     elseif evt == "UNIT_SPELLCAST_START" then
@@ -436,7 +436,8 @@ local function GetCooldownInfoBoolean(info, key)
     return DecodePotentialSecretBoolean(value)
 end
 
-local function GetCurrentIsOnGCD(info)
+local function GetCurrentIsOnGCD(info, trustField)
+    if trustField ~= true then return nil end
     return GetCooldownInfoBoolean(info, "isOnGCD")
 end
 
@@ -1032,6 +1033,7 @@ local function ClearCooldownStateContext(context)
     context.useBuffSwipe = nil
     context.skipAuraPhase = nil
     context.showGCDSwipe = nil
+    context.trustIsOnGCD = nil
     context.lastChargeRuntimeSpellID = nil
 end
 
@@ -1072,6 +1074,7 @@ function CDMResolvers.BuildCooldownStateContext(owner, entry, runtimeSpellID, op
     context.useBuffSwipe = options and options.useBuffSwipe
     context.skipAuraPhase = options and options.skipAuraPhase == true
     context.showGCDSwipe = options and options.showGCDSwipe == true
+    context.trustIsOnGCD = options and options.trustIsOnGCD == true
     context.lastChargeRuntimeSpellID = options and options.lastChargeRuntimeSpellID
     return context
 end
@@ -1898,10 +1901,14 @@ local function ResolveCooldownStateCore(context)
         return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
     end
 
+    local trustIsOnGCD = context.trustIsOnGCD == true
     local gcdCdInfo = QueryCooldown(sid)
-    local currentOnGCD = GetCurrentIsOnGCD(gcdCdInfo)
+    local currentOnGCD = GetCurrentIsOnGCD(gcdCdInfo, trustIsOnGCD)
+    local preserveGCDOnly = not trustIsOnGCD
+        and context.owner
+        and context.owner._resolvedCooldownMode == "gcd-only"
     local gcdDurObj
-    if currentOnGCD == true and context.showGCDSwipe == true then
+    if trustIsOnGCD and currentOnGCD == true then
         gcdDurObj = QueryGCDDurationObject(sid)
     end
     MemAuditProfilerMark("CDM_rsGCDProbe")
@@ -1924,12 +1931,24 @@ local function ResolveCooldownStateCore(context)
     do
         local cdInfo = gcdCdInfo or QueryCooldown(sid)
         local cdInfoActive = IsCooldownInfoActive(cdInfo)
-        if cdInfoActive ~= false then
-            local cdInfoOnGCD = GetCurrentIsOnGCD(cdInfo)
+        local cdInfoOnGCD = GetCurrentIsOnGCD(cdInfo, trustIsOnGCD)
+        if cdInfoActive == true or (cdInfoActive == nil and cdInfoOnGCD ~= true) then
             local durObj = QueryDuration(sid)
             state.cooldownInfoActive = cdInfoActive
             state.cooldownInfoOnGCD = cdInfoOnGCD
-            if durObj then
+            if preserveGCDOnly then
+                local gcdDur = QueryGCDDurationObject(sid)
+                if gcdDur then
+                    state.mode = "gcd-only"
+                    SetCooldownStateActivity(state, true)
+                    state.durObj = gcdDur
+                    state.sourceID = sid
+                    state.spellID = sid
+                    MemAuditProfilerMark("CDM_rsPreserveGCD")
+                    return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
+                end
+            end
+            if durObj and cdInfoOnGCD ~= true then
                 state.mode = "cooldown"
                 SetCooldownStateActivity(state, true)
                 state.durObj = durObj

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -221,7 +221,8 @@ local QueryChargeDuration = RuntimeQueries.QueryChargeDuration
 local QueryOverrideSpell  = RuntimeQueries.QueryOverrideSpell
 
 local function IsItemLikeEntry(entry)
-    return entry and (entry.type == "item" or entry.type == "trinket" or entry.type == "slot")
+    return entry and (entry.type == "item" or entry.type == "trinket" or entry.type == "slot"
+        or (entry.type == "consumable" and entry.itemID ~= nil))
 end
 
 local function QueryItemUseSpellID(itemID)
@@ -265,6 +266,8 @@ local function ResolveItemCooldownIdentity(entry)
             itemID = Sources.QueryInventoryItemID("player", slotID)
         end
         itemID = itemID or entry.itemID
+    elseif entry.type == "consumable" then
+        itemID = entry.itemID
     elseif entry.type == "macro" then
         local resolvedID, resolvedType = CDMResolvers.ResolveMacro(entry)
         if resolvedType == "item" then

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -1908,7 +1908,7 @@ local function ResolveCooldownStateCore(context)
         and context.owner
         and context.owner._resolvedCooldownMode == "gcd-only"
     local gcdDurObj
-    if trustIsOnGCD and currentOnGCD == true then
+    if trustIsOnGCD and currentOnGCD == true and context.showGCDSwipe == true then
         gcdDurObj = QueryGCDDurationObject(sid)
     end
     MemAuditProfilerMark("CDM_rsGCDProbe")

--- a/tests/unit/cdm_aura_priority_integration_test.lua
+++ b/tests/unit/cdm_aura_priority_integration_test.lua
@@ -163,6 +163,7 @@ local function resolveState(e, spellID, category)
         containerKey = category or e.viewerType,
         useBuffSwipe = true,
         showGCDSwipe = true,
+        trustIsOnGCD = true,
     })
 end
 

--- a/tests/unit/cdm_icon_custom_bar_policy_test.lua
+++ b/tests/unit/cdm_icon_custom_bar_policy_test.lua
@@ -197,6 +197,17 @@ assert(visible.renderVisible == true,
 assert(visible.isUsable == true,
     "known spells on cooldown should be considered usable for custom-bar visibility")
 
+cooldownStates[101] = {
+    gcdOnly = true,
+    isOnCooldown = true,
+    rechargeActive = true,
+    hasCharges = false,
+    hasChargesRemaining = false,
+}
+visible = policy:ComputeVisibility(icon, icon._spellEntry, trackerSettings.custom, 123)
+assert(visible.layoutVisible == false,
+    "GCD-only activity should not pass show-only-on-cooldown visibility")
+
 knownSpells[102] = false
 cooldownStates[102] = { isOnCooldown = false }
 local unusable = policy:ResolveUsability({ type = "spell", id = 102, spellID = 102 }, trackerSettings.custom, cooldownStates[102])

--- a/tests/unit/cdm_icon_factory_bling_test.lua
+++ b/tests/unit/cdm_icon_factory_bling_test.lua
@@ -99,6 +99,15 @@ loadChunk("QUI_CDM/cdm/cdm_icon_renderer.lua", "cdm_icon_factory.lua")("QUI", ns
 local createdIcon, createdEntry
 local acquiredIcon, acquiredEntry, acquiredReused
 local releasedIcon
+local rendererSource = assert(io.open("QUI_CDM/cdm/cdm_icon_renderer.lua", "r")):read("*a")
+assert(rendererSource:find('SetScript("OnCooldownDone"', 1, true),
+    "renderer should bind native cooldown completion")
+assert(rendererSource:find("CDMIcons:UpdateCooldownOnly()", 1, true),
+    "native cooldown completion should trigger a broad cooldown refresh")
+assert(rendererSource:find("updateCooldownOnly = function(trustIsOnGCD)", 1, true),
+    "runtime refresh adapter must accept the trusted GCD flag")
+assert(rendererSource:find("CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true)", 1, true),
+    "runtime refresh adapter must preserve the trusted GCD flag")
 
 ns.CDMIcons = {
     OnFactoryIconCreated = function(icon, entry)

--- a/tests/unit/cdm_icon_factory_bling_test.lua
+++ b/tests/unit/cdm_icon_factory_bling_test.lua
@@ -102,11 +102,13 @@ local releasedIcon
 local rendererSource = assert(io.open("QUI_CDM/cdm/cdm_icon_renderer.lua", "r")):read("*a")
 assert(rendererSource:find('SetScript("OnCooldownDone"', 1, true),
     "renderer should bind native cooldown completion")
-assert(rendererSource:find("CDMIcons:UpdateCooldownOnly()", 1, true),
-    "native cooldown completion should trigger a broad cooldown refresh")
+assert(rendererSource:find('ScheduleCDMUpdate(true, CDM_UPDATE_COOLDOWN, "cooldown_done")', 1, true),
+    "native cooldown completion should schedule one broad cooldown refresh")
+assert(rendererSource:find("context.forceResolveIdle ~= true", 1, true),
+    "event-driven cooldown refreshes should resolve idle icons")
 assert(rendererSource:find("updateCooldownOnly = function(trustIsOnGCD)", 1, true),
     "runtime refresh adapter must accept the trusted GCD flag")
-assert(rendererSource:find("CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true)", 1, true),
+assert(rendererSource:find("CDMIcons:UpdateCooldownOnly(trustIsOnGCD == true, true)", 1, true),
     "runtime refresh adapter must preserve the trusted GCD flag")
 
 ns.CDMIcons = {

--- a/tests/unit/cdm_icon_linked_aura_signature_test.lua
+++ b/tests/unit/cdm_icon_linked_aura_signature_test.lua
@@ -170,7 +170,7 @@ assert(shouldPlace({}, {}, {}, false) == false,
 
 local updateSource = sliceBetween(
     icons,
-    "UpdateIconCooldown = function(icon)",
+    "UpdateIconCooldown = function(icon, trustIsOnGCD)",
     "local function IsCustomBarEntryUsableOnCurrentClass(entry, viewerType)")
 updateSource = updateSource:gsub("^UpdateIconCooldown =", "return", 1)
 local ownedUpdates = 0

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -111,9 +111,15 @@ local customCooldownIcon = makeIcon("customCooldown", {
     viewerType = "custom",
     _isCustomEntry = true,
 })
+local consumableIcon = makeIcon("consumable", {
+    id = 808,
+    kind = "cooldown",
+    type = "consumable",
+    viewerType = "essential",
+})
 
 local iconPools = {
-    essential = { spellIcon, otherSpellIcon, itemIcon, mirrorAuraIcon, idleIcon, customCooldownIcon },
+    essential = { spellIcon, otherSpellIcon, itemIcon, mirrorAuraIcon, idleIcon, customCooldownIcon, consumableIcon },
     buff = { auraIcon },
 }
 
@@ -398,6 +404,15 @@ reset(auraApplied)
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 303, nil, "refresh", nil, 133)
 assert(auraApplied.aura == 1,
     "global-recovery refreshes must update matching aura-backed icons")
+reset(runtimeUpdated)
+controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, nil, "refresh", 808, nil, 909)
+assert(runtimeUpdated.consumable == 1 and consumableIcon._spellEntry.itemID == 909,
+    "cooldown category and item payloads must refresh category-backed entries")
+local schedulesBeforeOpaquePayload = #schedules
+controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, nil, "refresh", secretRecoveryCategory, nil, 909)
+assert(#schedules == schedulesBeforeOpaquePayload + 1
+        and schedules[#schedules].reason == "refresh_all",
+    "opaque cooldown categories must use the safe broad refresh fallback")
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "refresh", nil, secretRecoveryCategory)
 assert(trustedBroadCooldownRefreshes == 3 and forcedBroadCooldownRefreshes == 3,
     "opaque recovery categories must take the trusted broad refresh path: "

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -143,6 +143,7 @@ local barAuraRefreshMarks = {}
 local customOverlayRefreshes = 0
 local trustedCooldownUpdates = {}
 local trustedBroadCooldownRefreshes = 0
+local forcedBroadCooldownRefreshes = 0
 -- Names the isDefinitivelySelfAuraIcon stub reports as PROVABLE player
 -- self-auras. Populated by the target-scope test.
 local selfAuraNames = {}
@@ -176,9 +177,12 @@ local controller = module.Create({
         runtimeUpdated[icon.name] = count(runtimeUpdated, icon.name) + 1
         trustedCooldownUpdates[icon.name] = trustIsOnGCD == true
     end,
-    updateCooldownOnly = function(trustIsOnGCD)
+    updateCooldownOnly = function(trustIsOnGCD, forceResolveIdle)
         if trustIsOnGCD == true then
             trustedBroadCooldownRefreshes = trustedBroadCooldownRefreshes + 1
+        end
+        if forceResolveIdle == true then
+            forcedBroadCooldownRefreshes = forcedBroadCooldownRefreshes + 1
         end
     end,
     applyAuraScopedResolvedCooldown = function(icon)
@@ -385,6 +389,8 @@ assert(trustedCooldownUpdates.spell == true,
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "refresh", nil, 133)
 assert(trustedBroadCooldownRefreshes == 1,
     "GCD-category SPELL_UPDATE_COOLDOWN events must request one trusted broad refresh")
+assert(forcedBroadCooldownRefreshes == 1,
+    "GCD-category SPELL_UPDATE_COOLDOWN events must resolve idle icons")
 
 reset(applied)
 reset(runtimeUpdated)

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -51,6 +51,7 @@ end
 
 local secretSpellID = { token = "secret" }
 local secretUnit = { token = "secret-unit" }
+local secretRecoveryCategory = { token = "secret-category" }
 
 local function makeIcon(name, entry)
     return {
@@ -156,7 +157,9 @@ local module = assert(ns.CDMIconRuntimeRefresh, "runtime refresh module should b
 local controller = module.Create({
     isRuntimeEnabled = function() return true end,
     getIconPools = function() return iconPools end,
-    isSecretValue = function(value) return value == secretSpellID or value == secretUnit end,
+    isSecretValue = function(value)
+        return value == secretSpellID or value == secretUnit or value == secretRecoveryCategory
+    end,
     gcdSpellID = 61304,
     prepareBatch = function()
         return false, {}, {}, false
@@ -395,6 +398,10 @@ reset(auraApplied)
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 303, nil, "refresh", nil, 133)
 assert(auraApplied.aura == 1,
     "global-recovery refreshes must update matching aura-backed icons")
+controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "refresh", nil, secretRecoveryCategory)
+assert(trustedBroadCooldownRefreshes == 3 and forcedBroadCooldownRefreshes == 3,
+    "opaque recovery categories must take the trusted broad refresh path: "
+    .. trustedBroadCooldownRefreshes .. "/" .. forcedBroadCooldownRefreshes)
 
 reset(applied)
 reset(runtimeUpdated)

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -405,8 +405,11 @@ controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 303, nil, "refresh", ni
 assert(auraApplied.aura == 1,
     "global-recovery refreshes must update matching aura-backed icons")
 reset(runtimeUpdated)
-controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, nil, "refresh", 808, nil, 909)
-assert(runtimeUpdated.consumable == 1 and consumableIcon._spellEntry.itemID == 909,
+controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, 999998, "refresh", 808, nil, 909)
+assert(runtimeUpdated.consumable == 1
+        and consumableIcon._spellEntry.itemID == 909
+        and consumableIcon._spellEntry._runtimeSpellID == 999999
+        and consumableIcon._spellEntry._runtimeBaseSpellID == 999998,
     "cooldown category and item payloads must refresh category-backed entries")
 local schedulesBeforeOpaquePayload = #schedules
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, nil, "refresh", secretRecoveryCategory, nil, 909)

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -391,6 +391,10 @@ assert(trustedBroadCooldownRefreshes == 1,
     "GCD-category SPELL_UPDATE_COOLDOWN events must request one trusted broad refresh")
 assert(forcedBroadCooldownRefreshes == 1,
     "GCD-category SPELL_UPDATE_COOLDOWN events must resolve idle icons")
+reset(auraApplied)
+controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 303, nil, "refresh", nil, 133)
+assert(auraApplied.aura == 1,
+    "global-recovery refreshes must update matching aura-backed icons")
 
 reset(applied)
 reset(runtimeUpdated)
@@ -678,22 +682,20 @@ reset(runtimeUpdated)
 reset(stackWriteStates)
 local schedulesBeforeCastStart = #schedules
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "cast_start")
-assert(#schedules == schedulesBeforeCastStart + 1
-    and schedules[#schedules].reason == "cast_start",
-    "cast start should schedule a broad cooldown refresh for GCD visibility")
-assert(next(runtimeUpdated) == nil,
-    "cast start broad refresh should replace the targeted spell path")
+assert(#schedules == schedulesBeforeCastStart,
+    "readable cast start should stay on the targeted spell path")
+assert(runtimeUpdated.spell == 1 and runtimeUpdated.otherSpell == nil,
+    "readable cast start should update only the matching spell icon")
 
 reset(applied)
 reset(runtimeUpdated)
 reset(stackWriteStates)
 local schedulesBeforeSpellcastStop = #schedules
 controller:Handle("UNIT_SPELLCAST_STOP", "player", "cast-guid", 101)
-assert(#schedules == schedulesBeforeSpellcastStop + 1
-    and schedules[#schedules].reason == "unit_spellcast",
-    "player spellcast stop should schedule a broad cooldown refresh for GCD visibility")
-assert(next(runtimeUpdated) == nil,
-    "player spellcast stop broad refresh should replace the targeted spell path")
+assert(#schedules == schedulesBeforeSpellcastStop,
+    "readable player spellcast stop should stay on the targeted spell path")
+assert(runtimeUpdated.spell == 1 and runtimeUpdated.otherSpell == nil,
+    "readable player spellcast stop should update only the matching spell icon")
 
 reset(applied)
 reset(runtimeUpdated)
@@ -713,11 +715,10 @@ reset(runtimeUpdated)
 reset(stackWriteStates)
 local schedulesBeforeSecretUnit = #schedules
 controller:Handle("UNIT_SPELLCAST_STOP", secretUnit, "cast-guid", 101)
-assert(#schedules == schedulesBeforeSecretUnit + 1
-    and schedules[#schedules].reason == "unit_spellcast",
-    "secret unit spellcast stop should schedule a broad cooldown refresh")
-assert(next(runtimeUpdated) == nil,
-    "secret unit spellcast stop broad refresh should replace the targeted spell path")
+assert(#schedules == schedulesBeforeSecretUnit,
+    "secret unit token with a readable spell ID should stay on the targeted spell path")
+assert(runtimeUpdated.spell == 1 and runtimeUpdated.otherSpell == nil,
+    "secret unit token should still update only the matching spell icon")
 
 reset(applied)
 reset(runtimeUpdated)
@@ -741,14 +742,13 @@ controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "cast_succeed
 assert(recentCasts[1] == 101, "cast succeeded should record the player cast")
 assert(highlighterCasts[1] == 101, "cast succeeded should still notify the highlighter")
 assert(applied.spell == nil,
-    "cast succeeded should not run a synchronous broad cooldown refresh")
-assert(next(runtimeUpdated) == nil and next(visibilityUpdated) == nil
-    and next(blingSynced) == nil,
-    "cast succeeded should defer the broad refresh to the scheduler")
+    "cast succeeded should not run the stackless cooldown-only path")
+assert(runtimeUpdated.spell == 1 and runtimeUpdated.otherSpell == nil
+    and visibilityUpdated.spell == 1 and blingSynced.spell == 1,
+    "readable cast succeeded should update only the matching spell icon")
 assert(stackRequested == true, "cast succeeded should request a delayed stack text refresh")
-assert(#schedules == schedulesBeforeCastSucceeded + 1
-    and schedules[#schedules].reason == "cast_succeeded",
-    "cast succeeded should schedule a broad cooldown refresh for GCD visibility")
+assert(#schedules == schedulesBeforeCastSucceeded,
+    "readable cast succeeded should stay on the targeted spell path")
 
 reset(applied)
 reset(runtimeUpdated)

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -7,6 +7,12 @@ local function noop() end
 local inCombat = false
 local createdFrames = {}
 
+Constants = {
+    SpellCooldownConsts = {
+        GLOBAL_RECOVERY_CATEGORY = 133,
+    },
+}
+
 function InCombatLockdown() return inCombat end
 
 function wipe(tbl)
@@ -135,6 +141,8 @@ local stableClears = 0
 local spellCacheInvalidations = {}
 local barAuraRefreshMarks = {}
 local customOverlayRefreshes = 0
+local trustedCooldownUpdates = {}
+local trustedBroadCooldownRefreshes = 0
 -- Names the isDefinitivelySelfAuraIcon stub reports as PROVABLE player
 -- self-auras. Populated by the target-scope test.
 local selfAuraNames = {}
@@ -164,8 +172,14 @@ local controller = module.Create({
     applyResolvedCooldown = function(icon)
         applied[icon.name] = count(applied, icon.name) + 1
     end,
-    updateIconCooldown = function(icon)
+    updateIconCooldown = function(icon, trustIsOnGCD)
         runtimeUpdated[icon.name] = count(runtimeUpdated, icon.name) + 1
+        trustedCooldownUpdates[icon.name] = trustIsOnGCD == true
+    end,
+    updateCooldownOnly = function(trustIsOnGCD)
+        if trustIsOnGCD == true then
+            trustedBroadCooldownRefreshes = trustedBroadCooldownRefreshes + 1
+        end
     end,
     applyAuraScopedResolvedCooldown = function(icon)
         auraApplied[icon.name] = count(auraApplied, icon.name) + 1
@@ -350,6 +364,7 @@ assert(#stackWriteStates == 2 and stackWriteStates[1] == true and stackWriteStat
 reset(applied)
 reset(runtimeUpdated)
 reset(visibilityUpdated)
+reset(trustedCooldownUpdates)
 reset(batches)
 endedBatches = 0
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, nil, "refresh")
@@ -364,6 +379,12 @@ assert(applied.spell == nil, "matched per-spell cooldown refresh should not use 
 assert(visibilityUpdated.spell == 1, "matched per-spell cooldown refresh should update matching visibility")
 assert(stackWriteStates[1] == true and stackWriteStates[2] == false,
     "matched per-spell cooldown refresh should enable stack text writes around the full update")
+assert(trustedCooldownUpdates.spell == true,
+    "SPELL_UPDATE_COOLDOWN refreshes must mark isOnGCD as trusted")
+
+controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "refresh", nil, 133)
+assert(trustedBroadCooldownRefreshes == 1,
+    "GCD-category SPELL_UPDATE_COOLDOWN events must request one trusted broad refresh")
 
 reset(applied)
 reset(runtimeUpdated)
@@ -651,22 +672,22 @@ reset(runtimeUpdated)
 reset(stackWriteStates)
 local schedulesBeforeCastStart = #schedules
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "cast_start")
-assert(#schedules == schedulesBeforeCastStart,
-    "cast start with a spell ID should stay on the targeted spell path")
-assert(runtimeUpdated.spell == 1, "cast start should update the matching spell icon")
-assert(runtimeUpdated.otherSpell == nil, "cast start should not update unrelated spell icons")
-assert(stackWriteStates[1] == true and stackWriteStates[2] == false,
-    "cast start targeted refresh should enable stack text writes")
+assert(#schedules == schedulesBeforeCastStart + 1
+    and schedules[#schedules].reason == "cast_start",
+    "cast start should schedule a broad cooldown refresh for GCD visibility")
+assert(next(runtimeUpdated) == nil,
+    "cast start broad refresh should replace the targeted spell path")
 
 reset(applied)
 reset(runtimeUpdated)
 reset(stackWriteStates)
 local schedulesBeforeSpellcastStop = #schedules
 controller:Handle("UNIT_SPELLCAST_STOP", "player", "cast-guid", 101)
-assert(#schedules == schedulesBeforeSpellcastStop,
-    "player spellcast stop with a spell ID should stay on the targeted spell path")
-assert(runtimeUpdated.spell == 1, "player spellcast stop should update the matching spell icon")
-assert(runtimeUpdated.otherSpell == nil, "player spellcast stop should not update unrelated spell icons")
+assert(#schedules == schedulesBeforeSpellcastStop + 1
+    and schedules[#schedules].reason == "unit_spellcast",
+    "player spellcast stop should schedule a broad cooldown refresh for GCD visibility")
+assert(next(runtimeUpdated) == nil,
+    "player spellcast stop broad refresh should replace the targeted spell path")
 
 reset(applied)
 reset(runtimeUpdated)
@@ -686,10 +707,11 @@ reset(runtimeUpdated)
 reset(stackWriteStates)
 local schedulesBeforeSecretUnit = #schedules
 controller:Handle("UNIT_SPELLCAST_STOP", secretUnit, "cast-guid", 101)
-assert(#schedules == schedulesBeforeSecretUnit,
-    "secret unit spellcast stop with a spell ID should stay on the targeted spell path")
-assert(runtimeUpdated.spell == 1, "secret unit spellcast stop should still update the matching spell icon")
-assert(runtimeUpdated.otherSpell == nil, "secret unit spellcast stop should not update unrelated spell icons")
+assert(#schedules == schedulesBeforeSecretUnit + 1
+    and schedules[#schedules].reason == "unit_spellcast",
+    "secret unit spellcast stop should schedule a broad cooldown refresh")
+assert(next(runtimeUpdated) == nil,
+    "secret unit spellcast stop broad refresh should replace the targeted spell path")
 
 reset(applied)
 reset(runtimeUpdated)
@@ -712,23 +734,15 @@ local schedulesBeforeCastSucceeded = #schedules
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 101, nil, "cast_succeeded")
 assert(recentCasts[1] == 101, "cast succeeded should record the player cast")
 assert(highlighterCasts[1] == 101, "cast succeeded should still notify the highlighter")
--- Design shift: cast_succeeded no longer runs a broad applyResolvedCooldown
--- sweep over every spell icon. UNIT_SPELLCAST_SUCCEEDED carries the spellID,
--- so the targeted updateIconCooldown via ApplySpellID is sufficient and
--- avoids ~3 MB/sec of churn during sustained combat.
 assert(applied.spell == nil,
-    "cast succeeded should NOT run a broad applyResolvedCooldown sweep")
-assert(runtimeUpdated.spell == 1,
-    "cast succeeded should run the targeted updateIconCooldown for the cast spell")
-assert(visibilityUpdated.spell == 1,
-    "cast succeeded should update visibility for the cast spell (folded into ApplySpellID)")
-assert(blingSynced.spell == 1,
-    "cast succeeded should sync bling for the cast spell (folded into ApplySpellID)")
-assert(stackWriteStates[1] == true and stackWriteStates[2] == false,
-    "cast succeeded targeted refresh should enable stack text writes")
+    "cast succeeded should not run a synchronous broad cooldown refresh")
+assert(next(runtimeUpdated) == nil and next(visibilityUpdated) == nil
+    and next(blingSynced) == nil,
+    "cast succeeded should defer the broad refresh to the scheduler")
 assert(stackRequested == true, "cast succeeded should request a delayed stack text refresh")
-assert(#schedules == schedulesBeforeCastSucceeded,
-    "cast succeeded should not schedule a redundant broad cooldown refresh")
+assert(#schedules == schedulesBeforeCastSucceeded + 1
+    and schedules[#schedules].reason == "cast_succeeded",
+    "cast succeeded should schedule a broad cooldown refresh for GCD visibility")
 
 reset(applied)
 reset(runtimeUpdated)

--- a/tests/unit/cdm_resolvers_cooldown_state_test.lua
+++ b/tests/unit/cdm_resolvers_cooldown_state_test.lua
@@ -20,11 +20,13 @@ local cooldownDur = { token = "cooldown-dur" }
 local overrideCooldownDur = { token = "override-cooldown-dur" }
 local chargeDur = { token = "charge-dur" }
 local gcdDur = { token = "gcd-dur" }
+local gcdDurationIgnoringGCD = { token = "gcd-dur-ignore-gcd" }
 local itemAuraDur = { token = "item-aura-dur" }
 local secretItemStart = { token = "secret-item-start" }
 local secretItemDuration = { token = "secret-item-duration" }
 local secretCooldownStart = { token = "secret-cooldown-start" }
 local secretCooldownDuration = { token = "secret-cooldown-duration" }
+local secretCooldownActive = { token = "secret-cooldown-active" }
 local secretChargeZero = { token = "secret-current-charges", value = 0 }
 local secretChargeOne = { token = "secret-current-charges", value = 1 }
 local secretChargeUnknown = { token = "secret-current-charges", value = "unknown" }
@@ -42,6 +44,7 @@ function issecretvalue(value)
         or value == secretItemDuration
         or value == secretCooldownStart
         or value == secretCooldownDuration
+        or value == secretCooldownActive
 end
 
 Enum = { LuaCurveType = { Step = "Step" } }
@@ -239,10 +242,13 @@ local ns = {
             if spellID == 70002 then
                 return {
                     isActive = true,
-                    isOnGCD = true,
+                    isOnGCD = false,
                     startTime = secretCooldownStart,
                     duration = secretCooldownDuration,
                 }
+            end
+            if spellID == 70003 then
+                return { isActive = secretCooldownActive, isOnGCD = true }
             end
             if spellID == 91004 and itemUseSpellCooldownActive then
                 return { isActive = true, isOnGCD = false }
@@ -250,11 +256,14 @@ local ns = {
             return nil
         end,
         QuerySpellCooldownDuration = function(spellID, ignoreGCD)
-            if spellID == 70001 and ignoreGCD == false then
-                return gcdDur
+            if spellID == 70001 then
+                return ignoreGCD == true and gcdDurationIgnoringGCD or gcdDur
             end
             if spellID == 70002 then
                 return ignoreGCD == true and cooldownDur or gcdDur
+            end
+            if spellID == 70003 then
+                return gcdDur
             end
             -- 60011: a GCD duration is available (a GCD swipe would otherwise be
             -- drawn) so the test proves the active recharge wins over it.
@@ -501,7 +510,14 @@ loadChunk("QUI_CDM/cdm/cdm_runtime_queries.lua", "cdm_runtime_queries.lua")("QUI
 loadChunk("QUI_CDM/cdm/cdm_resolvers.lua", "cdm_resolvers.lua")("QUI", ns)
 
 local resolvers = assert(ns.CDMResolvers, "CDMResolvers should be exported")
-local resolve = assert(resolvers.ResolveCooldownState, "ResolveCooldownState should be exported")
+local resolveState = assert(resolvers.ResolveCooldownState, "ResolveCooldownState should be exported")
+local function resolveUntrusted(context)
+    return resolveState(context)
+end
+local function resolve(context)
+    context.trustIsOnGCD = true
+    return resolveState(context)
+end
 
 local function storeResolvedRuntimeState(icon, resolvedState)
     icon._cdmRuntimeState = {
@@ -513,10 +529,8 @@ local function storeResolvedRuntimeState(icon, resolvedState)
     }
 end
 
--- isOnGCD is now read directly off cdInfo (NeverSecret) by the resolver, so a
--- spell's GCD state comes from the cdInfo QuerySpellCooldown returns rather than
--- a primed trusted-GCD snapshot. The mocked source for the GCD spell below
--- already reports isOnGCD=true, so this is a no-op kept only to document intent.
+-- These resolver calls model the SPELL_UPDATE_COOLDOWN event path, which is the
+-- only path allowed to trust SpellCooldownInfo.isOnGCD.
 local function setGCDState() end
 
 local function cooldownEntry(spellID)
@@ -723,6 +737,19 @@ assert(state.gcdOnly == true, "GCD-only state should publish gcdOnly")
 assert(state.isGCDOnly == true, "GCD-only state should publish isGCDOnly")
 assert(state.isRealCooldownMode == false, "GCD-only state should not publish real cooldown mode")
 
+state = resolveUntrusted({
+    owner = { _resolvedCooldownMode = "gcd-only" },
+    entry = cooldownEntry(70001),
+    runtimeSpellID = 70001,
+    containerKey = "essential",
+    useBuffSwipe = false,
+    showGCDSwipe = true,
+})
+assert(state.mode == "gcd-only",
+    "untrusted refresh must preserve an active trusted GCD-only state")
+assert(state.isOnCooldown == false,
+    "preserved GCD-only state must remain excluded from cooldown-only filtering")
+
 state = resolve({
     entry = cooldownEntry(70002),
     runtimeSpellID = 70002,
@@ -731,10 +758,21 @@ state = resolve({
     showGCDSwipe = true,
 })
 
-assert(state.mode == "cooldown", "a real ignore-GCD duration should outrank isOnGCD")
+assert(state.mode == "cooldown", "a real cooldown with isOnGCD=false should resolve as cooldown")
 assert(state.durObj == cooldownDur, "real cooldown should bind its ignore-GCD DurationObject")
 assert(state.cooldownInfo == nil, "resolved state must not retain SpellCooldownInfo")
 assert(state.start == nil and state.duration == nil, "secret cooldown timing must not enter resolved state")
+state = resolve({
+    entry = cooldownEntry(70003),
+    runtimeSpellID = 70003,
+    containerKey = "essential",
+    useBuffSwipe = false,
+    showGCDSwipe = true,
+})
+assert(state.mode == "gcd-only",
+    "unknown active state on GCD must not become a real cooldown")
+assert(state.isOnCooldown == false,
+    "GCD-only state must not pass show-only-on-cooldown filtering")
 local secretField, wasSecret = resolvers.GetCooldownInfoField({ startTime = secretCooldownStart }, "startTime")
 assert(secretField == nil and wasSecret == true, "secret cooldown fields must be discarded at read time")
 

--- a/tests/unit/cdm_resolvers_cooldown_state_test.lua
+++ b/tests/unit/cdm_resolvers_cooldown_state_test.lua
@@ -737,6 +737,16 @@ assert(state.gcdOnly == true, "GCD-only state should publish gcdOnly")
 assert(state.isGCDOnly == true, "GCD-only state should publish isGCDOnly")
 assert(state.isRealCooldownMode == false, "GCD-only state should not publish real cooldown mode")
 
+state = resolve({
+    entry = cooldownEntry(70001),
+    runtimeSpellID = 70001,
+    containerKey = "essential",
+    useBuffSwipe = false,
+    showGCDSwipe = false,
+})
+assert(state.mode ~= "gcd-only" and state.isOnCooldown == false,
+    "trusted GCD refreshes must honor disabled GCD swipe visibility")
+
 state = resolveUntrusted({
     owner = { _resolvedCooldownMode = "gcd-only" },
     entry = cooldownEntry(70001),

--- a/tests/unit/cdm_resolvers_runtime_events_test.lua
+++ b/tests/unit/cdm_resolvers_runtime_events_test.lua
@@ -94,6 +94,12 @@ event = assert(published[#published], "SPELL_UPDATE_CHARGES should still publish
 assert(event[1] == "CDM:CHARGES_CHANGED" and event[2] == 55092,
     "SPELL_UPDATE_CHARGES compatibility should be preserved")
 
+runtimeFrame.OnEvent(runtimeFrame, "SPELL_UPDATE_COOLDOWN", 90010, 90011, 12, 133, 90012)
+event = assert(published[#published], "SPELL_UPDATE_COOLDOWN should publish a cooldown change")
+assert(event[1] == "CDM:COOLDOWN_CHANGED" and event[2] == 90010 and event[3] == 90011
+        and event[4] == "refresh" and event[5] == 12 and event[6] == 133 and event[7] == 90012,
+    "SPELL_UPDATE_COOLDOWN should preserve category and start-recovery payloads")
+
 ---------------------------------------------------------------------------
 -- UNIT_SPELLCAST_SUCCEEDED (Wave 2b task2b-A)
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes CDM cooldown visibility during cast transitions and secret cooldown completion.

- Preserve trusted SPELL_UPDATE_COOLDOWN payloads and GCD classification.
- Refresh all cooldown-only icons when GCD state can change.
- Keep GCD-only states out of show-only-on-cooldown filters.
- Cover resolver, runtime refresh, renderer, custom-bar, and completion paths with regressions.

Validation: bash tools/test.sh (ALL GATES PASSED).