### PR TITLE
fix: preserve beta runtime edge cases

### DIFF
--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -223,8 +223,12 @@ function CDMReanchorBoot.BuildRuntime(env)
         getCurated = env.getCurated,
         getSettings = env.getSettings,
         getAdditional = MakeGetAdditional(env),
-        shouldReplaceNativeAuraPhase = function()
-            return false
+        shouldReplaceNativeAuraPhase = function(frame, entry, containerKey)
+            if isBuffIconFrameKey(containerKey) or entry and (entry.isAura or entry.kind == "aura") then
+                return false
+            end
+            return frame and frame.cooldownUseAuraDisplayTime == true
+                and entry ~= nil and not isAuraPhaseEnabled()
         end,
         buildLayout = env.buildLayout,
         buildBuffLayout = env.buildBuffLayout,

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -58,6 +58,10 @@ function CDMReanchorBoot.BuildRuntime(env)
     local bridge = env.CDMReanchor.New({ sinkAnchor = env.uiParent })
     local wiring = env.CDMReanchorWiring.New({ bridge = bridge, index = env.index })
     local runtime
+    local function frameCanUseAuraForDisplay(frame)
+        local info = bridge:GetFrameCooldownInfo(frame)
+        return info and info.hasAura == true
+    end
     local function swipeSettings()
         return (ns._OwnedSwipe and ns._OwnedSwipe.GetSettings and ns._OwnedSwipe.GetSettings()) or {}
     end
@@ -227,8 +231,8 @@ function CDMReanchorBoot.BuildRuntime(env)
             if isBuffIconFrameKey(containerKey) or entry and (entry.isAura or entry.kind == "aura") then
                 return false
             end
-            return frame and frame.cooldownUseAuraDisplayTime == true
-                and entry ~= nil and not isAuraPhaseEnabled()
+            return entry ~= nil and not isAuraPhaseEnabled()
+                and frameCanUseAuraForDisplay(frame)
         end,
         buildLayout = env.buildLayout,
         buildBuffLayout = env.buildBuffLayout,

--- a/modules/dungeon/keystone.lua
+++ b/modules/dungeon/keystone.lua
@@ -5,6 +5,16 @@ local NUM_BAG_FRAMES = NUM_BAG_FRAMES or 4
 
 local GetSettings = Helpers.CreateDBGetter("general")
 
+local function CloseBags()
+    local bags = ns.Bags
+    local takeover = bags and bags.Takeover
+    if takeover and takeover.IsActive and takeover.IsActive() then
+        takeover.CloseForFrame()
+    else
+        CloseAllBags()
+    end
+end
+
 local function FindKeystoneInBags()
     for bag = 0, NUM_BAG_FRAMES do
         local slots = C_Container.GetContainerNumSlots(bag)
@@ -32,7 +42,7 @@ local function InsertKeystone()
     if C_Cursor.GetCursorItem() then
         C_ChallengeMode.SlotKeystone()
         if settings.closeBagsOnKeystoneInsert then
-            CloseAllBags()
+            CloseBags()
         end
     end
 end

--- a/modules/qol/qol.lua
+++ b/modules/qol/qol.lua
@@ -805,7 +805,7 @@ end
 
 local function OnQuestDetail()
     local settings = GetSettings()
-    if not settings or not settings.autoAcceptQuest then return end
+    if not settings or settings.autoAcceptQuest ~= true then return end
     if ShouldPauseQuest(settings) then return end
 
     AcceptQuest()

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -243,15 +243,19 @@ facade:DrainPendingCombatRefresh()
 
 swipeStub.showCooldownIconAuraPhase = false
 local shouldReplace = capturedRuntimeDeps.shouldReplaceNativeAuraPhase
+local nativeAuraFrame = { cooldownUseAuraDisplayTime = true }
 for _, entryType in ipairs({ "item", "slot", "trinket", "consumable", "macro" }) do
-    assert(shouldReplace({}, { type = entryType }, "essential") == false,
-        entryType .. "-backed native frame stays Blizzard-owned")
+    assert(shouldReplace(nativeAuraFrame, { type = entryType }, "essential") == true,
+        entryType .. "-backed native aura frame replaces when disabled")
 end
-assert(shouldReplace({}, { type = "spell" }, "essential") == false,
-    "ordinary spell native frame stays Blizzard-owned")
+assert(shouldReplace(nativeAuraFrame, { type = "spell" }, "essential") == true,
+    "ordinary spell native aura frame replaces when disabled")
 assert(shouldReplace({}, { type = "item" }, "buff") == false,
     "item-backed BuffIcon entry remains native")
