### PR TITLE
fix(cdm): repair native target debuff cooldown state

### DIFF
--- a/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
@@ -68,21 +68,16 @@ function CDMReanchorAuraPhase:OnNativeCooldownPush(frame, cd)
         and deps.isAuraPhaseEnabled() == false) then
         return
     end
-    local ok, show = ns.SafeCall("bulkhead", function()
-        return frame and frame.cooldownUseAuraDisplayTime
-    end)
-    if not ok or (_issecretvalue and _issecretvalue(show)) or show ~= true then return end
+    local show = frame and frame.cooldownUseAuraDisplayTime
+    if (_issecretvalue and _issecretvalue(show)) or show ~= true then return end
     ns.SafeCall("bulkhead", deps.requestAuraPhaseRefresh, frame, self._keyByFrame[frame], true)
 end
 
 function CDMReanchorAuraPhase:IsStaleLinkedAura(frame)
-    local ok, linkedSpellID, auraInstanceID, wasSetFromAura = ns.SafeCall("bulkhead", function()
-        local info = frame and frame.cooldownInfo
-        return info and info.linkedSpellID,
-            frame and frame.auraInstanceID,
-            frame and frame.wasSetFromAura
-    end)
-    if not ok then return false end
+    local info = frame and frame.cooldownInfo
+    local linkedSpellID = info and info.linkedSpellID
+    local auraInstanceID = frame and frame.auraInstanceID
+    local wasSetFromAura = frame and frame.wasSetFromAura
     if (_issecretvalue and _issecretvalue(linkedSpellID))
         or (_issecretvalue and _issecretvalue(auraInstanceID))
         or (_issecretvalue and _issecretvalue(wasSetFromAura)) then

--- a/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
@@ -19,6 +19,11 @@ function CDMReanchorAuraPhase.New(deps)
         _drawSwipeReentry = setmetatable({}, { __mode = "k" }),
         _nativeAuraDisplayState = setmetatable({}, { __mode = "k" }),
         _keyByFrame = setmetatable({}, { __mode = "k" }),
+        _entryByFrame = setmetatable({}, { __mode = "k" }),
+        _nativeClearHooked = setmetatable({}, { __mode = "k" }),
+        _nativeDesaturatedHooked = setmetatable({}, { __mode = "k" }),
+        _nativeDesaturationHooked = setmetatable({}, { __mode = "k" }),
+        _nativeRepairReentry = setmetatable({}, { __mode = "k" }),
     }, InstanceMT)
 end
 
@@ -57,6 +62,57 @@ function CDMReanchorAuraPhase:OnNativeAuraDisplayTime(frame, show, cd)
     self:ObserveNativeAuraDisplayTime(frame, cd, show)
 end
 
