### PR TITLE
fix: honor tracked buff bar color overrides

### DIFF
--- a/QUI_CDM/cdm/cdm_bar_renderer.lua
+++ b/QUI_CDM/cdm/cdm_bar_renderer.lua
@@ -305,9 +305,12 @@ local function GetBarSpellData(bar)
     local resolvedSpellID = overrideSpellID or baseSpellID
     if not resolvedSpellID and not entry.name then return nil end
     return {
+        id = entry.id,
         spellID = resolvedSpellID,
         baseSpellID = baseSpellID or resolvedSpellID,
         overrideSpellID = overrideSpellID,
+        linkedSpellID = entry.linkedSpellID,
+        linkedSpellIDs = entry.linkedSpellIDs,
         name = entry.name,
         cooldownID = entry.cooldownID,
     }
@@ -694,56 +697,42 @@ local function WriteDurationTextFromDurationObject(bar, durObj)
     return true
 end
 
-local function GetTrackedBarOverrideColor(settings, spellData)
-    local overrides = settings and settings.colorOverrides
-    if type(overrides) ~= "table" or type(spellData) ~= "table" then
-        return nil
-    end
-
-    local color = spellData.spellID and overrides[spellData.spellID]
-    if type(color) == "table" then
-        return color
-    end
-
-    color = spellData.overrideSpellID and overrides[spellData.overrideSpellID]
-    if type(color) == "table" then
-        return color
-    end
-
-    color = spellData.baseSpellID and overrides[spellData.baseSpellID]
-    if type(color) == "table" then
-        return color
-    end
-
-    color = spellData.cooldownID and overrides[spellData.cooldownID]
-    if type(color) == "table" then
-        return color
-    end
-
-    return nil
-end
-
-local function GetTrackedBarOverrideColorForEntry(settings, entry)
+local function GetTrackedBarOverrideColorFromEntry(settings, entry)
     local overrides = settings and settings.colorOverrides
     if type(overrides) ~= "table" or type(entry) ~= "table" then
         return nil
     end
 
-    local spellID = entry.overrideSpellID or entry.spellID or entry.id
-    local color = spellID and overrides[spellID]
-    if type(color) == "table" then return color end
+    local function lookup(id)
+        if type(id) ~= "number" or (issecretvalue and issecretvalue(id)) then
+            return nil
+        end
+        local color = overrides[id]
+        return type(color) == "table" and color or nil
+    end
 
-    color = entry.overrideSpellID and overrides[entry.overrideSpellID]
-    if type(color) == "table" then return color end
+    local color = lookup(entry.id) or lookup(entry.spellID)
+        or lookup(entry.overrideSpellID) or lookup(entry.baseSpellID)
+        or lookup(entry.linkedSpellID) or lookup(entry.cooldownID)
+    if color then return color end
 
-    local baseSpellID = entry.spellID or entry.id
-    color = baseSpellID and overrides[baseSpellID]
-    if type(color) == "table" then return color end
-
-    color = entry.cooldownID and overrides[entry.cooldownID]
-    if type(color) == "table" then return color end
+    local linked = entry.linkedSpellIDs
+    if type(linked) == "table" and not (issecretvalue and issecretvalue(linked)) then
+        for i = 1, #linked do
+            color = lookup(linked[i])
+            if color then return color end
+        end
+    end
 
     return nil
+end
+
+local function GetTrackedBarOverrideColor(settings, spellData)
+    return GetTrackedBarOverrideColorFromEntry(settings, spellData)
+end
+
+local function GetTrackedBarOverrideColorForEntry(settings, entry)
+    return GetTrackedBarOverrideColorFromEntry(settings, entry)
 end
 
 local function ColorStateChanged(state, color)

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -245,31 +245,6 @@ local function _EnsureBarWidgets(live)
     return w
 end
 
-local function _GetBarOverrideColor(settings, entry)
-    local overrides = settings and settings.colorOverrides
-    if type(overrides) ~= "table" or type(entry) ~= "table" then return nil end
-
-    local function lookup(id)
-        if type(id) ~= "number" or _issecretvalue(id) then return nil end
-        local color = overrides[id]
-        return type(color) == "table" and color or nil
-    end
-
-    local color = lookup(entry.spellID) or lookup(entry.overrideSpellID)
-        or lookup(entry.baseSpellID) or lookup(entry.id)
-        or lookup(entry.linkedSpellID) or lookup(entry.cooldownID)
-    if color then return color end
-
-    local linked = entry.linkedSpellIDs
-    if type(linked) == "table" and not _issecretvalue(linked) then
-        for i = 1, #linked do
-            color = lookup(linked[i])
-            if color then return color end
-        end
-    end
-    return nil
-end
-
 local function _BarReskinWork(live, settings)
     local bar = live.Bar
     if not bar then return end
