### PR TITLE
release: v5.2.1-beta6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.1-beta6 - 2026-08-20
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Action-bar ping, combat tooltip, Objective Tracker, roster, and Raid Buffs
+refresh fixes.
+
+### Fixed
+
+- **Action-bar pings preserve sender formatting.** Ping messages now render the
+  sender and role text through Blizzard's expected chat format.
+- **Roster-driven group-frame state stays current.** Roster changes refresh
+  missing Raid Buffs, click-cast state, targeted spells, and aura displays
+  without stale indicators or unnecessary combat allocations.
+- **Combat tooltip content remains safely scoped.** Custom tooltip content is
+  kept out of combat while visual skinning continues to refresh.
+- **Objective Tracker and UI-hider updates recover after roster changes.**
+  Widget pools and hidden-frame state now catch up when the relevant UI changes.
+
 ## v5.2.1-beta5 - 2026-08-19
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.1-beta5
+## Version: 5.2.1-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
## Release

Bump the 11 shipped TOCs to `5.2.1-beta6` and add the release changelog section.

## Verification

- `bash tools/test.sh` — all 9 gates passed
- Release-note extraction for `v5.2.1-beta6` passed
- TOC measurement: 11 shipped TOCs