+function CDMReanchorAuraPhase:OnNativeCooldownPush(frame, cd)
+    local deps = self._deps
+    if not (deps.requestAuraPhaseRefresh and deps.isAuraPhaseEnabled
+        and deps.isAuraPhaseEnabled() == false) then
+        return
+    end
+    local ok, show = ns.SafeCall("bulkhead", function()
+        return frame and frame.cooldownUseAuraDisplayTime
+    end)
+    if not ok or (_issecretvalue and _issecretvalue(show)) or show ~= true then return end
+    ns.SafeCall("bulkhead", deps.requestAuraPhaseRefresh, frame, self._keyByFrame[frame], true)
+end
+
+function CDMReanchorAuraPhase:IsStaleLinkedAura(frame)
+    local ok, linkedSpellID, auraInstanceID, wasSetFromAura = ns.SafeCall("bulkhead", function()
+        local info = frame and frame.cooldownInfo
+        return info and info.linkedSpellID,
+            frame and frame.auraInstanceID,
+            frame and frame.wasSetFromAura
+    end)
+    if not ok then return false end
+    if (_issecretvalue and _issecretvalue(linkedSpellID))
+        or (_issecretvalue and _issecretvalue(auraInstanceID))
+        or (_issecretvalue and _issecretvalue(wasSetFromAura)) then
+        return false
+    end
+    return linkedSpellID ~= nil and auraInstanceID == nil and wasSetFromAura ~= true
+end
+
+function CDMReanchorAuraPhase:IsNativeCooldownRepairFrame(frame, containerKey)
+    local deps = self._deps
+    if not deps.isNativeCooldownRepairFrame then return false end
+    local ok, eligible = ns.SafeCall("bulkhead", deps.isNativeCooldownRepairFrame,
+        frame, containerKey, self._entryByFrame[frame])
+    return ok and eligible == true
+end
+
+function CDMReanchorAuraPhase:OnNativeRepairDriver(frame, cd, reason)
+    if not cd or self._nativeRepairReentry[cd] then return end
+    local deps = self._deps
+    if not deps.repairStaleLinkedAura
+        or not self:IsNativeCooldownRepairFrame(frame, self._keyByFrame[frame])
+        or not self:IsStaleLinkedAura(frame) then
+        return
+    end
+    self._nativeRepairReentry[cd] = true
+    ns.SafeCall("bulkhead", deps.repairStaleLinkedAura, frame, cd,
+        self._entryByFrame[frame], reason)
+    self._nativeRepairReentry[cd] = nil
+end
+
 function CDMReanchorAuraPhase:ObserveNativeAuraDisplayTime(frame, cd, show)
     if not cd then return end
     local state = show
@@ -79,9 +135,10 @@ function CDMReanchorAuraPhase:ObserveNativeAuraDisplayTime(frame, cd, show)
     end
 end
 
-function CDMReanchorAuraPhase:Hook(frame, containerKey)
+function CDMReanchorAuraPhase:Hook(frame, containerKey, entry)
     if not frame then return end
     if containerKey ~= nil then self._keyByFrame[frame] = containerKey end
+    if entry ~= nil then self._entryByFrame[frame] = entry end
     local hooksec = self._deps.hooksecurefunc or hooksecurefunc
     local securecall = self._deps.securecall or function(fn, ...) return fn(...) end
     local this = self
@@ -98,6 +155,61 @@ function CDMReanchorAuraPhase:Hook(frame, containerKey)
             end
             hooksec(cd, "SetUseAuraDisplayTime", function(_, show)
                 securecall(auraDisplayWork, show)
+            end)
+        end
+        self._nativeCooldownPushHooked = self._nativeCooldownPushHooked
+            or setmetatable({}, { __mode = "k" })
+        local function cooldownPushWork()
+            this:OnNativeCooldownPush(frame, cd)
+        end
+        if type(cd.SetCooldown) == "function" and not self._nativeCooldownPushHooked[cd] then
+            self._nativeCooldownPushHooked[cd] = true
+            hooksec(cd, "SetCooldown", function()
+                securecall(cooldownPushWork)
+            end)
+        end
+        if type(cd.SetCooldownFromDurationObject) == "function"
+            and not self._nativeCooldownDurationPushHooked then
+            self._nativeCooldownDurationPushHooked = setmetatable({}, { __mode = "k" })
+        end
+        if type(cd.SetCooldownFromDurationObject) == "function"
+            and not self._nativeCooldownDurationPushHooked[cd] then
+            self._nativeCooldownDurationPushHooked[cd] = true
+            hooksec(cd, "SetCooldownFromDurationObject", function()
+                securecall(cooldownPushWork)
+            end)
+        end
+    end
+    if cd and self._deps.repairStaleLinkedAura
+        and self:IsNativeCooldownRepairFrame(frame, containerKey) then
+        if type(cd.Clear) == "function" and not self._nativeClearHooked[cd] then
+            self._nativeClearHooked[cd] = true
+            hooksec(cd, "Clear", function()
+                securecall(function()
+                    this:OnNativeRepairDriver(frame, cd, "clear")
+                end)
+            end)
+        end
+        local texture = frame.Icon
+        if texture and type(texture.SetDesaturated) ~= "function" then
+            texture = texture.Icon
+        end
+        if texture and type(texture.SetDesaturated) == "function"
+            and not self._nativeDesaturatedHooked[frame] then
+            self._nativeDesaturatedHooked[frame] = true
+            hooksec(texture, "SetDesaturated", function()
+                securecall(function()
+                    this:OnNativeRepairDriver(frame, cd, "desaturated")
+                end)
+            end)
+        end
+        if texture and type(texture.SetDesaturation) == "function"
+            and not self._nativeDesaturationHooked[frame] then
+            self._nativeDesaturationHooked[frame] = true
+            hooksec(texture, "SetDesaturation", function()
+                securecall(function()
+                    this:OnNativeRepairDriver(frame, cd, "desaturation")
+                end)
             end)
         end
     end