@@ -304,10 +279,7 @@ local function _BarReskinWork(live, settings)
     if bar.SetStatusBarColor then
         local opacity = settings.barOpacity or 1.0
         local r, g, b
-        local override = _GetBarOverrideColor(settings, w and w.entry)
-        if override then
-            r, g, b = override[1] or 0.2, override[2] or 0.8, override[3] or 0.6
-        elseif settings.useClassColor and UnitClass and RAID_CLASS_COLORS then
+        if settings.useClassColor and UnitClass and RAID_CLASS_COLORS then
             local _, class = UnitClass("player")
             -- @secret-policy: collapse-only — UnitClass can return SECRET on 12.1 PTR7
             if _issecretvalue(class) then class = nil end

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -245,10 +245,36 @@ local function _EnsureBarWidgets(live)
     return w
 end
 
+local function _GetBarOverrideColor(settings, entry)
+    local overrides = settings and settings.colorOverrides
+    if type(overrides) ~= "table" or type(entry) ~= "table" then return nil end
+
+    local function lookup(id)
+        if type(id) ~= "number" or _issecretvalue(id) then return nil end
+        local color = overrides[id]
+        return type(color) == "table" and color or nil
+    end
+
+    local color = lookup(entry.spellID) or lookup(entry.overrideSpellID)
+        or lookup(entry.baseSpellID) or lookup(entry.id)
+        or lookup(entry.linkedSpellID) or lookup(entry.cooldownID)
+    if color then return color end
+
+    local linked = entry.linkedSpellIDs
+    if type(linked) == "table" and not _issecretvalue(linked) then
+        for i = 1, #linked do
+            color = lookup(linked[i])
+            if color then return color end
+        end
+    end
+    return nil
+end
+
 local function _BarReskinWork(live, settings)
     local bar = live.Bar
     if not bar then return end
     settings = settings or {}
+    local w = _EnsureBarWidgets(live)
     local showIcon = not settings.hideIcon
     local iconSize = settings.barHeight or 25
     if live.Icon and live.Icon.Hide then live.Icon:Hide() end
@@ -278,7 +304,10 @@ local function _BarReskinWork(live, settings)
     if bar.SetStatusBarColor then
         local opacity = settings.barOpacity or 1.0
         local r, g, b
-        if settings.useClassColor and UnitClass and RAID_CLASS_COLORS then
+        local override = _GetBarOverrideColor(settings, w and w.entry)
+        if override then
+            r, g, b = override[1] or 0.2, override[2] or 0.8, override[3] or 0.6
+        elseif settings.useClassColor and UnitClass and RAID_CLASS_COLORS then
             local _, class = UnitClass("player")
             -- @secret-policy: collapse-only — UnitClass can return SECRET on 12.1 PTR7
             if _issecretvalue(class) then class = nil end
@@ -292,7 +321,6 @@ local function _BarReskinWork(live, settings)
         bar:SetStatusBarColor(r, g, b, opacity)
     end
 
-    local w = _EnsureBarWidgets(live)
     if w then
         if w.bg then
             local bg = settings.bgColor or { 0, 0, 0, 1 }

--- a/tests/unit/cdm_bars_color_override_runtime_test.lua
+++ b/tests/unit/cdm_bars_color_override_runtime_test.lua
@@ -1,0 +1,98 @@
+local function noop() end
+local methods = {
+    ClearAllPoints = true,
+    Hide = true,
+    SetAlpha = true,
+    SetFrameLevel = true,
+    SetFrameStrata = true,
+    SetHeight = true,
+    SetLooping = true,
+    SetOrientation = true,
+    SetPoint = true,
+    SetReverseFill = true,
+    SetScript = true,
+    SetSize = true,
+    SetStatusBarTexture = true,
+    SetTexCoord = true,
+    SetTexture = true,
+    SetValue = true,
+    Show = true,
+}
+
+local function object(fields)
+    return setmetatable(fields or {}, {
+        __index = function(_, name)
+            if name == "GetFrameLevel" then
+                return function() return 1 end
+            end
+            return methods[name] and noop or nil
+        end,
+    })
+end
+
+C_Timer = { After = noop }
+function InCombatLockdown() return false end
+function UnitClass() return "Death Knight", "DEATHKNIGHT" end
+RAID_CLASS_COLORS = {
+    DEATHKNIGHT = { r = 0.2, g = 0.4, b = 0.8 },
+}
+
+function CreateFrame()
+    local frame = object()
+    function frame:CreateAnimationGroup()
+        local group = object()
+        function group:CreateAnimation() return object({ SetDuration = noop }) end
+        return group
+    end
+    return frame
+end
+
+local ns = {
+    Helpers = {
+        GetGeneralFont = function() return "Fonts\\FRIZQT__.TTF" end,
+        GetGeneralFontOutline = function() return "" end,
+        GetSkinBorderColor = function() return 0, 0, 0, 1 end,
+    },
+    LSM = { Fetch = function() return nil end },
+}
+
+assert(loadfile("QUI_CDM/cdm/cdm_bar_renderer.lua"))("QUI", ns)
+
+local applied
+local statusBar = object({
+    SetStatusBarColor = function(_, r, g, b, a) applied = { r, g, b, a } end,
+})
+local bar = object({
+    _active = true,
+    StatusBar = statusBar,
+    _spellEntry = {
+        id = 101,
+        spellID = 202,
+        baseSpellID = 202,
+        linkedSpellID = 303,
+        linkedSpellIDs = { 404 },
+        cooldownID = 505,
+    },
+})
+local settings = {
+    barColor = { 1, 1, 1, 1 },
+    barOpacity = 0.75,
+    borderSize = 0,
+    colorOverrides = {
+        [101] = { 0.1, 0.8, 0.2, 1 },
+    },
+    useClassColor = true,
+}
+
+ns.CDMBars.ConfigureBar(bar, settings, 215)
+assert(applied[1] == 0.1 and applied[2] == 0.8 and applied[3] == 0.2
+    and applied[4] == 0.75,
+    "ConfigureBar must prefer the configured entry id over class color")
+
+settings.colorOverrides = { [303] = { 0.9, 0.2, 0.7, 1 } }
+ns.CDMBars.ConfigureBar(bar, settings, 215)
+assert(applied[1] == 0.9 and applied[2] == 0.2 and applied[3] == 0.7
+    and applied[4] == 0.75,
+    "ConfigureBar must honor a linked runtime spell override")
+
+print("OK: cdm_bars_color_override_runtime_test")