-assert(shouldReplace({}, { type = "spell", kind = "aura" }, "essential") == false,
+assert(shouldReplace(nativeAuraFrame, { type = "spell", kind = "aura" }, "essential") == false,
     "explicit aura entry remains native")
+swipeStub.showCooldownIconAuraPhase = true
+assert(shouldReplace(nativeAuraFrame, { type = "spell" }, "essential") == false,
+    "native aura frame stays native when aura phase is enabled")
 
 print("OK: cdm_reanchor_boot_buildruntime_test")

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -243,13 +243,20 @@ facade:DrainPendingCombatRefresh()
 
 swipeStub.showCooldownIconAuraPhase = false
 local shouldReplace = capturedRuntimeDeps.shouldReplaceNativeAuraPhase
-local nativeAuraFrame = { cooldownUseAuraDisplayTime = true }
+local nativeAuraFrame = {
+    cooldownUseAuraDisplayTime = false,
+    GetCooldownInfo = function() return { hasAura = true } end,
+}
 for _, entryType in ipairs({ "item", "slot", "trinket", "consumable", "macro" }) do
     assert(shouldReplace(nativeAuraFrame, { type = entryType }, "essential") == true,
         entryType .. "-backed native aura frame replaces when disabled")
 end
 assert(shouldReplace(nativeAuraFrame, { type = "spell" }, "essential") == true,
     "ordinary spell native aura frame replaces when disabled")
+assert(shouldReplace({ cooldownUseAuraDisplayTime = true,
+        GetCooldownInfo = function() return { hasAura = false } end },
+        { type = "spell" }, "essential") == false,
+    "native non-aura frame stays native when disabled")
 assert(shouldReplace({}, { type = "item" }, "buff") == false,
     "item-backed BuffIcon entry remains native")
 assert(shouldReplace(nativeAuraFrame, { type = "spell", kind = "aura" }, "essential") == false,

--- a/tests/unit/keystone_auto_insert_test.lua
+++ b/tests/unit/keystone_auto_insert_test.lua
@@ -1,0 +1,49 @@
+local settings = { autoInsertKey = true, closeBagsOnKeystoneInsert = true }
+local closeAllBags = 0
+local takeoverCloses = 0
+local showHook
+
+_G.C_AddOns = { IsAddOnLoaded = function() return true end }
+_G.C_Container = {
+    GetContainerNumSlots = function() return 1 end,
+    GetContainerItemID = function() return 999 end,
+    PickupContainerItem = function() end,
+}
+_G.Enum = { ItemClass = { Reagent = "Reagent" }, ItemReagentSubclass = { Keystone = "Keystone" } }
+_G.C_Item = { GetItemInfo = function() return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, Enum.ItemClass.Reagent, Enum.ItemReagentSubclass.Keystone end }
+_G.C_Cursor = { GetCursorItem = function() return true end }
+_G.C_ChallengeMode = { SlotKeystone = function() end }
+_G.CloseAllBags = function() closeAllBags = closeAllBags + 1 end
+_G.C_Timer = { After = function(_, fn) fn() end }
+_G.CreateFrame = function()
+    return {
+        RegisterEvent = function() end,
+        UnregisterEvent = function() end,
+        SetScript = function(_, _, fn) showHook = fn end,
+    }
+end
+_G.ChallengesKeystoneFrame = {
+    HookScript = function(_, _, fn) showHook = fn end,
+}
+
+local ns = {
+    Helpers = { CreateDBGetter = function() return function() return settings end end },
+    Bags = {
+        Takeover = {
+            IsActive = function() return true end,
+            CloseForFrame = function() takeoverCloses = takeoverCloses + 1 end,
+        },
+    },
+}
+
+assert(loadfile("modules/dungeon/keystone.lua"))("QUI", ns)
+assert(showHook, "keystone frame must receive an OnShow hook")
+showHook()
+assert(takeoverCloses == 1, "QUI bags must close through the active takeover")
+assert(closeAllBags == 0, "active QUI bags must not rely on Blizzard's container frames")
+
+ns.Bags.Takeover.IsActive = function() return false end
+showHook()
+assert(closeAllBags == 1, "Blizzard bags must close when QUI takeover is inactive")
+
+print("keystone_auto_insert_test.lua: ok")

--- a/tests/unit/qol_auto_accept_quest_test.lua
+++ b/tests/unit/qol_auto_accept_quest_test.lua
@@ -1,0 +1,39 @@
+local loadstring = loadstring or load
+
+local function readAll(path)
+    local file = assert(io.open(path, "rb"))
+    local source = file:read("*a")
+    file:close()
+    return source:gsub("\r\n", "\n")
+end
+
+local source = readAll("modules/qol/qol.lua")
+local start = assert(source:find("local function OnQuestDetail()", 1, true))
+local finish = assert(source:find("\nend", start, true))
+local block = source:sub(start, finish + 4)
+_G.QUI_TEST_QUEST_SETTINGS = nil
+_G.QUI_TEST_QUEST_ACCEPTED = 0
+local OnQuestDetail = assert(loadstring(([=[
+local GetSettings = function() return QUI_TEST_QUEST_SETTINGS end
+local ShouldPauseQuest = function() return false end
+local AcceptQuest = function() QUI_TEST_QUEST_ACCEPTED = QUI_TEST_QUEST_ACCEPTED + 1 end
+%s
+return OnQuestDetail
+]=]):format(block), "qol_auto_accept_quest"))()
+
+for _, value in ipairs({ false, "off", 0 }) do
+    QUI_TEST_QUEST_SETTINGS = { autoAcceptQuest = value }
+    OnQuestDetail()
+end
+QUI_TEST_QUEST_SETTINGS = nil
+OnQuestDetail()
+assert(_G.QUI_TEST_QUEST_ACCEPTED == 0, "disabled and legacy off values must not accept quests")
+
+QUI_TEST_QUEST_SETTINGS = { autoAcceptQuest = true }
+OnQuestDetail()
+assert(_G.QUI_TEST_QUEST_ACCEPTED == 1, "true must accept quests")
+
+_G.QUI_TEST_QUEST_SETTINGS = nil
+_G.QUI_TEST_QUEST_ACCEPTED = nil
+
+print("qol_auto_accept_quest_test.lua: ok")


### PR DESCRIPTION
## Summary
- replace aura-capable native reanchored cooldown frames when aura phase display is disabled
- close the active QUI bag takeover after automatic keystone insertion
- require a strict boolean for automatic quest acceptance
- add focused regression tests for all three paths

## Verification
- `bash tools/test.sh` — all 9 gates passed
- mutation checks made each focused regression test fail before restoring the intended code