--- a/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_auraphase.lua
@@ -184,10 +184,11 @@ function CDMReanchorAuraPhase:Hook(frame, containerKey, entry)
         and self:IsNativeCooldownRepairFrame(frame, containerKey) then
         if type(cd.Clear) == "function" and not self._nativeClearHooked[cd] then
             self._nativeClearHooked[cd] = true
+            local function clearWork()
+                this:OnNativeRepairDriver(frame, cd, "clear")
+            end
             hooksec(cd, "Clear", function()
-                securecall(function()
-                    this:OnNativeRepairDriver(frame, cd, "clear")
-                end)
+                securecall(clearWork)
             end)
         end
         local texture = frame.Icon
@@ -197,19 +198,21 @@ function CDMReanchorAuraPhase:Hook(frame, containerKey, entry)
         if texture and type(texture.SetDesaturated) == "function"
             and not self._nativeDesaturatedHooked[frame] then
             self._nativeDesaturatedHooked[frame] = true
+            local function desaturatedWork()
+                this:OnNativeRepairDriver(frame, cd, "desaturated")
+            end
             hooksec(texture, "SetDesaturated", function()
-                securecall(function()
-                    this:OnNativeRepairDriver(frame, cd, "desaturated")
-                end)
+                securecall(desaturatedWork)
             end)
         end
         if texture and type(texture.SetDesaturation) == "function"
             and not self._nativeDesaturationHooked[frame] then
             self._nativeDesaturationHooked[frame] = true
+            local function desaturationWork()
+                this:OnNativeRepairDriver(frame, cd, "desaturation")
+            end
             hooksec(texture, "SetDesaturation", function()
-                securecall(function()
-                    this:OnNativeRepairDriver(frame, cd, "desaturation")
-                end)
+                securecall(desaturationWork)
             end)
         end
     end

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -185,9 +185,59 @@ function CDMReanchorBoot.BuildRuntime(env)
             if not hasCharges then cd:SetDrawSwipe(true) end
         end
     end