--- a/tests/unit/cdm_reanchor_realenv_test.lua
+++ b/tests/unit/cdm_reanchor_realenv_test.lua
@@ -733,6 +733,28 @@ do
     print("OK: Task 6 — _BarReskinWork zero raw SetFont on native bar.Name/bar.Duration; reskin intact")
 end
 
+do
+    local appliedColor
+    local nativeBar = {
+        SetStatusBarColor = function(_, r, g, b, a) appliedColor = { r, g, b, a } end,
+    }
+    local nativeLive = { Bar = nativeBar }
+    local entry = { spellID = 12345 }
+
+    RE._BarDecorateWork(nativeLive, { _spellEntry = entry }, {
+        useClassColor = true,
+        barOpacity = 0.75,
+        colorOverrides = { [12345] = { 0.1, 0.8, 0.2, 1 } },
+    })
+
+    assert(appliedColor and appliedColor[1] == 0.1
+        and appliedColor[2] == 0.8 and appliedColor[3] == 0.2
+        and appliedColor[4] == 0.75,
+        "Task 7: native bar must apply its per-entry override before class color")
+
+    print("OK: Task 7 — native tracked-bar per-entry color overrides class color")
+end
+
 -- Task A: G2 (SetHideCountdownNumbers), G3 (duration text colour),
 -- G4 (per-(size,outline) font-object cache; distinct names, no collapse).
 -- Field names verified against the owned-icon path:

--- a/tests/unit/cdm_reanchor_realenv_test.lua
+++ b/tests/unit/cdm_reanchor_realenv_test.lua
@@ -733,28 +733,6 @@ do
     print("OK: Task 6 — _BarReskinWork zero raw SetFont on native bar.Name/bar.Duration; reskin intact")
 end
 
-do
-    local appliedColor
-    local nativeBar = {
-        SetStatusBarColor = function(_, r, g, b, a) appliedColor = { r, g, b, a } end,
-    }
-    local nativeLive = { Bar = nativeBar }
-    local entry = { spellID = 12345 }
-
-    RE._BarDecorateWork(nativeLive, { _spellEntry = entry }, {
-        useClassColor = true,
-        barOpacity = 0.75,
-        colorOverrides = { [12345] = { 0.1, 0.8, 0.2, 1 } },
-    })
-
-    assert(appliedColor and appliedColor[1] == 0.1
-        and appliedColor[2] == 0.8 and appliedColor[3] == 0.2
-        and appliedColor[4] == 0.75,
-        "Task 7: native bar must apply its per-entry override before class color")
-
-    print("OK: Task 7 — native tracked-bar per-entry color overrides class color")
-end
-
 -- Task A: G2 (SetHideCountdownNumbers), G3 (duration text colour),
 -- G4 (per-(size,outline) font-object cache; distinct names, no collapse).
 -- Field names verified against the owned-icon path:


### PR DESCRIPTION
## Summary
- apply per-entry and linked-spell color overrides in the native tracked buff-bar reskin path
- keep class color and container fallback behavior
- add native regression coverage

## Verification
- bash tools/test.sh
- focused native reskin and composer preview tests
- graphify update .