+    local function cleanSpellID(spellID)
+        if _issecretvalue(spellID) or type(spellID) ~= "number" or spellID <= 0 then
+            return nil
+        end
+        return spellID
+    end
+    local function isNativeCooldownRepairFrame(frame, containerKey, entry)
+        if containerKey ~= "essential" and containerKey ~= "utility" then return false end
+        if entry and (entry.isAura or entry.kind == "aura") then return false end
+        if frame and (frame.viewerFrame == _G.BuffIconCooldownViewer
+            or frame.viewerFrame == _G.BuffBarCooldownViewer) then
+            return false
+        end
+        return true
+    end
+    local function repairStaleLinkedAura(frame, cd, entry)
+        local Sources = ns.CDMSources
+        if not (frame and cd and Sources and Sources.QuerySpellCooldown
+            and Sources.QuerySpellCooldownDuration) then
+            return
+        end
+        local spellID = cleanSpellID(entry and (entry.overrideSpellID
+            or entry.spellID or entry.id))
+        if not spellID then return end
+        local effectiveID = spellID
+        if Sources.QueryOverrideSpell then
+            effectiveID = cleanSpellID(Sources.QueryOverrideSpell(spellID)) or spellID
+        end
+        local cooldown = Sources.QuerySpellCooldown(effectiveID)
+            or (effectiveID ~= spellID and Sources.QuerySpellCooldown(spellID))
+        if not cooldown then return end
+        local active, onGCD = cooldown.isActive, cooldown.isOnGCD
+        if _issecretvalue(active) or _issecretvalue(onGCD)
+            or active ~= true or onGCD ~= false then
+            return
+        end
+        local duration = Sources.QuerySpellCooldownDuration(effectiveID, true)
+        if not duration and effectiveID ~= spellID then
+            duration = Sources.QuerySpellCooldownDuration(spellID, true)
+        end
+        if not duration then return end
+        if cd.SetUseAuraDisplayTime then cd:SetUseAuraDisplayTime(false) end
+        if ns.CDMRenderers and ns.CDMRenderers.ApplyDurationObjectCooldown then
+            ns.CDMRenderers.ApplyDurationObjectCooldown(cd, duration, true, false)
+        elseif cd.SetCooldownFromDurationObject then
+            cd:SetCooldownFromDurationObject(duration, true)
+        end
+    end
     local auraPhase = ns.CDMReanchorAuraPhase and ns.CDMReanchorAuraPhase.New({
         securecall = securecallfunction,
         isAuraPhaseEnabled = isAuraPhaseEnabled,
+        isNativeCooldownRepairFrame = isNativeCooldownRepairFrame,
+        repairStaleLinkedAura = repairStaleLinkedAura,
         requestAuraPhaseRefresh = function(_, containerKey)
             if env.canMutate and not env.canMutate() then
                 if runtime and runtime.QueuePendingCombatRefresh then

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -221,7 +221,11 @@ function CDMReanchorBoot.BuildRuntime(env)
             effectiveID = cleanSpellID(Sources.QueryOverrideSpell(spellID)) or spellID
         end
         local cooldown = Sources.QuerySpellCooldown(effectiveID)
-            or (effectiveID ~= spellID and Sources.QuerySpellCooldown(spellID))
+        if _issecretvalue(cooldown) then return end
+        if not cooldown and effectiveID ~= spellID then
+            cooldown = Sources.QuerySpellCooldown(spellID)
+            if _issecretvalue(cooldown) then return end
+        end
         if not cooldown then return end
         local active, onGCD = cooldown.isActive, cooldown.isOnGCD
         if _issecretvalue(active) or _issecretvalue(onGCD)

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -193,9 +193,16 @@ function CDMReanchorBoot.BuildRuntime(env)
     end
     local function isNativeCooldownRepairFrame(frame, containerKey, entry)
         if containerKey ~= "essential" and containerKey ~= "utility" then return false end
+        if not runtime or not runtime.IsFrameClaimedByAnyContainer
+            or not runtime:IsFrameClaimedByAnyContainer(frame)
+            or not runtime.GetEntryForFrame
+            or runtime:GetEntryForFrame(frame) ~= entry then
+            return false
+        end
         if entry and (entry.isAura or entry.kind == "aura") then return false end
-        if frame and (frame.viewerFrame == _G.BuffIconCooldownViewer
-            or frame.viewerFrame == _G.BuffBarCooldownViewer) then
+        if frame and ((_G.BuffIconCooldownViewer
+                and frame.viewerFrame == _G.BuffIconCooldownViewer)
+            or (_G.BuffBarCooldownViewer and frame.viewerFrame == _G.BuffBarCooldownViewer)) then
             return false
         end
         return true

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -218,7 +218,7 @@ function CDMReanchorBoot.BuildRuntime(env)
         if not cooldown then return end
         local active, onGCD = cooldown.isActive, cooldown.isOnGCD
         if _issecretvalue(active) or _issecretvalue(onGCD)
-            or active ~= true or onGCD ~= false then
+            or active ~= true or onGCD == true then
             return
         end
         local duration = Sources.QuerySpellCooldownDuration(effectiveID, true)

--- a/tests/unit/cdm_reanchor_auraphase_test.lua
+++ b/tests/unit/cdm_reanchor_auraphase_test.lua
@@ -106,6 +106,106 @@ do
     local inst = M.New({
         securecall = function(fn, ...) return fn(...) end,
         hooksecurefunc = function(_, method, fn) hooks[method] = fn end,
+        isAuraPhaseEnabled = function() return false end,
+        requestAuraPhaseRefresh = function(_, key, show)
+            requested[#requested + 1] = { key = key, show = show }
+        end,
+    })
+    local cd = {
+        SetCooldown = function() end,
+        SetCooldownFromDurationObject = function() end,
+        SetUseAuraDisplayTime = function() end,
+    }
+    local frame = {
+        cooldownUseAuraDisplayTime = true,
+        GetCooldownFrame = function() return cd end,
+    }
+    inst:Hook(frame, "essential")
+    hooks.SetCooldown(cd)
+    hooks.SetCooldownFromDurationObject(cd)
+    assert(#requested == 2 and requested[1].key == "essential"
+        and requested[1].show == true,
+        "disabled aura phase rechecks native cooldown pushes")
+end
+
+do
+    local hooks, textureHooks = {}, {}
+    local repairs = {}
+    local inst
+    local texture = {
+        SetDesaturated = function() end,
+        SetDesaturation = function() end,
+    }
+    local cd = {
+        Clear = function() end,
+        SetUseAuraDisplayTime = function() end,
+        SetCooldownFromDurationObject = function() end,
+    }
+    local frame = {
+        cooldownInfo = { linkedSpellID = 9001 },
+        auraInstanceID = nil,
+        wasSetFromAura = false,
+        Icon = texture,
+        GetCooldownFrame = function() return cd end,
+    }
+    inst = M.New({
+        securecall = function(fn, ...) return fn(...) end,
+        hooksecurefunc = function(obj, method, fn)
+            if obj == texture then textureHooks[method] = fn else hooks[method] = fn end
+        end,
+        isNativeCooldownRepairFrame = function(_, key) return key == "essential" end,
+        repairStaleLinkedAura = function(f, cdw, entry, reason)
+            repairs[#repairs + 1] = { frame = f, cd = cdw, entry = entry, reason = reason }
+            inst:OnNativeRepairDriver(f, cdw, reason)
+        end,
+    })
+    local entry = { spellID = 9001 }
+    inst:Hook(frame, "essential", entry)
+    assert(hooks.Clear and textureHooks.SetDesaturated and textureHooks.SetDesaturation,
+        "stale-link repair hooks native Clear and both desaturation drivers")
+    hooks.Clear(cd)
+    assert(#repairs == 1 and repairs[1].entry == entry and repairs[1].reason == "clear",
+        "stale-link repair runs once and is re-entry guarded")
+    textureHooks.SetDesaturated(texture)
+    textureHooks.SetDesaturation(texture)
+    assert(#repairs == 3, "desaturation drivers recheck stale linked state")
+    frame.auraInstanceID = 12
+    hooks.Clear(cd)
+    assert(#repairs == 3, "active aura instance blocks native cooldown repair")
+    frame.auraInstanceID = nil
+    frame.wasSetFromAura = true
+    textureHooks.SetDesaturated(texture)
+    assert(#repairs == 3, "native aura ownership blocks native cooldown repair")
+end
+
+do
+    local repairs = 0
+    local inst = M.New({
+        isNativeCooldownRepairFrame = function(_, key) return key == "essential" end,
+        repairStaleLinkedAura = function() repairs = repairs + 1 end,
+    })
+    local cd = {}
+    local frame = {
+        cooldownInfo = { linkedSpellID = 9002 },
+        auraInstanceID = nil,
+        wasSetFromAura = false,
+    }
+    inst:Hook(frame, "buff", { spellID = 9002 })
+    assert(inst:IsNativeCooldownRepairFrame(frame, "buff") == false,
+        "buff frames are excluded from stale-link repair")
+    inst:OnNativeRepairDriver(frame, cd, "clear")
+    assert(repairs == 0, "excluded frames never invoke stale-link repair")
+    frame.cooldownInfo.linkedSpellID = nil
+    inst:OnNativeRepairDriver(frame, cd, "clear")
+    assert(repairs == 0, "frames without a linked spell are ignored")
+end
+
+do
+    local hooks = {}
+    local requested = {}
+    local inst = M.New({
+        securecall = function(fn, ...) return fn(...) end,
+        hooksecurefunc = function(_, method, fn) hooks[method] = fn end,
         requestAuraPhaseRefresh = function(_, _, show) requested[#requested + 1] = show end,
     })
     local cd = { SetUseAuraDisplayTime = function() end, SetDrawEdge = function() end }

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -202,6 +202,12 @@ assert(type(capturedAuraDeps.isNativeCooldownRepairFrame) == "function",
     "auraPhase receives the native cooldown repair eligibility gate")
 assert(type(capturedAuraDeps.repairStaleLinkedAura) == "function",
     "auraPhase receives the stale linked-aura repair callback")
+assert(facade.runtime:GetEntryForFrame(fMatch) == curatedEntry,
+    "runtime records the claimed native frame")
+assert(capturedAuraDeps.isNativeCooldownRepairFrame(fMatch, "essential", curatedEntry),
+    "claimed native frames remain eligible for stale-link repair")
+assert(not capturedAuraDeps.isNativeCooldownRepairFrame({}, "essential", curatedEntry),
+    "released or unclaimed native frames are excluded from stale-link repair")
 local repairCalls = {}
 ns.CDMSources = {
     QueryOverrideSpell = function(spellID) return spellID + 1 end,

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -257,6 +257,14 @@ local beforeExplicitGCDRepair = #repairCalls
 capturedAuraDeps.repairStaleLinkedAura(repairFrame, repairCd, repairEntry)
 assert(appliedRepair == nil and #repairCalls == beforeExplicitGCDRepair,
     "explicit GCD cooldowns are excluded from native stale-link repair")
+ns.CDMSources.QuerySpellCooldown = function()
+    return secretGCD
+end
+appliedRepair = nil
+local beforeSecretRepair = #repairCalls
+capturedAuraDeps.repairStaleLinkedAura(repairFrame, repairCd, repairEntry)
+assert(appliedRepair == nil and #repairCalls == beforeSecretRepair,
+    "secret cooldown results are excluded before field access")
 ns.CDMSources = nil
 ns.CDMRenderers = nil
 swipeStub.showCooldownIconAuraPhase = false

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -198,6 +198,53 @@ assert(type(capturedAuraDeps.reassertSwipe) == "function",
     "auraPhase receives reassertSwipe")
 assert(type(capturedAuraDeps.requestAuraPhaseRefresh) == "function",
     "auraPhase receives the safe aura-phase refresh request")
+assert(type(capturedAuraDeps.isNativeCooldownRepairFrame) == "function",
+    "auraPhase receives the native cooldown repair eligibility gate")
+assert(type(capturedAuraDeps.repairStaleLinkedAura) == "function",
+    "auraPhase receives the stale linked-aura repair callback")
+local repairCalls = {}
+ns.CDMSources = {
+    QueryOverrideSpell = function(spellID) return spellID + 1 end,
+    QuerySpellCooldown = function(spellID)
+        repairCalls[#repairCalls + 1] = { "cooldown", spellID }
+        return { isActive = true, isOnGCD = false }
+    end,
+    QuerySpellCooldownDuration = function(spellID, ignoreGCD)
+        repairCalls[#repairCalls + 1] = { "duration", spellID, ignoreGCD }
+        return "duration-object"
+    end,
+}
+local appliedRepair
+ns.CDMRenderers = {
+    ApplyDurationObjectCooldown = function(cd, duration, clearWhenZero, reverse)
+        appliedRepair = { cd = cd, duration = duration,
+            clearWhenZero = clearWhenZero, reverse = reverse }
+    end,
+}
+local repairFrame = { cooldownUseAuraDisplayTime = true }
+local repairCd = { SetUseAuraDisplayTime = function(_, show)
+    repairFrame.cooldownUseAuraDisplayTime = show
+end }
+local repairEntry = { spellID = 700 }
+capturedAuraDeps.repairStaleLinkedAura(repairFrame, repairCd, repairEntry)
+assert(appliedRepair and appliedRepair.cd == repairCd
+    and appliedRepair.duration == "duration-object"
+    and appliedRepair.clearWhenZero == true and appliedRepair.reverse == false,
+    "stale linked-aura repair reuses the duration-object renderer")
+assert(repairCalls[1][1] == "cooldown" and repairCalls[1][2] == 701
+    and repairCalls[2][1] == "duration" and repairCalls[2][2] == 701
+    and repairCalls[2][3] == true,
+    "stale linked-aura repair resolves the effective spell and ignores GCD duration")
+local beforeGCDRepair = #repairCalls
+ns.CDMSources.QuerySpellCooldown = function()
+    return { isActive = true, isOnGCD = true }
+end
+appliedRepair = nil
+capturedAuraDeps.repairStaleLinkedAura(repairFrame, repairCd, repairEntry)
+assert(appliedRepair == nil and #repairCalls == beforeGCDRepair,
+    "GCD cooldowns are excluded from native stale-link repair")
+ns.CDMSources = nil
+ns.CDMRenderers = nil
 swipeStub.showCooldownIconAuraPhase = false
 local nativeAuraFrame = {
     cooldownUseAuraDisplayTime = true,

--- a/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
+++ b/tests/unit/cdm_reanchor_boot_buildruntime_test.lua
@@ -237,12 +237,20 @@ assert(repairCalls[1][1] == "cooldown" and repairCalls[1][2] == 701
     "stale linked-aura repair resolves the effective spell and ignores GCD duration")
 local beforeGCDRepair = #repairCalls
 ns.CDMSources.QuerySpellCooldown = function()
-    return { isActive = true, isOnGCD = true }
+    return { isActive = true, isOnGCD = nil }
 end
 appliedRepair = nil
 capturedAuraDeps.repairStaleLinkedAura(repairFrame, repairCd, repairEntry)
-assert(appliedRepair == nil and #repairCalls == beforeGCDRepair,
-    "GCD cooldowns are excluded from native stale-link repair")
+assert(appliedRepair and #repairCalls == beforeGCDRepair + 1,
+    "unknown GCD state permits active native stale-link repair")
+ns.CDMSources.QuerySpellCooldown = function()
+    return { isActive = true, isOnGCD = true }
+end
+appliedRepair = nil
+local beforeExplicitGCDRepair = #repairCalls
+capturedAuraDeps.repairStaleLinkedAura(repairFrame, repairCd, repairEntry)
+assert(appliedRepair == nil and #repairCalls == beforeExplicitGCDRepair,
+    "explicit GCD cooldowns are excluded from native stale-link repair")
 ns.CDMSources = nil
 ns.CDMRenderers = nil
 swipeStub.showCooldownIconAuraPhase = false


### PR DESCRIPTION
## Summary
- recheck native aura-display cooldown pushes when aura phase is disabled
- repair stale linked native cooldown state for eligible Essential/Utility entries
- add regression coverage for push hooks, stale-link drivers, exclusions, and duration-object reuse

## Verification
- `bash tools/test.sh` — all 9 gates passed

## Live verification
- requires a WoW reload and target-debuff test after merge
