### PR TITLE
fix(cdm): stabilize custom consumable runtime state

### DIFF
--- a/QUI_CDM/cdm/cdm_catalog.lua
+++ b/QUI_CDM/cdm/cdm_catalog.lua
@@ -38,13 +38,18 @@ local ALL_RENDERED_CATEGORIES = { 0, 1, 2, 3, 5, 6, 7, 8 }
 local CONSUMABLE_CATEGORY_META = {
     [4]    = { name = "Combat Potion", icon = "Interface/ICONS/INV_POTION_114" },
     [30]   = { name = "Health Potion", icon = "Interface/ICONS/INV_POTION_54" },
-    [1711] = { name = "Healthstone",   icon = "Interface/ICONS/Warlock_ Healthstone" },
-    [2566] = { name = "Demonic Healthstone", icon = "Interface/ICONS/Warlock_ Bloodstone" },
+    [1711] = { name = "Healthstone",   icon = "Interface/ICONS/Warlock_ Healthstone", tooltipItemIDFallback = 5512 },
+    [2566] = { name = "Demonic Healthstone", icon = "Interface/ICONS/Warlock_ Bloodstone", tooltipItemIDFallback = 224464 },
 }
 local BLIZZARD_CDM_ENTRY_SOURCE = "blizzardCDM"
 
 function CDMCatalog.GetConsumableCategoryMeta(catID)
     return CONSUMABLE_CATEGORY_META[catID]
+end
+
+function CDMCatalog.GetConsumableCategoryItemID(catID)
+    local meta = CONSUMABLE_CATEGORY_META[catID]
+    return meta and meta.tooltipItemIDFallback
 end
 
 function CDMCatalog.IsUsableID(id)

--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -153,13 +153,11 @@ local function GetTrackerSettings(trackerKey)
 
     local db = GetDB()
     if not db then return nil end
-    if db[trackerKey] then
+    if Shared and ((Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(trackerKey))
+        or (Shared.GetBuiltinContainerEntryKind and Shared.GetBuiltinContainerEntryKind(trackerKey))) then
         return db[trackerKey]
     end
-    if db.containers and db.containers[trackerKey] then
-        return db.containers[trackerKey]
-    end
-    return nil
+    return db.containers and db.containers[trackerKey] or nil
 end
 
 local function IsHUDAnchoredToCDM()
@@ -1350,10 +1348,11 @@ end
 function CDMContainers_API:GetContainerSettings(key)
     local db = GetDB()
     if not db then return nil end
-    if db.containers and db.containers[key] then
-        return db.containers[key]
+    if Shared and ((Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(key))
+        or (Shared.GetBuiltinContainerEntryKind and Shared.GetBuiltinContainerEntryKind(key))) then
+        return db[key]
     end
-    return db[key] or nil
+    return db.containers and db.containers[key] or nil
 end
 
 function CDMContainers_API:GetContainersByType(containerType)
@@ -1388,7 +1387,6 @@ function CDMContainers_API:CreateContainer(name, containerType)
 
     db.containers[key] = settings
 
-    db[key] = settings
 
     local frameName = "QUI_CDM_" .. key
     local frame = RegisterContainerFrame(key, CreateContainer(frameName))

--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -1323,13 +1323,13 @@ end
 
 function CDMContainers_API:GetContainers()
     local db = GetDB()
-    local ct = db and db.containers
-    if not ct then return {} end
+    if not db then return {} end
+    local ct = db.containers or {}
 
     local result = {}
     for _, key in ipairs(BUILTIN_KEYS) do
-        if ct[key] then
-            result[#result + 1] = { key = key, settings = ct[key] }
+        if db[key] then
+            result[#result + 1] = { key = key, settings = db[key] }
         end
     end
     local customKeys = {}

--- a/QUI_CDM/cdm/cdm_frame_writes.lua
+++ b/QUI_CDM/cdm/cdm_frame_writes.lua
@@ -7,7 +7,7 @@ ns.CDMRenderers = CDMRenderers
 local issecretvalue = issecretvalue
 
 function CDMRenderers.ApplyDurationObjectCooldown(cd, durObj, clearWhenZero, reverse)
-    if not cd or not durObj or not cd.SetCooldownFromDurationObject then
+    if not cd or type(durObj) == "nil" or not cd.SetCooldownFromDurationObject then
         return false
     end
 
@@ -86,7 +86,7 @@ local STATUS_BAR_INTERPOLATION_IMMEDIATE = 0
 local STATUS_BAR_TIMER_REMAINING = 1
 
 function CDMRenderers.SetStatusBarTimerDuration(statusBar, durObj, direction)
-    if not statusBar or not durObj or not statusBar.SetTimerDuration then
+    if not statusBar or type(durObj) == "nil" or not statusBar.SetTimerDuration then
         return false
     end
     local ok = pcall(

--- a/QUI_CDM/cdm/cdm_icon_factory.lua
+++ b/QUI_CDM/cdm/cdm_icon_factory.lua
@@ -150,7 +150,18 @@ function CDMIconFactory.ShowEntryTooltip(owner, entry, tooltipContext)
         if not sid and ns.CDMSpellData and ns.CDMSpellData.ResolveDisplaySpellID then
             sid = ns.CDMSpellData:ResolveDisplaySpellID(entry)
         end
-        if sid then
+        local consumableItemID
+        if entry.type == "consumable" then
+            consumableItemID = Sources and Sources.QueryLastCategoryCooldownSource
+                and select(2, Sources.QueryLastCategoryCooldownSource(entry.id))
+            consumableItemID = consumableItemID
+                or (ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
+                    and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id))
+                or entry.itemID
+        end
+        if consumableItemID then
+            GameTooltip.SetItemByID(GameTooltip, consumableItemID)
+        elseif sid then
             if entry.type == "trinket" or entry.type == "slot" then
                 local itemID = entry.itemID
                 if not itemID and Sources and Sources.QueryInventoryItemID then

--- a/QUI_CDM/cdm/cdm_icon_factory.lua
+++ b/QUI_CDM/cdm/cdm_icon_factory.lua
@@ -152,12 +152,11 @@ function CDMIconFactory.ShowEntryTooltip(owner, entry, tooltipContext)
         end
         local consumableItemID
         if entry.type == "consumable" then
-            consumableItemID = Sources and Sources.QueryLastCategoryCooldownSource
-                and select(2, Sources.QueryLastCategoryCooldownSource(entry.id))
+            consumableItemID = Sources and Sources.QueryConsumableCategoryItem
+                and Sources.QueryConsumableCategoryItem(entry.id)
             consumableItemID = consumableItemID
                 or (ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
                     and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id))
-                or entry.itemID
         end
         if consumableItemID then
             GameTooltip.SetItemByID(GameTooltip, consumableItemID)

--- a/QUI_CDM/cdm/cdm_icon_policies.lua
+++ b/QUI_CDM/cdm/cdm_icon_policies.lua
@@ -587,6 +587,7 @@ local _, ns = ...
 
 local CDMIconItemVisualPolicy = {}
 ns.CDMIconItemVisualPolicy = CDMIconItemVisualPolicy
+local Shared = ns.CDMShared
 
 local PROFESSION_QUALITY_DRAW_LAYER = "ARTWORK"
 local PROFESSION_QUALITY_DRAW_SUBLEVEL = 1
@@ -677,8 +678,11 @@ function CDMIconItemVisualPolicy.Create(callbacks)
 
         local ncdm = getNCDM()
         local viewerType = entry.viewerType
-        local containerDB = ncdm and viewerType
-            and (ncdm[viewerType] or (ncdm.containers and ncdm.containers[viewerType]))
+        local containerDB = Shared and Shared.GetContainerDB
+            and Shared.GetContainerDB(viewerType)
+        if not containerDB and ncdm and ncdm.containers then
+            containerDB = ncdm.containers[viewerType]
+        end
         if containerDB and containerDB.showProfessionQuality == false then
             controller:ClearProfessionQuality(icon)
             return
@@ -1040,9 +1044,9 @@ function CDMIconRangePolicy.Create(callbacks)
         return nil
     end
 
-    local function queryReadableSpellUsable(spellID)
-        if not spellID or not callbacks.querySpellUsable then return true, false end
-        local usable, noMana = callbacks.querySpellUsable(spellID)
+    local function queryReadableUsable(query, id)
+        if not id or not query then return true, false end
+        local usable, noMana = query(id)
         local noManaBool = type(noMana) == "boolean" and noMana or false
         if type(usable) == "boolean" and usable == false then return false, noManaBool end
         if type(usable) == "boolean" and usable == true then return true, noManaBool end
@@ -1150,10 +1154,22 @@ function CDMIconRangePolicy.Create(callbacks)
         end
 
         if newVisualState == "normal" and usabilityEnabled and not cooldownVisualPriority then
-            local isUsable = controller.usableCycleCache[spellID]
+            local usabilityID = spellID
+            local usabilityQuery = callbacks.querySpellUsable
+            local usabilityCacheKey = spellID
+            if entry.type == "consumable" and callbacks.queryItemUsable and callbacks.getItemIDForEntry then
+                local itemID = callbacks.getItemIDForEntry(entry)
+                if itemID then
+                    usabilityID = itemID
+                    usabilityQuery = callbacks.queryItemUsable
+                    usabilityCacheKey = "item:" .. tostring(itemID)
+                end
+            end
+
+            local isUsable = controller.usableCycleCache[usabilityCacheKey]
             if isUsable == nil then
-                isUsable = queryReadableSpellUsable(spellID)
-                controller.usableCycleCache[spellID] = isUsable
+                isUsable = queryReadableUsable(usabilityQuery, usabilityID)
+                controller.usableCycleCache[usabilityCacheKey] = isUsable
             end
             if not isUsable then
                 local chargeState = callbacks.resolveCooldownActivityState
@@ -1583,7 +1599,24 @@ function CDMIconCustomBarPolicy.Create(callbacks)
         end
 
         local sources = Sources()
-        if entry.type == "item" then
+        if entry.type == "consumable" then
+            local itemID = sources and sources.QueryLastCategoryCooldownSource
+                and select(2, sources.QueryLastCategoryCooldownSource(entry.id))
+            itemID = itemID
+                or (ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
+                    and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id))
+                or entry.itemID
+            if itemID and sources and sources.QueryItemCount then
+                local count = sources.QueryItemCount(itemID, false, containerDB and containerDB.showItemCharges == true, true)
+                if issecretvalue and issecretvalue(count) then
+                    return true -- @secret-policy: opaque-value-present
+                end
+                if type(count) == "number" then
+                    return count > 0
+                end
+            end
+            return true
+        elseif entry.type == "item" then
             local itemID = ResolveEntryItemID(entry)
             if sources and sources.QueryItemInfoInstant and Enum and Enum.ItemClass then
                 local instantItemID, instantItemType, instantItemSubType, instantEquipLoc, instantIcon, classID =

--- a/QUI_CDM/cdm/cdm_icon_policies.lua
+++ b/QUI_CDM/cdm/cdm_icon_policies.lua
@@ -1025,6 +1025,7 @@ function CDMIconRangePolicy.Create(callbacks)
         rangeCycleCache = {},
         hasRangeCycleCache = {},
         usableCycleCache = {},
+        itemUsableCycleCache = {},
         enabledRangeSpellChecks = {},
         desiredRangeSpellChecks = {},
         stackTextWritesForBatch = false,
@@ -1156,20 +1157,20 @@ function CDMIconRangePolicy.Create(callbacks)
         if newVisualState == "normal" and usabilityEnabled and not cooldownVisualPriority then
             local usabilityID = spellID
             local usabilityQuery = callbacks.querySpellUsable
-            local usabilityCacheKey = spellID
+            local usabilityCache = controller.usableCycleCache
             if entry.type == "consumable" and callbacks.queryItemUsable and callbacks.getItemIDForEntry then
                 local itemID = callbacks.getItemIDForEntry(entry)
                 if itemID then
                     usabilityID = itemID
                     usabilityQuery = callbacks.queryItemUsable
-                    usabilityCacheKey = "item:" .. tostring(itemID)
+                    usabilityCache = controller.itemUsableCycleCache
                 end
             end
 
-            local isUsable = controller.usableCycleCache[usabilityCacheKey]
+            local isUsable = usabilityCache[usabilityID]
             if isUsable == nil then
                 isUsable = queryReadableUsable(usabilityQuery, usabilityID)
-                controller.usableCycleCache[usabilityCacheKey] = isUsable
+                usabilityCache[usabilityID] = isUsable
             end
             if not isUsable then
                 local chargeState = callbacks.resolveCooldownActivityState
@@ -1250,6 +1251,7 @@ function CDMIconRangePolicy.Create(callbacks)
         wipe(controller.rangeCycleCache)
         wipe(controller.hasRangeCycleCache)
         wipe(controller.usableCycleCache)
+        wipe(controller.itemUsableCycleCache)
     end
 
     function controller:UpdateIconRangesForUsabilityEvent(iconPools)

--- a/QUI_CDM/cdm/cdm_icon_policies.lua
+++ b/QUI_CDM/cdm/cdm_icon_policies.lua
@@ -1602,12 +1602,11 @@ function CDMIconCustomBarPolicy.Create(callbacks)
 
         local sources = Sources()
         if entry.type == "consumable" then
-            local itemID = sources and sources.QueryLastCategoryCooldownSource
-                and select(2, sources.QueryLastCategoryCooldownSource(entry.id))
+            local itemID = sources and sources.QueryConsumableCategoryItem
+                and sources.QueryConsumableCategoryItem(entry.id)
             itemID = itemID
                 or (ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
                     and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id))
-                or entry.itemID
             if itemID and sources and sources.QueryItemCount then
                 local count = sources.QueryItemCount(itemID, false, containerDB and containerDB.showItemCharges == true, true)
                 if issecretvalue and issecretvalue(count) then

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -131,7 +131,7 @@ function _resolverRuntimePolicy.ApplyDurationObjectCooldown(cd, durObj, clearWhe
         return ns.CDMRenderers.ApplyDurationObjectCooldown(cd, durObj, clearWhenZero, reverse)
     end
 
-    if not cd or not durObj or not cd.SetCooldownFromDurationObject then
+    if not cd or type(durObj) == "nil" or not cd.SetCooldownFromDurationObject then
         return false
     end
 
@@ -390,6 +390,27 @@ local function QueryItemVisualTexture(itemID)
     return nil
 end
 
+local function GetItemIDForEntry(entry)
+    if not entry then return nil end
+    local entryType = entry.type
+    if entryType == "item" then
+        return (Sources and Sources.QueryBestOwnedItemVariant
+            and Sources.QueryBestOwnedItemVariant(entry.id)) or entry.id
+    end
+    if (entryType == "trinket" or entryType == "slot")
+        and Sources and Sources.QueryInventoryItemID then
+        return Sources.QueryInventoryItemID("player", entry.id)
+    end
+    if entryType == "consumable" then
+        local categoryItemID = Sources and Sources.QueryLastCategoryCooldownSource
+            and select(2, Sources.QueryLastCategoryCooldownSource(entry.id))
+        local fallbackItemID = ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
+            and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id)
+        return categoryItemID or fallbackItemID or entry.itemID
+    end
+    return nil
+end
+
 function _resolverRuntimePolicy.MarkGCDSwipe(icon)
     if cooldownPolicy then
         cooldownPolicy:MarkGCDSwipe(icon)
@@ -571,7 +592,13 @@ local function ResolveTrackerSettingsNow(viewerType)
     end
     local db = GetDB and GetDB()
     if not db or not viewerType then return nil end
-    return db[viewerType] or (db.containers and db.containers[viewerType]) or nil
+    if (Shared and Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(viewerType))
+        or (Shared and Shared.GetBuiltinContainerEntryKind
+            and Shared.GetBuiltinContainerEntryKind(viewerType) ~= nil)
+        or GetBuiltinContainerType(viewerType) then
+        return db[viewerType]
+    end
+    return db.containers and db.containers[viewerType] or nil
 end
 
 local function IsCustomBarSettingsNow(settings)
@@ -661,12 +688,19 @@ local function ApplyCooldownDesaturation(icon, entry, settings, resolvedMode, re
         return
     end
 
-    local realCdDur = resolvedMode == "item-cooldown" and resolvedDurObj or nil
-    if not realCdDur and resolvedSpellID and Sources and Sources.QuerySpellCooldownDuration then
+    local realCdDur
+    if resolvedMode == "item-cooldown" then
+        if type(resolvedDurObj) ~= "nil" then
+            realCdDur = resolvedDurObj
+        end
+    elseif type(resolvedSpellID) ~= "nil"
+        and Sources and Sources.QuerySpellCooldownDuration then
         realCdDur = Sources.QuerySpellCooldownDuration(resolvedSpellID, true)
     end
-    local curve = realCdDur and GetCooldownDesatCurve()
-    if realCdDur and curve and realCdDur.EvaluateRemainingPercent
+    local curve = GetCooldownDesatCurve()
+    if type(realCdDur) ~= "nil"
+        and type(curve) ~= "nil"
+        and realCdDur.EvaluateRemainingPercent
         and icon.Icon.SetDesaturation then
         icon.Icon:SetDesaturation(realCdDur:EvaluateRemainingPercent(curve))
         return
@@ -1191,14 +1225,15 @@ ApplyResolvedCooldown = function(icon, preResolvedState, trustIsOnGCD)
     icon._lastResolvedSpellID = sid or resolvedSpellID
 
     local applied
-    if durObj then
+    if type(durObj) ~= "nil" then
         if measure then
             applied = measure(
                 "CDM_applyCooldownFrame",
                 _resolverRuntimePolicy.ApplyDurationObjectCooldown,
                 addonCD, durObj, true, mode == "aura")
         else
-            applied = _resolverRuntimePolicy.ApplyDurationObjectCooldown(addonCD, durObj, true, mode == "aura")
+            applied = _resolverRuntimePolicy.ApplyDurationObjectCooldown(
+                addonCD, durObj, true, mode == "aura")
         end
     elseif hasNumericCooldown then
         if ns.CDMRenderers and ns.CDMRenderers.ApplyNumericCooldown then
@@ -1736,9 +1771,8 @@ UpdateIconSecureAttributes = function(icon, entry, viewerType)
             ClearClickButtonAttributes(btn)
             btn:Hide()
         end
-    elseif entry.type == "item" then
-        local itemID = (Sources and Sources.QueryBestOwnedItemVariant
-            and Sources.QueryBestOwnedItemVariant(entry.id)) or entry.id
+    elseif entry.type == "item" or entry.type == "consumable" then
+        local itemID = GetItemIDForEntry(entry)
         local itemName = Sources and Sources.QueryItemNameByID and Sources.QueryItemNameByID(itemID)
         if itemName then
             btn:SetAttribute("type", "item")
@@ -2227,7 +2261,12 @@ function GetTrackerSettings(viewerType)
 
     local db = GetDB()
     if not db or not viewerType then return nil end
-    if db[viewerType] then return db[viewerType] end
+    if (Shared and Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(viewerType))
+        or (Shared and Shared.GetBuiltinContainerEntryKind
+            and Shared.GetBuiltinContainerEntryKind(viewerType) ~= nil)
+        or GetBuiltinContainerType(viewerType) then
+        return db[viewerType]
+    end
     return db.containers and db.containers[viewerType] or nil
 end
 
@@ -2577,11 +2616,12 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
         if stackTextWritesAllowed then
             _resolverRuntimePolicy.HideIconStackText(icon, "slot-clear")
         end
-    elseif entry.type == "item" then
-        local itemID = (Sources and Sources.QueryBestOwnedItemVariant
-            and Sources.QueryBestOwnedItemVariant(entry.id)) or entry.id
-        RefreshItemIconVisuals(icon, entry, itemID)
-        if stackTextWritesAllowed and Sources and Sources.QueryItemCount then
+    elseif entry.type == "item" or entry.type == "consumable" then
+        local itemID = GetItemIDForEntry(entry)
+        if itemID and entry.type == "item" then
+            RefreshItemIconVisuals(icon, entry, itemID)
+        end
+        if itemID and stackTextWritesAllowed and Sources and Sources.QueryItemCount then
             local containerDB = GetTrackerSettings(entry.viewerType)
             local includeUses = containerDB and containerDB.showItemCharges == true
             local count = Sources.QueryItemCount(itemID, false, includeUses, true)
@@ -2618,6 +2658,8 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
             else
                 _resolverRuntimePolicy.ShowIconStackText(icon, "0", containerDB, "item-count-fallback")
             end
+        elseif stackTextWritesAllowed then
+            _resolverRuntimePolicy.HideIconStackText(icon, "item-count-missing-item")
         end
     else
         local _chargedAuraActive = false
@@ -2732,7 +2774,7 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
             "mode=", tostring(resolvedMode),
             "start=", tostring(startTime),
             "duration=", tostring(duration),
-            "durObj=", durObj and "yes" or "no",
+            "durObj=", type(durObj) ~= "nil" and "yes" or "no",
             "active=", tostring(resolvedActive),
             "hasCharges=", tostring(runtimeHasCharges),
             "entryHasCharges=", tostring(entry.hasCharges),
@@ -2765,7 +2807,7 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
                 "real=", tostring(realCooldownActive),
                 "gcdOnly=", tostring(resolvedMode == "gcd-only"),
                 "resolvedActive=", tostring(resolvedActive),
-                "durObj=", durObj and "yes" or "no")
+                "durObj=", type(durObj) ~= "nil" and "yes" or "no")
         end
 
         local prevGCD = icon._wasShowingGCDSwipe or false
@@ -2986,7 +3028,8 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
             elseif not InCombatLockdown() then
                 _resolverRuntimePolicy.HideIconStackText(icon, "item-aura-stack-nil")
             end
-        elseif stackTextWritesAllowed and not _chargeCountForwarded and entry.type ~= "item" then
+        elseif stackTextWritesAllowed and not _chargeCountForwarded
+            and entry.type ~= "item" and entry.type ~= "consumable" then
             local stackVal = GetAuraApplicationsForSpell(_runtimeSid, entry, icon)
             if _resolverRuntimePolicy.ValueIsPresent(stackVal) then
                 local displayText
@@ -3042,7 +3085,8 @@ end
 
 local function BuildSpellEntryFromCustom(entry, idx, viewerType)
     if type(entry) ~= "table" or entry.id == nil then return nil end
-    local isSpellType = (entry.type ~= "item" and entry.type ~= "trinket" and entry.type ~= "slot")
+    local isSpellType = (entry.type ~= "item" and entry.type ~= "trinket"
+        and entry.type ~= "slot" and entry.type ~= "consumable")
     local kind = entry.kind
     if not (kind == "aura" or kind == "cooldown") then
         if not isSpellType then
@@ -3570,10 +3614,17 @@ local function ApplyIconVisibility(icon, shouldShow, dynamicLayout)
     end
 end
 
+local function GetRuntimeContainerDB(containerKey, ncdm, ncdmContainers)
+    if ncdm and GetBuiltinContainerType(containerKey) then
+        return ncdm[containerKey]
+    end
+    return ncdmContainers and ncdmContainers[containerKey] or nil
+end
+
 local function ResolveContainerDBAndType(entry, ncdm, ncdmContainers)
     if not entry then return nil, "cooldown" end
 
-    local containerDB = ncdm and (ncdm[entry.viewerType] or (ncdmContainers and ncdmContainers[entry.viewerType]))
+    local containerDB = GetRuntimeContainerDB(entry.viewerType, ncdm, ncdmContainers)
     local cType = containerDB and containerDB.containerType
     if not cType then
         local vt = entry.viewerType
@@ -3798,8 +3849,7 @@ local function RefreshAllIcon(icon, context)
     local isHiddenOverride = spellOvr and spellOvr.hidden
 
     if entry then
-        local containerDB = ncdm
-            and (ncdm[entry.viewerType] or (ncdmContainers and ncdmContainers[entry.viewerType]))
+        local containerDB = GetRuntimeContainerDB(entry.viewerType, ncdm, ncdmContainers)
 
         UpdateCooldownContainerVisibility(icon, entry, containerDB, editMode, inCombat)
 
@@ -4152,8 +4202,13 @@ function CustomCDM:UpdateAllCooldowns() CDMIcons:UpdateAllCooldowns() end
 local rangePolicy = ns.CDMIconRangePolicy and ns.CDMIconRangePolicy.Create({
     getDB = GetDB,
     resolveSettings = function(viewerType, cachedDB)
-        return (cachedDB and (cachedDB[viewerType] or (cachedDB.containers and cachedDB.containers[viewerType])))
-            or GetTrackerSettings(viewerType)
+        if cachedDB and GetBuiltinContainerType(viewerType) then
+            return cachedDB[viewerType]
+        end
+        if cachedDB and cachedDB.containers then
+            return cachedDB.containers[viewerType]
+        end
+        return GetTrackerSettings(viewerType)
     end,
     querySpellInRange = function(spellID, unit)
         return Sources and Sources.QuerySpellInRange and Sources.QuerySpellInRange(spellID, unit)
@@ -4161,6 +4216,10 @@ local rangePolicy = ns.CDMIconRangePolicy and ns.CDMIconRangePolicy.Create({
     querySpellUsable = function(spellID)
         return Sources and Sources.QuerySpellUsable and Sources.QuerySpellUsable(spellID)
     end,
+    queryItemUsable = function(itemID)
+        return Sources and Sources.QueryItemUsable and Sources.QueryItemUsable(itemID)
+    end,
+    getItemIDForEntry = GetItemIDForEntry,
     querySpellHasRange = function(spellID)
         return Sources and Sources.QuerySpellHasRange and Sources.QuerySpellHasRange(spellID)
     end,
@@ -4222,29 +4281,11 @@ local function UpdateIconsForSpellRangeEvent(spellIdentifier, isInRange, checksR
     end
 end
 
-local function GetItemIDForEntry(entry)
-    if not entry then return nil end
-    local entryType = entry.type
-    if entryType == "item" then
-        return (Sources and Sources.QueryBestOwnedItemVariant
-            and Sources.QueryBestOwnedItemVariant(entry.id)) or entry.id
-    end
-    if (entryType == "trinket" or entryType == "slot")
-        and Sources and Sources.QueryInventoryItemID then
-        return Sources.QueryInventoryItemID("player", entry.id)
-    end
-    if entryType == "consumable" then
-        if entry.itemID then return entry.itemID end
-        return Sources and Sources.QueryLastCategoryCooldownSource
-            and select(2, Sources.QueryLastCategoryCooldownSource(entry.id))
-    end
-    return nil
-end
-
 local cdEventFrame = CreateFrame("Frame")
 cdEventFrame:RegisterEvent("BAG_UPDATE_COOLDOWN")
 cdEventFrame:RegisterEvent("BAG_UPDATE_DELAYED")
 cdEventFrame:RegisterEvent("ITEM_COUNT_CHANGED")
+cdEventFrame:RegisterEvent("SPELL_UPDATE_USES")
 cdEventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_SOFT_ENEMY_CHANGED")

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -406,7 +406,9 @@ local function GetItemIDForEntry(entry)
             and select(2, Sources.QueryLastCategoryCooldownSource(entry.id))
         local fallbackItemID = ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
             and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id)
-        return categoryItemID or fallbackItemID or entry.itemID
+        return categoryItemID or entry.itemID or fallbackItemID
+            or (Sources and Sources.QueryBestOwnedConsumableCategoryItem
+                and Sources.QueryBestOwnedConsumableCategoryItem(entry.id))
     end
     return nil
 end
@@ -1719,6 +1721,7 @@ UpdateIconSecureAttributes = function(icon, entry, viewerType)
         icon._pendingSecureUpdate = true
         return
     end
+    icon._pendingSecureUpdate = nil
 
     if viewerType == "buff" then
         if icon.clickButton then
@@ -1773,11 +1776,17 @@ UpdateIconSecureAttributes = function(icon, entry, viewerType)
         end
     elseif entry.type == "item" or entry.type == "consumable" then
         local itemID = GetItemIDForEntry(entry)
+        if entry.type == "consumable" and itemID then
+            entry.itemID = itemID
+        end
         local itemName = Sources and Sources.QueryItemNameByID and Sources.QueryItemNameByID(itemID)
         if itemName then
             btn:SetAttribute("type", "item")
             btn:SetAttribute("item", itemName)
             btn:Show()
+            if entry.type == "consumable" then
+                icon._lastConsumableSecureItemID = itemID
+            end
         else
             ClearClickButtonAttributes(btn)
             btn:Hide()
@@ -1805,7 +1814,6 @@ UpdateIconSecureAttributes = function(icon, entry, viewerType)
         end
     end
 
-    icon._pendingSecureUpdate = nil
 end
 
 function CDMIcons.UpdateSecureClickOverlay(icon, entry, viewerType)
@@ -2620,6 +2628,11 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
         local itemID = GetItemIDForEntry(entry)
         if itemID and entry.type == "item" then
             RefreshItemIconVisuals(icon, entry, itemID)
+        end
+        if itemID and entry.type == "consumable"
+            and icon._lastConsumableSecureItemID ~= itemID then
+            entry.itemID = itemID
+            UpdateIconSecureAttributes(icon, entry, entry.viewerType)
         end
         if itemID and stackTextWritesAllowed and Sources and Sources.QueryItemCount then
             local containerDB = GetTrackerSettings(entry.viewerType)
@@ -4637,6 +4650,16 @@ do
         refreshCustomAuraTargets = function(identityChanged)
             if ns.CDMCustomAuraRuns and ns.CDMCustomAuraRuns.RefreshTargets then
                 ns.CDMCustomAuraRuns.RefreshTargets(identityChanged)
+            end
+        end,
+        refreshPendingSecureAttributes = function()
+            for _, pool in pairs(iconPools) do
+                for _, icon in ipairs(pool) do
+                    if icon and icon._pendingSecureUpdate then
+                        local entry = icon._spellEntry
+                        UpdateIconSecureAttributes(icon, entry, entry and entry.viewerType)
+                    end
+                end
             end
         end,
     }

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -4285,7 +4285,6 @@ local cdEventFrame = CreateFrame("Frame")
 cdEventFrame:RegisterEvent("BAG_UPDATE_COOLDOWN")
 cdEventFrame:RegisterEvent("BAG_UPDATE_DELAYED")
 cdEventFrame:RegisterEvent("ITEM_COUNT_CHANGED")
-cdEventFrame:RegisterEvent("SPELL_UPDATE_USES")
 cdEventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_SOFT_ENEMY_CHANGED")
@@ -4661,9 +4660,9 @@ local function OnCDMCooldownChanged(_, spellID, baseSpellID, kind, category, sta
     end
 end
 
-local function OnCDMChargesChanged(_, spellID)
+local function OnCDMChargesChanged(_, spellID, baseSpellID)
     if runtimeRefresh then
-        return runtimeRefresh:HandleChargesChanged(_, spellID)
+        return runtimeRefresh:HandleChargesChanged(_, spellID, baseSpellID)
     end
 end
 

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -402,13 +402,11 @@ local function GetItemIDForEntry(entry)
         return Sources.QueryInventoryItemID("player", entry.id)
     end
     if entryType == "consumable" then
-        local categoryItemID = Sources and Sources.QueryLastCategoryCooldownSource
-            and select(2, Sources.QueryLastCategoryCooldownSource(entry.id))
-        local fallbackItemID = ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
+        local itemID = Sources and Sources.QueryConsumableCategoryItem
+            and Sources.QueryConsumableCategoryItem(entry.id)
+        if itemID then return itemID end
+        return ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
             and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id)
-        return categoryItemID or entry.itemID or fallbackItemID
-            or (Sources and Sources.QueryBestOwnedConsumableCategoryItem
-                and Sources.QueryBestOwnedConsumableCategoryItem(entry.id))
     end
     return nil
 end
@@ -1776,9 +1774,6 @@ UpdateIconSecureAttributes = function(icon, entry, viewerType)
         end
     elseif entry.type == "item" or entry.type == "consumable" then
         local itemID = GetItemIDForEntry(entry)
-        if entry.type == "consumable" and itemID then
-            entry.itemID = itemID
-        end
         local itemName = Sources and Sources.QueryItemNameByID and Sources.QueryItemNameByID(itemID)
         if itemName then
             btn:SetAttribute("type", "item")
@@ -2631,7 +2626,6 @@ local function UpdateIconCooldownOwned(icon, trustIsOnGCD)
         end
         if itemID and entry.type == "consumable"
             and icon._lastConsumableSecureItemID ~= itemID then
-            entry.itemID = itemID
             UpdateIconSecureAttributes(icon, entry, entry.viewerType)
         end
         if itemID and stackTextWritesAllowed and Sources and Sources.QueryItemCount then
@@ -4617,6 +4611,11 @@ do
             end
         end,
         invalidateMacroCache = InvalidateMacroCache,
+        invalidateConsumableCategoryItems = function()
+            if Sources and Sources.InvalidateConsumableCategoryItems then
+                Sources.InvalidateConsumableCategoryItems()
+            end
+        end,
         updateIconsForSpellRangeEvent = UpdateIconsForSpellRangeEvent,
         clearTextureCycleCache = function()
             wipe(_textureCycleCache)

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -244,6 +244,8 @@ local function entryHasLinkedSpellIDs(callbacks, icon, entry)
     return entryLinkedSpellIDsMatch(callbacks, icon, entry)
 end
 
+local itemEntryMatchesAuraSpellIdentifierSet
+
 local function entryMatchesSpellIdentifierSet(callbacks, icon, entry, spellIDs, hasSpellIDs)
     if not hasSpellIDs or not entry then return false end
     if spellIdentifierSetHas(callbacks, spellIDs, icon and icon._runtimeSpellID) then return true end
@@ -258,10 +260,11 @@ local function entryMatchesSpellIdentifierSet(callbacks, icon, entry, spellIDs, 
         end
     end
 
+    if itemEntryMatchesAuraSpellIdentifierSet(callbacks, entry, spellIDs, hasSpellIDs) then return true end
     return entryLinkedSpellIDsMatch(callbacks, icon, entry, spellIDs)
 end
 
-local function itemEntryMatchesAuraSpellIdentifierSet(callbacks, entry, spellIDs, hasSpellIDs)
+itemEntryMatchesAuraSpellIdentifierSet = function(callbacks, entry, spellIDs, hasSpellIDs)
     if not hasSpellIDs or not (entry and callbacks.queryItemSpell) then return false end
     local itemID = callbacks.getItemIDForEntry and callbacks.getItemIDForEntry(entry)
     if normalizeSpellIdentifier(callbacks, itemID) == nil then return false end
@@ -343,8 +346,8 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         if state.frame then
             state.frame:SetScript("OnUpdate", nil)
             if state.frame.Hide then state.frame:Hide() end
-        end
     end
+end
 
     function controller:AddSpellIdentifierToSet(set, rawID)
         return addSpellIdentifierToSet(callbacks, set, rawID)
@@ -1219,10 +1222,6 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end
             return
         end
-        if event == "SPELL_UPDATE_USES" then
-            controller:QueueItemScopeRefresh({ refreshRuntime = true })
-            return
-        end
     end
 
     function controller:Handle(event, arg1, arg2, arg3, arg4, frame)
@@ -1304,14 +1303,15 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         end
     end
 
-    function controller:HandleChargesChanged(_, spellID)
+    function controller:HandleChargesChanged(_, spellID, baseSpellID)
         if not isRuntimeEnabled(callbacks) then return end
         if callbacks.requestStackTextUpdate then
             callbacks.requestStackTextUpdate()
         end
-        if normalizeSpellIdentifier(callbacks, spellID) ~= nil then
+        if normalizeSpellIdentifier(callbacks, spellID) ~= nil
+            or normalizeSpellIdentifier(callbacks, baseSpellID) ~= nil then
             if runtimeRefreshStats then runtimeRefreshStats.chargeCooldownSkips = runtimeRefreshStats.chargeCooldownSkips + 1 end
-            controller:QueueResolvedCooldownForSpellID(spellID, nil)
+            controller:QueueResolvedCooldownForSpellID(spellID, baseSpellID)
         else
             if callbacks.scheduleUpdate then
                 callbacks.scheduleUpdate(true, UPDATE_COOLDOWN, "charges")

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -1219,6 +1219,10 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end
             return
         end
+        if event == "SPELL_UPDATE_USES" then
+            controller:QueueItemScopeRefresh({ refreshRuntime = true })
+            return
+        end
     end
 
     function controller:Handle(event, arg1, arg2, arg3, arg4, frame)

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -346,8 +346,8 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         if state.frame then
             state.frame:SetScript("OnUpdate", nil)
             if state.frame.Hide then state.frame:Hide() end
+        end
     end
-end
 
     function controller:AddSpellIdentifierToSet(set, rawID)
         return addSpellIdentifierToSet(callbacks, set, rawID)

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -1152,6 +1152,9 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         end
         if event == "PLAYER_REGEN_ENABLED" then
             controller:DrainDeferredFullRefresh()
+            if callbacks.refreshPendingSecureAttributes then
+                callbacks.refreshPendingSecureAttributes()
+            end
             return
         end
         if event == "UPDATE_MACROS" then

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -608,7 +608,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
                     local entryCategory = normalizeSpellIdentifier(callbacks, entry and entry.id)
                     if normalizedCategory and entryCategory == normalizedCategory
                         and entry and entry.type == "consumable" then
-                        entry.itemID = normalizedItemID
+                        entry._runtimeItemID = normalizedItemID
                         entry._runtimeSpellID = normalizeSpellIdentifier(callbacks, eventSpellID)
                             or normalizeSpellIdentifier(callbacks, eventBaseSpellID)
                         entry._runtimeBaseSpellID = normalizeSpellIdentifier(callbacks, eventBaseSpellID)
@@ -1220,6 +1220,9 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             return
         end
         if event == "BAG_UPDATE_DELAYED" or event == "ITEM_COUNT_CHANGED" then
+            if callbacks.invalidateConsumableCategoryItems then
+                callbacks.invalidateConsumableCategoryItems()
+            end
             controller:QueueItemScopeRefresh({ refreshRuntime = true })
             if callbacks.setBarsDirty then callbacks.setBarsDirty(true) end
             if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end

--- a/QUI_CDM/cdm/cdm_layout_mode.lua
+++ b/QUI_CDM/cdm/cdm_layout_mode.lua
@@ -42,13 +42,10 @@ local function GetCDMDB(cdmKey)
 
     local ncdm = GetNcdmDB()
     if not ncdm then return nil end
-    if ncdm[dbKey] then
+    if Shared and Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(dbKey) then
         return ncdm[dbKey]
     end
-    if ncdm.containers and ncdm.containers[dbKey] then
-        return ncdm.containers[dbKey]
-    end
-    return nil
+    return ncdm.containers and ncdm.containers[dbKey] or nil
 end
 
 local function RefreshCDM()

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -262,10 +262,12 @@ local function ResolveItemCooldownIdentity(entry)
         end
         itemID = itemID or entry.itemID
     elseif entry.type == "consumable" then
-        itemID = entry.itemID
-        if not itemID and Sources and Sources.QueryLastCategoryCooldownSource then
+        if Sources and Sources.QueryLastCategoryCooldownSource then
             categorySpellID, itemID = Sources.QueryLastCategoryCooldownSource(entry.id)
         end
+        local fallbackItemID = ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
+            and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id)
+        itemID = itemID or fallbackItemID or entry.itemID
     elseif entry.type == "macro" then
         local resolvedID, resolvedType = CDMResolvers.ResolveMacro(entry)
         if resolvedType == "item" then
@@ -275,7 +277,7 @@ local function ResolveItemCooldownIdentity(entry)
 
     if not itemID then return nil, slotID, nil, nil end
 
-    local itemSpellID = QueryItemUseSpellID(itemID) or categorySpellID
+    local itemSpellID = categorySpellID or QueryItemUseSpellID(itemID)
     local keySource = slotID and (tostring(slotID) .. ":" .. tostring(itemID)) or tostring(itemID)
     return itemID, slotID, itemSpellID, keySource
 end
@@ -447,7 +449,7 @@ local function QueryGCDDurationObject(spellID)
     if spellID then
         durObj = QueryGCDDuration(spellID)
     end
-    if not durObj and spellID ~= GCD_SPELL_ID then
+    if type(durObj) == "nil" and spellID ~= GCD_SPELL_ID then
         durObj = QueryGCDDuration(GCD_SPELL_ID)
     end
     return durObj
@@ -902,7 +904,7 @@ local function BuildDurationObjectFromStart(startTime, duration)
     if not (C_DurationUtil and C_DurationUtil.CreateDuration) then return nil end
 
     local okCreate, durObj = pcall(C_DurationUtil.CreateDuration)
-    if not okCreate or not durObj or not durObj.SetTimeFromStart then
+    if not okCreate or type(durObj) == "nil" or not durObj.SetTimeFromStart then
         return nil
     end
 
@@ -947,8 +949,8 @@ local function GetIconItemDurationObject(icon, sourceID, startTime, duration)
         return nil
     end
 
-    local durObj = state.durObj or icon._lastDurObj
-    if durObj then
+    local durObj = type(state.durObj) ~= "nil" and state.durObj or icon._lastDurObj
+    if type(durObj) ~= "nil" then
         if resolverStats then resolverStats.itemDurationIconReuses = resolverStats.itemDurationIconReuses + 1 end
         return durObj
     end
@@ -958,7 +960,7 @@ end
 local function BuildIconItemDurationObject(icon, keySource, startTime, duration)
     local sourceID = BuildItemDurationSourceID(icon, keySource)
     local durObj = GetIconItemDurationObject(icon, sourceID, startTime, duration)
-    if durObj then
+    if type(durObj) ~= "nil" then
         return durObj, sourceID
     end
     return BuildDurationObjectFromStart(startTime, duration), sourceID
@@ -1071,7 +1073,7 @@ local function ResolveItemDurationObjectForIcon(icon, entry)
         local cdInfoActive = cdInfo and IsCooldownInfoActive(cdInfo)
         if cdInfoActive ~= false and GetCurrentIsOnGCD(cdInfo) ~= true then
             local durObj = QueryDuration(itemSpellID)
-            if durObj then
+            if type(durObj) ~= "nil" then
                 return durObj, "item-cooldown",
                     "spell:" .. tostring(itemSpellID) .. ":" .. tostring(keySource),
                     nil, nil, itemSpellID
@@ -1113,7 +1115,7 @@ end
 function CDMResolvers.BuildEntryItemDurationObject(entry)
     local durObj, mode, _, startTime, duration = ResolveItemDurationObjectForIcon(nil, entry)
     if mode ~= "item-cooldown" then return nil end
-    if durObj then return durObj end
+    if type(durObj) ~= "nil" then return durObj end
     return BuildDurationObjectFromStart(startTime, duration)
 end
 
@@ -1572,7 +1574,8 @@ local function ResolveCooldownStateCore(context)
         end
     end
 
-    if itemID and not context.skipAuraPhase
+    if itemID and not (entry.type == "consumable" and entry.kind == "cooldown")
+       and not context.skipAuraPhase
        and ResolveItemAuraForContext(state, context, entry, itemID, itemSpellID) then
         MemAuditProfilerMark("CDM_rsReturnItemAura")
         return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
@@ -1630,7 +1633,7 @@ local function ResolveCooldownStateCore(context)
         and (entry.hasCharges == true or entry.charges == true)
     if currentOnGCD == true and HasActiveChargeRecharge(sid, entryMayHaveCharges) then
         local chargeDur = QueryChargeDuration(sid)
-        if chargeDur then
+        if type(chargeDur) ~= "nil" then
             state.mode = "cooldown"
             SetCooldownStateActivity(state, true)
             state.durObj = chargeDur
@@ -1651,7 +1654,7 @@ local function ResolveCooldownStateCore(context)
             state.cooldownInfoOnGCD = cdInfoOnGCD
             if preserveGCDOnly then
                 local gcdDur = QueryGCDDurationObject(sid)
-                if gcdDur then
+                if type(gcdDur) ~= "nil" then
                     state.mode = "gcd-only"
                     SetCooldownStateActivity(state, true)
                     state.durObj = gcdDur
@@ -1661,7 +1664,7 @@ local function ResolveCooldownStateCore(context)
                     return FinalizeCooldownStateActivity(state, context, entry, sid, entryIsAura, itemBackedEntry)
                 end
             end
-            if durObj and cdInfoOnGCD ~= true then
+            if type(durObj) ~= "nil" and cdInfoOnGCD ~= true then
                 state.mode = "cooldown"
                 SetCooldownStateActivity(state, true)
                 state.durObj = durObj
@@ -1672,7 +1675,7 @@ local function ResolveCooldownStateCore(context)
             end
             if cdInfoOnGCD == true and context.showGCDSwipe == true then
                 local gcdDur = QueryGCDDurationObject(sid)
-                if gcdDur then
+                if type(gcdDur) ~= "nil" then
                     state.mode = "gcd-only"
                     SetCooldownStateActivity(state, true)
                     state.durObj = gcdDur
@@ -1686,7 +1689,7 @@ local function ResolveCooldownStateCore(context)
     end
     MemAuditProfilerMark("CDM_rsLiveCDProbe")
 
-    if gcdDurObj then
+    if type(gcdDurObj) ~= "nil" then
         state.mode = "gcd-only"
         SetCooldownStateActivity(state, true)
         state.durObj = gcdDurObj
@@ -1699,7 +1702,7 @@ local function ResolveCooldownStateCore(context)
 
     if HasActiveChargeRecharge(sid, entryMayHaveCharges) then
         local chargeDur = QueryChargeDuration(sid)
-        if chargeDur then
+        if type(chargeDur) ~= "nil" then
             state.mode = "cooldown"
             SetCooldownStateActivity(state, true)
             state.durObj = chargeDur

--- a/QUI_CDM/cdm/cdm_resolvers.lua
+++ b/QUI_CDM/cdm/cdm_resolvers.lua
@@ -267,7 +267,7 @@ local function ResolveItemCooldownIdentity(entry)
         end
         local fallbackItemID = ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
             and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id)
-        itemID = itemID or fallbackItemID or entry.itemID
+        itemID = itemID or entry._runtimeItemID or fallbackItemID or entry.itemID
     elseif entry.type == "macro" then
         local resolvedID, resolvedType = CDMResolvers.ResolveMacro(entry)
         if resolvedType == "item" then

--- a/QUI_CDM/cdm/cdm_shared.lua
+++ b/QUI_CDM/cdm/cdm_shared.lua
@@ -227,10 +227,14 @@ function CDMShared.GetContainerDB(containerKey)
     if not ncdm or type(containerKey) ~= "string" or containerKey == "" then
         return nil
     end
-    if ncdm[containerKey] then
+    if not CDMShared.IsBuiltinContainerKey(containerKey)
+        and ncdm.containers and ncdm.containers[containerKey] then
+        return ncdm.containers[containerKey]
+    end
+    if CDMShared.IsBuiltinContainerKey(containerKey) and ncdm[containerKey] then
         return ncdm[containerKey]
     end
-    return ncdm.containers and ncdm.containers[containerKey] or nil
+    return nil
 end
 
 function CDMShared.GetContainerType(containerKey, containerDB)

--- a/QUI_CDM/cdm/cdm_sources.lua
+++ b/QUI_CDM/cdm/cdm_sources.lua
@@ -35,19 +35,34 @@ local _C_SpellHasRange = C_Spell and C_Spell.SpellHasRange
 local _C_FindSpellBookSlotForSpell = C_SpellBook and C_SpellBook.FindSpellBookSlotForSpell
 local _C_GetNumSpellBookSkillLines = C_SpellBook and C_SpellBook.GetNumSpellBookSkillLines
 local _lastCategoryCooldownSources = {}
+local _categoryMetadataSpellIDs = {}
+local _categoryMetadataIndexVersion
 
 local function QueryCategoryMetadataSpellID(categoryID)
     if not categoryID then return nil end
     local index = ns.CDMIndex
+    local indexVersion = index and index.Version and index.Version()
+    if _categoryMetadataIndexVersion ~= indexVersion then
+        _categoryMetadataSpellIDs = {}
+        _categoryMetadataIndexVersion = indexVersion
+    end
+    local cached = _categoryMetadataSpellIDs[categoryID]
+    if cached ~= nil then return cached or nil end
     local record = index and index.GetByCategory and index.GetByCategory(categoryID)
     local cooldownID = record and record.cooldownID
-    if cooldownID == nil then return nil end
     local catalog = ns.CDMCatalog
-    local info = catalog and catalog.GetCooldownInfo and catalog.GetCooldownInfo(cooldownID)
-    if type(info) ~= "table" then return nil end
-    local spellID = info.overrideSpellID or info.spellID
-    if WoW_IsSecretValue and WoW_IsSecretValue(spellID) then return nil end -- @secret-policy: reject-secret-ids
-    return type(spellID) == "number" and spellID or nil
+    local info = cooldownID ~= nil and catalog and catalog.GetCooldownInfo
+        and catalog.GetCooldownInfo(cooldownID)
+    local spellID = type(info) == "table" and (info.overrideSpellID or info.spellID) or nil
+    if WoW_IsSecretValue and WoW_IsSecretValue(spellID) then spellID = nil end -- @secret-policy: reject-secret-ids
+    if type(spellID) ~= "number" then spellID = nil end
+    indexVersion = index and index.Version and index.Version()
+    if _categoryMetadataIndexVersion ~= indexVersion then
+        _categoryMetadataSpellIDs = {}
+        _categoryMetadataIndexVersion = indexVersion
+    end
+    _categoryMetadataSpellIDs[categoryID] = spellID or false
+    return spellID
 end
 
 function CDMSources.QuerySpellCharges(spellID)

--- a/QUI_CDM/cdm/cdm_sources.lua
+++ b/QUI_CDM/cdm/cdm_sources.lua
@@ -77,7 +77,12 @@ function CDMSources.QueryLastCategoryCooldownSource(categoryID)
         spellID = QueryCategoryMetadataSpellID(categoryID)
     end
     if spellID ~= nil and itemID ~= nil then
-        _lastCategoryCooldownSources[categoryID] = { spellID = spellID, itemID = itemID }
+        if not cached then
+            cached = {}
+            _lastCategoryCooldownSources[categoryID] = cached
+        end
+        if cached.spellID ~= spellID then cached.spellID = spellID end
+        if cached.itemID ~= itemID then cached.itemID = itemID end
     elseif cached then
         return cached.spellID, cached.itemID
     end

--- a/QUI_CDM/cdm/cdm_sources.lua
+++ b/QUI_CDM/cdm/cdm_sources.lua
@@ -308,6 +308,19 @@ function CDMSources.QueryItemCount(itemID, includeBank, includeUses, forceUpdate
     return _C_GetItemCount(itemID, includeBank, includeUses, forceUpdate)
 end
 
+function CDMSources.QueryBestOwnedConsumableCategoryItem(categoryID)
+    local consumables = ns.ConsumableMacros
+    local getCandidates = consumables and consumables.GetCategoryItemCandidates
+    local candidates = getCandidates and getCandidates(categoryID)
+    if type(candidates) ~= "table" then return nil end
+    for _, itemID in ipairs(candidates) do
+        local count = CDMSources.QueryItemCount(itemID, false, false)
+        if issecretvalue and issecretvalue(count) then return nil end -- @secret-policy: reject-secret-value
+        if type(count) == "number" and count > 0 then return itemID end
+    end
+    return nil
+end
+
 function CDMSources.QueryBestOwnedItemVariant(itemID)
     if not itemID then return nil end
     if issecretvalue and issecretvalue(itemID) then return nil end -- @secret-policy: reject-secret-ids

--- a/QUI_CDM/cdm/cdm_sources.lua
+++ b/QUI_CDM/cdm/cdm_sources.lua
@@ -308,17 +308,44 @@ function CDMSources.QueryItemCount(itemID, includeBank, includeUses, forceUpdate
     return _C_GetItemCount(itemID, includeBank, includeUses, forceUpdate)
 end
 
+local _bestOwnedConsumableCategoryItems = {}
+
+function CDMSources.InvalidateConsumableCategoryItems()
+    for categoryID in pairs(_bestOwnedConsumableCategoryItems) do
+        _bestOwnedConsumableCategoryItems[categoryID] = nil
+    end
+end
+
 function CDMSources.QueryBestOwnedConsumableCategoryItem(categoryID)
+    local cached = _bestOwnedConsumableCategoryItems[categoryID]
+    if cached ~= nil then return cached or nil end
     local consumables = ns.ConsumableMacros
     local getCandidates = consumables and consumables.GetCategoryItemCandidates
     local candidates = getCandidates and getCandidates(categoryID)
     if type(candidates) ~= "table" then return nil end
+    local countsReadable = true
     for _, itemID in ipairs(candidates) do
         local count = CDMSources.QueryItemCount(itemID, false, false)
         if issecretvalue and issecretvalue(count) then return nil end -- @secret-policy: reject-secret-value
-        if type(count) == "number" and count > 0 then return itemID end
+        if type(count) == "number" then
+            if count > 0 then
+                _bestOwnedConsumableCategoryItems[categoryID] = itemID
+                return itemID
+            end
+        else
+            countsReadable = false
+        end
     end
+    if countsReadable then _bestOwnedConsumableCategoryItems[categoryID] = false end
     return nil
+end
+
+function CDMSources.QueryConsumableCategoryItem(categoryID)
+    local itemID = CDMSources.QueryBestOwnedConsumableCategoryItem(categoryID)
+    if itemID then return itemID end
+    local catalog = ns.CDMCatalog
+    return catalog and catalog.GetConsumableCategoryItemID
+        and catalog.GetConsumableCategoryItemID(categoryID)
 end
 
 function CDMSources.QueryBestOwnedItemVariant(itemID)

--- a/QUI_CDM/cdm/cdm_sources.lua
+++ b/QUI_CDM/cdm/cdm_sources.lua
@@ -34,6 +34,21 @@ local _C_IsSpellInRange = C_Spell and C_Spell.IsSpellInRange
 local _C_SpellHasRange = C_Spell and C_Spell.SpellHasRange
 local _C_FindSpellBookSlotForSpell = C_SpellBook and C_SpellBook.FindSpellBookSlotForSpell
 local _C_GetNumSpellBookSkillLines = C_SpellBook and C_SpellBook.GetNumSpellBookSkillLines
+local _lastCategoryCooldownSources = {}
+
+local function QueryCategoryMetadataSpellID(categoryID)
+    if not categoryID then return nil end
+    local index = ns.CDMIndex
+    local record = index and index.GetByCategory and index.GetByCategory(categoryID)
+    local cooldownID = record and record.cooldownID
+    if cooldownID == nil then return nil end
+    local catalog = ns.CDMCatalog
+    local info = catalog and catalog.GetCooldownInfo and catalog.GetCooldownInfo(cooldownID)
+    if type(info) ~= "table" then return nil end
+    local spellID = info.overrideSpellID or info.spellID
+    if WoW_IsSecretValue and WoW_IsSecretValue(spellID) then return nil end -- @secret-policy: reject-secret-ids
+    return type(spellID) == "number" and spellID or nil
+end
 
 function CDMSources.QuerySpellCharges(spellID)
     if not spellID or not _C_GetSpellCharges then return nil, false end
@@ -52,9 +67,19 @@ end
 
 function CDMSources.QueryLastCategoryCooldownSource(categoryID)
     if not categoryID or not _C_GetLastCategoryCooldownSource then return nil, nil end
+    local cached = _lastCategoryCooldownSources[categoryID]
     local spellID, itemID = _C_GetLastCategoryCooldownSource(categoryID)
     if issecretvalue and (issecretvalue(spellID) or issecretvalue(itemID)) then
-        return nil, nil
+        return cached and cached.spellID or QueryCategoryMetadataSpellID(categoryID),
+            cached and cached.itemID or nil
+    end
+    if spellID == nil then
+        spellID = QueryCategoryMetadataSpellID(categoryID)
+    end
+    if spellID ~= nil and itemID ~= nil then
+        _lastCategoryCooldownSources[categoryID] = { spellID = spellID, itemID = itemID }
+    elseif cached then
+        return cached.spellID, cached.itemID
     end
     return spellID, itemID
 end
@@ -179,6 +204,7 @@ local _C_GetItemIconByID = C_Item and C_Item.GetItemIconByID
 local _C_GetItemNameByID = C_Item and C_Item.GetItemNameByID
 local _C_GetItemSpell = C_Item and C_Item.GetItemSpell
 local _C_GetItemQualityByID = C_Item and C_Item.GetItemQualityByID
+local _C_IsUsableItem = C_Item and C_Item.IsUsableItem
 
 function CDMSources.QueryItemInfoInstant(itemID)
     if not itemID or not _C_GetItemInfoInstant then return nil end
@@ -203,6 +229,11 @@ end
 function CDMSources.QueryItemQualityByID(itemID)
     if not itemID or not _C_GetItemQualityByID then return nil end
     return _C_GetItemQualityByID(itemID)
+end
+
+function CDMSources.QueryItemUsable(itemID)
+    if not itemID or not _C_IsUsableItem then return nil, nil end
+    return _C_IsUsableItem(itemID)
 end
 
 function CDMSources.QueryItemProfessionQualityInfo(itemInfo)
@@ -284,10 +315,20 @@ function CDMSources.QueryBestOwnedItemVariant(itemID)
 end
 
 local _C_GetItemCooldown = C_Item and C_Item.GetItemCooldown
+local _C_Container_GetItemCooldown = C_Container and C_Container.GetItemCooldown
 
 function CDMSources.QueryItemCooldown(itemID)
-    if not itemID or not _C_GetItemCooldown then return nil end
-    return _C_GetItemCooldown(itemID)
+    if not itemID then return nil end
+    if _C_Container_GetItemCooldown then
+        local startTime, duration, enabled = _C_Container_GetItemCooldown(itemID)
+        if type(startTime) ~= "nil" or type(duration) ~= "nil" or type(enabled) ~= "nil" then
+            return startTime, duration, enabled
+        end
+    end
+    if _C_GetItemCooldown then
+        return _C_GetItemCooldown(itemID)
+    end
+    return nil
 end
 
 local function QueryScannerActive(scanner, spellID, itemID)

--- a/QUI_CDM/cdm/cdm_spelldata.lua
+++ b/QUI_CDM/cdm/cdm_spelldata.lua
@@ -1706,13 +1706,11 @@ local function GetContainerDB(containerKey)
 
     local ncdm = GetNcdmDB()
     if not ncdm then return nil end
-    if ncdm[containerKey] then
+    if Shared and ((Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(containerKey))
+        or (Shared.GetBuiltinContainerEntryKind and Shared.GetBuiltinContainerEntryKind(containerKey))) then
         return ncdm[containerKey]
     end
-    if ncdm.containers and ncdm.containers[containerKey] then
-        return ncdm.containers[containerKey]
-    end
-    return nil
+    return ncdm.containers and ncdm.containers[containerKey] or nil
 end
 
 local function NormalizeOwnedEntry(entry)
@@ -2779,16 +2777,11 @@ function CDMSpellData:CheckAllDormantSpells()
 end
 
 function CDMSpellData:GetSpecEntries(containerKey, specKey)
-    local list = GetSpecEntryList(containerKey, specKey, false)
-    if type(list) == "table" then
-        return list
-    end
-
     local db = GetContainerDB(containerKey)
     if type(db) == "table" and db.specSpecific then
-        return MoveLegacySpecEntriesToPerSpecStorage(containerKey, db)
+        MoveLegacySpecEntriesToPerSpecStorage(containerKey, db)
     end
-    return list
+    return GetSpecEntryList(containerKey, specKey, false)
 end
 
 function CDMSpellData:OnSpecSpecificToggled(containerKey)

--- a/QUI_CDM/cdm/settings/composer.lua
+++ b/QUI_CDM/cdm/settings/composer.lua
@@ -221,13 +221,11 @@ GetContainerDB = function(containerKey)
 
     local ncdm = GetNcdmDB()
     if not ncdm then return nil end
-    if ncdm[containerKey] then
+    if Shared and ((Shared.IsBuiltinContainerKey and Shared.IsBuiltinContainerKey(containerKey))
+        or (Shared.GetBuiltinContainerEntryKind and Shared.GetBuiltinContainerEntryKind(containerKey))) then
         return ncdm[containerKey]
     end
-    if ncdm.containers and ncdm.containers[containerKey] then
-        return ncdm.containers[containerKey]
-    end
-    return nil
+    return ncdm.containers and ncdm.containers[containerKey] or nil
 end
 
 local function GetCDMSpellData()

--- a/QUI_CDM/cdm/settings/containers_page.lua
+++ b/QUI_CDM/cdm/settings/containers_page.lua
@@ -420,7 +420,10 @@ local function ResolveTrackerDB(containerKey)
         return nil
     end
 
-    return ncdm[containerKey] or (ncdm.containers and ncdm.containers[containerKey]) or nil
+    if IsBuiltIn(containerKey) then
+        return ncdm[containerKey]
+    end
+    return ncdm.containers and ncdm.containers[containerKey] or nil
 end
 
 local function RefreshKeybinds()

--- a/QUI_Debug/cdm_debug.lua
+++ b/QUI_Debug/cdm_debug.lua
@@ -71,15 +71,24 @@ local function EventTraceGetItemUseSpellID(itemID)
 end
 
 local function EventTraceIsItemLikeEntry(entry)
-    return entry and (entry.type == "item" or entry.type == "trinket" or entry.type == "slot")
+    return entry and (entry.type == "item" or entry.type == "trinket"
+        or entry.type == "slot" or entry.type == "consumable")
 end
 
 local function EventTraceResolveItemCooldownIdentity(entry)
     if not entry then return nil, nil, nil, nil end
 
-    local itemID, slotID
+    local itemID, slotID, categorySpellID
     if entry.type == "item" then
         itemID = entry.id
+    elseif entry.type == "consumable" then
+        if Sources and Sources.QueryLastCategoryCooldownSource then
+            categorySpellID, itemID = Sources.QueryLastCategoryCooldownSource(entry.id)
+        end
+        itemID = itemID
+            or (ns.CDMCatalog and ns.CDMCatalog.GetConsumableCategoryItemID
+                and ns.CDMCatalog.GetConsumableCategoryItemID(entry.id))
+            or entry.itemID
     elseif entry.type == "trinket" or entry.type == "slot" then
         slotID = entry.id
         if Sources and Sources.QueryInventoryItemID then
@@ -95,7 +104,7 @@ local function EventTraceResolveItemCooldownIdentity(entry)
 
     if not itemID then return nil, slotID, nil, nil end
 
-    local itemSpellID = EventTraceGetItemUseSpellID(itemID)
+    local itemSpellID = categorySpellID or EventTraceGetItemUseSpellID(itemID)
     local keySource = slotID and (tostring(slotID) .. ":" .. tostring(itemID)) or tostring(itemID)
     return itemID, slotID, itemSpellID, keySource
 end
@@ -209,6 +218,14 @@ local function EventTraceEntryMatches(targetID, entry)
     if CDMIcons.EventTraceSpellIDMatches(targetID, entry.spellID) then return true end
     if CDMIcons.EventTraceSpellIDMatches(targetID, entry.id) then return true end
     if CDMIcons.EventTraceSpellIDMatches(targetID, entry.itemID) then return true end
+    if entry.type == "consumable"
+        and Sources and Sources.QueryLastCategoryCooldownSource then
+        local sourceSpellID, sourceItemID = Sources.QueryLastCategoryCooldownSource(entry.id)
+        if CDMIcons.EventTraceSpellIDMatches(targetID, sourceSpellID)
+            or CDMIcons.EventTraceSpellIDMatches(targetID, sourceItemID) then
+            return true
+        end
+    end
     if type(entry.linkedSpellIDs) == "table" then
         for _, linkedID in ipairs(entry.linkedSpellIDs) do
             if CDMIcons.EventTraceSpellIDMatches(targetID, linkedID) then return true end
@@ -256,9 +273,7 @@ local function EventTraceHasItemOrSlotCooldownIconForTarget(targetID)
         for _, icon in ipairs(pool) do
             if CDMIcons.EventTraceIconMatches(icon, targetID) then
                 local entry = icon._spellEntry
-                if entry and (entry.type == "item"
-                              or entry.type == "trinket"
-                              or entry.type == "slot"
+                if entry and (EventTraceIsItemLikeEntry(entry)
                               or entry.kind == "item-cooldown"
                               or entry.itemID) then
                     return true
@@ -520,6 +535,9 @@ function CDMIcons.EventTraceIconWriteState(icon)
         end
     end
 
+    local stackText = icon.StackText and icon.StackText.GetText
+        and icon.StackText.GetText(icon.StackText)
+
     local probeNumeric = ProbeNumeric
     local cdStart, cdDur = "nil", "nil"
     if baseSid and Sources and Sources.QuerySpellCooldown then
@@ -552,7 +570,7 @@ function CDMIcons.EventTraceIconWriteState(icon)
         tostring(icon._activeAuraSpellID),
         qChg, qDur, qChgO, qDurO,
         cdStart, cdDur,
-        CDMIcons.EventTraceValue(icon.stackText),
+        CDMIcons.EventTraceValue(stackText),
         tostring(icon._stackTextSource),
         eMaxCharges)
 end
@@ -562,7 +580,23 @@ function CDMIcons.EventTraceAPISummary(spellID)
     local chargeActive, currentCharges, maxCharges = nil, nil, nil
     local usable, resourceBlocked = nil, nil
     local itemStart, itemDuration, itemEnabled = nil, nil, nil
-    local itemSpellID = EventTraceGetItemUseSpellID(spellID)
+    local itemID, itemSpellID, matchedConsumable
+    for _, pool in pairs(iconPools) do
+        for _, icon in ipairs(pool) do
+            local entry = icon and icon._spellEntry
+            if entry and entry.type == "consumable"
+                and CDMIcons.EventTraceIconMatches(icon, spellID) then
+                matchedConsumable = true
+                itemID, _, itemSpellID = EventTraceResolveItemCooldownIdentity(entry)
+                break
+            end
+        end
+        if matchedConsumable then break end
+    end
+    if not matchedConsumable then
+        itemID = spellID
+        itemSpellID = EventTraceGetItemUseSpellID(itemID)
+    end
     local itemSpellCdActive, itemSpellCdOnGCD = nil, nil
 
     if Sources and Sources.QuerySpellCooldown then
@@ -571,7 +605,7 @@ function CDMIcons.EventTraceAPISummary(spellID)
             cdActive = EventTraceCooldownInfoField(cdInfo, "isActive")
             cdOnGCD = cdInfo.isOnGCD
         end
-        if itemSpellID then
+        if itemSpellID and itemSpellID ~= spellID then
             local itemSpellCdInfo = Sources.QuerySpellCooldown(itemSpellID)
             if itemSpellCdInfo then
                 itemSpellCdActive = EventTraceCooldownInfoField(itemSpellCdInfo, "isActive")
@@ -593,14 +627,14 @@ function CDMIcons.EventTraceAPISummary(spellID)
         resourceBlocked = isResourceBlocked
     end
     if Sources and Sources.QueryItemCooldown then
-        local startTime, duration, enabled = Sources.QueryItemCooldown(spellID)
+        local startTime, duration, enabled = Sources.QueryItemCooldown(itemID)
         itemStart = startTime
         itemDuration = duration
         itemEnabled = enabled
     end
 
     return string.format(
-        "api cdActive=%s isOnGCD=%s charges=%s/%s chargeActive=%s usable=%s resourceBlocked=%s itemCd=%s/%s/%s itemSpell=%s itemSpellCd=%s/%s",
+        "api cdActive=%s isOnGCD=%s charges=%s/%s chargeActive=%s usable=%s resourceBlocked=%s itemID=%s itemCd=%s/%s/%s itemSpell=%s itemSpellCd=%s/%s",
         CDMIcons.EventTraceValue(cdActive),
         CDMIcons.EventTraceValue(cdOnGCD),
         CDMIcons.EventTraceValue(currentCharges),
@@ -608,6 +642,7 @@ function CDMIcons.EventTraceAPISummary(spellID)
         CDMIcons.EventTraceValue(chargeActive),
         CDMIcons.EventTraceValue(usable),
         CDMIcons.EventTraceValue(resourceBlocked),
+        CDMIcons.EventTraceValue(itemID),
         CDMIcons.EventTraceValue(itemStart),
         CDMIcons.EventTraceValue(itemDuration),
         CDMIcons.EventTraceValue(itemEnabled),
@@ -1373,6 +1408,17 @@ local function CDMGCDFirstID(...)
     return nil
 end
 
+local function CDMGCDResolveProbeSpellID(icon, entry)
+    local _, _, itemSpellID = EventTraceResolveItemCooldownIdentity(entry)
+    return CDMGCDFirstID(
+        entry and entry.type == "consumable" and itemSpellID or nil,
+        icon and icon._runtimeSpellID,
+        entry and entry.overrideSpellID,
+        entry and entry.spellID,
+        entry and entry.id,
+        entry and entry.itemID)
+end
+
 local function CDMGCDCall(owner, methodName)
     if not (owner and owner[methodName]) then
         return "n/a"
@@ -1410,10 +1456,7 @@ local function CDMGCDIconMatches(icon, needle, targetID)
     if not entry then return false end
     if targetID then
         if CDMGCDIDMatches(icon._runtimeSpellID, targetID)
-            or CDMGCDIDMatches(entry.overrideSpellID, targetID)
-            or CDMGCDIDMatches(entry.spellID, targetID)
-            or CDMGCDIDMatches(entry.id, targetID)
-            or CDMGCDIDMatches(entry.itemID, targetID) then
+            or EventTraceEntryMatches(targetID, entry) then
             return true
         end
 
@@ -1507,12 +1550,7 @@ local function CDMGCDPrintWatchSample(elapsed, needle, targetID)
             if CDMGCDIconMatches(icon, needle, targetID) then
                 matches = matches + 1
                 local entry = icon._spellEntry
-                local sid = CDMGCDFirstID(
-                    icon._runtimeSpellID,
-                    entry.overrideSpellID,
-                    entry.spellID,
-                    entry.id,
-                    entry.itemID)
+                local sid = CDMGCDResolveProbeSpellID(icon, entry)
                 local cdInfo = sid and Sources and Sources.QuerySpellCooldown
                     and Sources.QuerySpellCooldown(sid)
                 local cdActive = cdInfo and EventTraceCooldownInfoField(cdInfo, "isActive")
@@ -1635,12 +1673,7 @@ local function RunCDMDebugGCD(msg)
             if CDMGCDIconMatches(icon, needle, targetID) then
                 matches = matches + 1
                 local entry = icon._spellEntry
-                local sid = CDMGCDFirstID(
-                    icon._runtimeSpellID,
-                    entry.overrideSpellID,
-                    entry.spellID,
-                    entry.id,
-                    entry.itemID)
+                local sid = CDMGCDResolveProbeSpellID(icon, entry)
                 local cdInfo = sid and Sources and Sources.QuerySpellCooldown
                     and Sources.QuerySpellCooldown(sid)
                 local cdActive = cdInfo and EventTraceCooldownInfoField(cdInfo, "isActive")
@@ -1659,11 +1692,16 @@ local function RunCDMDebugGCD(msg)
                 if sid and Sources and Sources.QuerySpellUsable then
                     usable, resourceBlocked = Sources.QuerySpellUsable(sid)
                 end
+                local itemID = select(1, EventTraceResolveItemCooldownIdentity(entry))
+                local itemUsable = itemID and Sources and Sources.QueryItemUsable
+                    and Sources.QueryItemUsable(itemID)
                 local resolvedState = CDMGCDResolveCooldownState(icon)
                 local durObj = resolvedState and resolvedState.durObj
                 local mode = resolvedState and resolvedState.mode
                 local sourceID = resolvedState and resolvedState.sourceID
                 local cd = icon.Cooldown
+                local containerDB = ns.CDMShared and ns.CDMShared.GetContainerDB
+                    and ns.CDMShared.GetContainerDB(entry.viewerType)
 
                 print(string.format(
                     "|cff34d399[cdmgcd]|r #%d %s sid=%s viewer=%s kind=%s type=%s shown=%s",
@@ -1675,11 +1713,13 @@ local function RunCDMDebugGCD(msg)
                     CDMGCDValue(entry.type),
                     CDMGCDCall(icon, "IsShown")))
                 print(string.format(
-                    "|cff34d399[cdmgcd]|r api isActive=%s isOnGCD=%s usable=%s resourceBlocked=%s gcdDur=%s realDur=%s chargeDur=%s chargeActive=%s maxCharges=%s",
+                    "|cff34d399[cdmgcd]|r api isActive=%s isOnGCD=%s usable=%s resourceBlocked=%s itemID=%s itemUsable=%s gcdDur=%s realDur=%s chargeDur=%s chargeActive=%s maxCharges=%s",
                     CDMGCDValue(cdActive),
                     CDMGCDValue(cdOnGCD),
                     CDMGCDValue(usable),
                     CDMGCDValue(resourceBlocked),
+                    CDMGCDValue(itemID),
+                    CDMGCDValue(itemUsable),
                     CDMGCDValue(gcdDur),
                     CDMGCDValue(realDur),
                     CDMGCDValue(chargeDur),
@@ -1693,12 +1733,16 @@ local function RunCDMDebugGCD(msg)
                     tostring(icon._resolvedCooldownMode),
                     tostring(icon._lastDurObjKey)))
                 print(string.format(
-                    "|cff34d399[cdmgcd]|r icon showingGCD=%s showingReal=%s hasReal=%s hasCooldown=%s aura=%s",
+                    "|cff34d399[cdmgcd]|r icon showingGCD=%s showingReal=%s hasReal=%s hasCooldown=%s aura=%s usabilitySetting=%s visualState=%s usabilityTinted=%s rangeTinted=%s",
                     tostring(icon._showingGCDSwipe),
                     tostring(icon._showingRealCooldownSwipe),
                     tostring(icon._hasRealCooldownActive),
                     tostring(icon._hasCooldownActive),
-                    tostring(icon._auraActive)))
+                    tostring(icon._auraActive),
+                    CDMGCDValue(containerDB and containerDB.usabilityIndicator),
+                    tostring(icon._lastVisualState),
+                    tostring(icon._usabilityTinted),
+                    tostring(icon._rangeTinted)))
                 print(string.format(
                     "|cff34d399[cdmgcd]|r cooldown drawSwipe=%s intendedDrawSwipe=%s drawEdge=%s intendedDrawEdge=%s color=%s",
                     CDMGCDCall(cd, "GetDrawSwipe"),
@@ -3238,12 +3282,7 @@ local function FindDebugTargetID(target)
             local entry = icon and icon._spellEntry
             local name = entry and entry.name
             if type(name) == "string" and name:lower():find(needle, 1, true) then
-                return CDMGCDFirstID(
-                    icon._runtimeSpellID,
-                    entry.overrideSpellID,
-                    entry.spellID,
-                    entry.id,
-                    entry.itemID)
+                return CDMGCDResolveProbeSpellID(icon, entry)
             end
         end
     end

--- a/core/migrations.lua
+++ b/core/migrations.lua
@@ -7,7 +7,7 @@ if _G.QUI then _G.QUI.Migrations = Migrations end
 local _currentGlobalDB     = nil
 local _currentProfileKey   = nil
 
-local CURRENT_SCHEMA_VERSION = 61
+local CURRENT_SCHEMA_VERSION = 62
 
 local MIN_SUPPORTED_SCHEMA = 47
 
@@ -737,6 +737,26 @@ function Migrations.PurgeOrphanContainerSatellites(profile)
     end
 
     return true
+end
+
+function Migrations.PurgeLegacyCustomBarShadowStores(profile)
+    local ncdm = profile and profile.ncdm
+    local containers = ncdm and ncdm.containers
+    if type(ncdm) ~= "table" or type(containers) ~= "table" then return false end
+
+    local toRemove = {}
+    for key in pairs(ncdm) do
+        if type(key) == "string"
+            and (key:find("^custom_") or key:find("^customBar_"))
+            and type(containers[key]) == "table"
+        then
+            toRemove[#toRemove + 1] = key
+        end
+    end
+    for _, key in ipairs(toRemove) do
+        ncdm[key] = nil
+    end
+    return #toRemove > 0
 end
 
 local CUSTOM_TRACKER_ANCHOR_PREFIX = "customTracker:"
@@ -1613,6 +1633,8 @@ function Migrations.RunOnProfile(profile)
         end
 
         Migrations.FoldDefensiveIndicatorIntoElements(profile)
+
+        Migrations.PurgeLegacyCustomBarShadowStores(profile)
 
         Migrations.PurgeOrphanContainerSatellites(profile)
     end

--- a/core/migrations.lua
+++ b/core/migrations.lua
@@ -754,6 +754,7 @@ function Migrations.PurgeLegacyCustomBarShadowStores(profile)
         end
     end
     for _, key in ipairs(toRemove) do
+        containers[key] = ncdm[key]
         ncdm[key] = nil
     end
     return #toRemove > 0

--- a/modules/utility/consumablemacros.lua
+++ b/modules/utility/consumablemacros.lua
@@ -363,6 +363,28 @@ for _, slot in ipairs(MACRO_SLOTS) do
     DEFS_BY_DBKEY[slot.dbKey] = slot.defs
 end
 
+local CATEGORY_ITEM_SOURCES = {
+    [4] = { defs = POTION_DEFS, options = ConsumableMacros.POTION_OPTIONS },
+    [30] = { defs = HEALTH_DEFS, options = ConsumableMacros.HEALTH_OPTIONS },
+}
+local categoryItemCandidates = {}
+
+function ConsumableMacros.GetCategoryItemCandidates(categoryID)
+    local cached = categoryItemCandidates[categoryID]
+    if cached then return cached end
+    local source = CATEGORY_ITEM_SOURCES[categoryID]
+    if not source then return nil end
+    local result = {}
+    for _, option in ipairs(source.options) do
+        local def = source.defs[option.value]
+        for _, variant in ipairs(def and def.variants or {}) do
+            result[#result + 1] = variant.itemID
+        end
+    end
+    categoryItemCandidates[categoryID] = result
+    return result
+end
+
 function ConsumableMacros.GetSelectedItem(dbKey)
     local db = GetDB and GetDB()
     if not db then return nil end

--- a/tests/fixtures/current/basic_fresh/expected.sv.lua
+++ b/tests/fixtures/current/basic_fresh/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         quiUnitFrames = {
           focus = {
             castbar = {

--- a/tests/fixtures/current/basic_fresh/invariants.lua
+++ b/tests/fixtures/current/basic_fresh/invariants.lua
@@ -7,7 +7,7 @@ return {
         name = "_schemaVersion is at current value",
         assert = function(sv, ctx)
             local p = sv.QUI_DB.profiles.Default
-            return p._schemaVersion == 61  -- bump when CURRENT_SCHEMA_VERSION changes
+            return p._schemaVersion == 62  -- bump when CURRENT_SCHEMA_VERSION changes
         end,
     },
     {

--- a/tests/fixtures/current/cdm_item_auraonly_override/expected.sv.lua
+++ b/tests/fixtures/current/cdm_item_auraonly_override/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         ncdm = {
           containers = {
             ["customBar:mybar"] = {

--- a/tests/fixtures/current/cdm_item_in_buff_container/expected.sv.lua
+++ b/tests/fixtures/current/cdm_item_in_buff_container/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         ncdm = {
           buff = {
             ownedSpells = {

--- a/tests/fixtures/current/channel-colors/expected.sv.lua
+++ b/tests/fixtures/current/channel-colors/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         chat = {
           channelColors = {
             RAID = {

--- a/tests/fixtures/current/damage_meter_appearance_default/expected.sv.lua
+++ b/tests/fixtures/current/damage_meter_appearance_default/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         quiUnitFrames = {
           focus = {
             castbar = {

--- a/tests/fixtures/current/damage_meter_appearance_set/expected.sv.lua
+++ b/tests/fixtures/current/damage_meter_appearance_set/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         damageMeter = {
           appearance = {
             global = {

--- a/tests/fixtures/current/damage_meter_set_default/expected.sv.lua
+++ b/tests/fixtures/current/damage_meter_set_default/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         quiUnitFrames = {
           focus = {
             castbar = {

--- a/tests/fixtures/current/damage_meter_set_default/invariants.lua
+++ b/tests/fixtures/current/damage_meter_set_default/invariants.lua
@@ -25,7 +25,7 @@ return {
     {
         name = "schema migrated to current version",
         assert = function(sv, ctx)
-            return sv.QUI_DB.profiles.Default._schemaVersion == 61
+            return sv.QUI_DB.profiles.Default._schemaVersion == 62
         end,
     },
 }

--- a/tests/fixtures/current/fresh_install_seed/expected.sv.lua
+++ b/tests/fixtures/current/fresh_install_seed/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         actionBars = {
           bars = {
             bags = {

--- a/tests/fixtures/current/fresh_install_seed/invariants.lua
+++ b/tests/fixtures/current/fresh_install_seed/invariants.lua
@@ -28,7 +28,7 @@ return {
     {
         name = "_schemaVersion stamped at current value after seed",
         assert = function(sv, ctx)
-            return sv.QUI_DB.profiles.Default._schemaVersion == 61
+            return sv.QUI_DB.profiles.Default._schemaVersion == 62
         end,
     },
 }

--- a/tests/fixtures/current/skin_damage_meter_default/expected.sv.lua
+++ b/tests/fixtures/current/skin_damage_meter_default/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         quiUnitFrames = {
           focus = {
             castbar = {

--- a/tests/fixtures/current/skin_damage_meter_default/invariants.lua
+++ b/tests/fixtures/current/skin_damage_meter_default/invariants.lua
@@ -14,7 +14,7 @@ return {
             local p = sv.QUI_DB.profiles.Default
             -- Match basic_fresh's pinned schema version. Bump in lockstep when
             -- CURRENT_SCHEMA_VERSION changes. See tests/fixtures/current/basic_fresh/invariants.lua line 10.
-            return p._schemaVersion == 61
+            return p._schemaVersion == 62
         end,
     },
 }

--- a/tests/fixtures/edge/empty_composer/expected.sv.lua
+++ b/tests/fixtures/edge/empty_composer/expected.sv.lua
@@ -8368,7 +8368,7 @@ return {
       Default = {
         _defaultsVersion = 3,
         _needsLateAbImport = true,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         ncdm = {
           buff = {
             ownedSpells = {}

--- a/tests/fixtures/edge/idempotency_check/expected.sv.lua
+++ b/tests/fixtures/edge/idempotency_check/expected.sv.lua
@@ -8367,7 +8367,7 @@ return {
     profiles = {
       Default = {
         _defaultsVersion = 3,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         cdm = {
           engine = "owned"
         },

--- a/tests/fixtures/edge/idempotency_check/invariants.lua
+++ b/tests/fixtures/edge/idempotency_check/invariants.lua
@@ -7,7 +7,7 @@ return {
     {
         name = "_schemaVersion stays at CURRENT after re-run",
         assert = function(sv, ctx)
-            return sv.QUI_DB.profiles.Default._schemaVersion == 61
+            return sv.QUI_DB.profiles.Default._schemaVersion == 62
         end,
     },
     {

--- a/tests/fixtures/edge/migration_backup_present/expected.sv.lua
+++ b/tests/fixtures/edge/migration_backup_present/expected.sv.lua
@@ -8367,7 +8367,7 @@ return {
     profiles = {
       Default = {
         _defaultsVersion = 3,
-        _schemaVersion = 61,
+        _schemaVersion = 62,
         quiUnitFrames = {
           focus = {
             castbar = {

--- a/tests/unit/cdm_catalog_test.lua
+++ b/tests/unit/cdm_catalog_test.lua
@@ -21,6 +21,9 @@ local loadChunk = dofile("tests/helpers/load_cdm_consolidated_chunk.lua")
 local chunk = loadChunk("QUI_CDM/cdm/cdm_catalog.lua", "cdm_catalog.lua")
 chunk("QUI", ns)
 
+assert(ns.CDMCatalog.GetConsumableCategoryItemID(1711) == 5512,
+    "Healthstone category should expose Blizzard's tooltip item fallback")
+
 ns.CDMSources = {
     QuerySpellInfo = function(spellID)
         if spellID == 12345 then

--- a/tests/unit/cdm_containers_api_builtin_precedence_test.lua
+++ b/tests/unit/cdm_containers_api_builtin_precedence_test.lua
@@ -1,0 +1,38 @@
+local file = assert(io.open("QUI_CDM/cdm/cdm_containers.lua", "rb"))
+local source = file:read("*a")
+file:close()
+
+local startAt = assert(source:find("function CDMContainers_API:GetContainers()", 1, true))
+local endAt = assert(source:find("function CDMContainers_API:CreateContainer", startAt, true))
+local apiSource = source:sub(startAt, endAt - 1)
+
+local activeEssential = { containerType = "cooldown", marker = "active" }
+local staleEssential = { containerType = "cooldown", marker = "stale" }
+local custom = { containerType = "customBar", marker = "custom" }
+local db = {
+    essential = activeEssential,
+    containers = {
+        essential = staleEssential,
+        custom = custom,
+    },
+}
+
+local chunk = assert(loadstring([[
+local db = ...
+local BUILTIN_KEYS = { "essential", "utility", "buff", "trackedBar" }
+local BUILTIN_NAMES = { essential = true, utility = true, buff = true, trackedBar = true }
+local CDMContainers_API = {}
+local function GetDB() return db end
+local Shared = { IsBuiltinContainerKey = function(key) return BUILTIN_NAMES[key] == true end }
+]] .. apiSource .. [[
+return CDMContainers_API
+]], "@cdm_containers_api"))
+local api = chunk(db)
+local containers = api:GetContainers()
+
+assert(containers[1].key == "essential" and containers[1].settings == activeEssential)
+assert(containers[2].key == "custom" and containers[2].settings == custom)
+assert(api:GetContainerSettings("essential") == activeEssential)
+assert(api:GetContainersByType("cooldown")[1].settings == activeEssential)
+
+print("OK: cdm_containers_api_builtin_precedence_test")

--- a/tests/unit/cdm_debug_gcd_probe_test.lua
+++ b/tests/unit/cdm_debug_gcd_probe_test.lua
@@ -47,7 +47,7 @@ print = function(...)
 end
 
 local icon = {
-    _runtimeSpellID = 12345,
+    _runtimeSpellID = 1711,
     _showingGCDSwipe = true,
     _showingRealCooldownSwipe = nil,
     _hasRealCooldownActive = false,
@@ -55,11 +55,10 @@ local icon = {
     _resolvedCooldownMode = "gcd-only",
     _spellEntry = {
         name = "Debug Spell",
-        id = 12345,
-        spellID = 12345,
+        id = 1711,
         viewerType = "essential",
         kind = "cooldown",
-        type = "spell",
+        type = "consumable",
     },
     Cooldown = {
         _quiIntendedDrawSwipe = true,
@@ -72,6 +71,17 @@ local icon = {
 }
 
 local ns = {
+    CDMCatalog = {
+        GetConsumableCategoryItemID = function(categoryID)
+            assert(categoryID == 1711)
+            return 5512
+        end,
+    },
+    CDMShared = {
+        GetContainerDB = function()
+            return { usabilityIndicator = true }
+        end,
+    },
     CDMIcons = {
         IsRuntimeEnabled = function() return true end,
         ResolveCooldownState = function()
@@ -80,8 +90,8 @@ local ns = {
                 active = true,
                 isActive = true,
                 durObj = { token = "gcd" },
-                sourceID = 12345,
-                spellID = 12345,
+                sourceID = 6262,
+                spellID = 6262,
             }
         end,
         GetCooldownInfoField = function(info, key)
@@ -95,6 +105,10 @@ local ns = {
         },
     },
     CDMSources = {
+        QueryLastCategoryCooldownSource = function(categoryID)
+            assert(categoryID == 1711)
+            return 6262, nil
+        end,
         QuerySpellCooldown = function()
             return { isActive = true, isOnGCD = true }
         end,
@@ -106,6 +120,14 @@ local ns = {
         end,
         QuerySpellCharges = function()
             return nil
+        end,
+        QueryItemUsable = function(itemID)
+            assert(itemID == 5512, "debug probe should query the consumable item identity")
+            return true, false
+        end,
+        QueryItemCooldown = function(itemID)
+            assert(itemID == 5512, "API summary should query the catalog fallback item")
+            return 300, 60, 1
         end,
     },
     _OwnedSwipe = {
@@ -121,6 +143,12 @@ local ns = {
 assert(loadfile("QUI_Debug/cdm_debug.lua"))("QUI_Debug", ns)
 assert(SlashCmdList["QUI_CDMDEBUG"], "/cdmdebug should be registered")
 assert(SlashCmdList["CDMGCD"] == nil, "legacy /cdmgcd command should not be registered")
+ns.CDMIcons._eventTraceSpellID = 1711
+assert(ns.CDMIcons.EventTraceShouldPrintFrameEvent("BAG_UPDATE_COOLDOWN") == true,
+    "consumable categories should retain bag cooldown event traces")
+local apiSummary = ns.CDMIcons.EventTraceAPISummary(1711)
+assert(apiSummary:find("itemID=5512", 1, true),
+    "API summary should report the catalog fallback item identity")
 
 SlashCmdList["QUI_CDMDEBUG"]("spell Debug Spell")
 
@@ -128,10 +156,14 @@ print = originalPrint
 
 local output = table.concat(lines, "\n")
 assert(output:find("settings", 1, true), "/cdmdebug spell should print swipe settings")
+assert(output:find("sid=6262", 1, true), "/cdmdebug spell should probe the category source spell")
 assert(output:find("api", 1, true), "/cdmdebug spell should print cooldown API state")
+assert(output:find("itemID=5512 itemUsable=true", 1, true), "/cdmdebug spell should print item usability state")
 assert(output:find("resolver", 1, true), "/cdmdebug spell should print resolver output")
 assert(output:find("resolver mode=gcd%-only"), "/cdmdebug spell should preserve resolver mode return value")
 assert(output:find("icon", 1, true), "/cdmdebug spell should print icon flags")
+assert(output:find("usabilitySetting=true", 1, true), "/cdmdebug spell should print the container usability setting")
+assert(output:find("usabilityTinted=", 1, true), "/cdmdebug spell should print the applied usability tint state")
 assert(output:find("cooldown", 1, true), "/cdmdebug spell should print cooldown frame draw state")
 
 originalPrint("OK: cdm_debug_gcd_probe_test")

--- a/tests/unit/cdm_gcd_refresh_state_test.lua
+++ b/tests/unit/cdm_gcd_refresh_state_test.lua
@@ -124,6 +124,9 @@ local ns = {
             assert(itemID == 5512, "consumable usability should query item 5512")
             return healthstoneItemUsable, false
         end,
+        QueryConsumableCategoryItem = function(categoryID)
+            return categoryID == 1711 and 5512 or nil
+        end,
         QuerySpellCooldown = function()
             return { isActive = currentOnGCD, isOnGCD = currentOnGCD }
         end,

--- a/tests/unit/cdm_gcd_refresh_state_test.lua
+++ b/tests/unit/cdm_gcd_refresh_state_test.lua
@@ -10,6 +10,7 @@ local subscriptions = {}
 local currentOnGCD = false
 local gcdQueryable = false
 local gcdDuration = { token = "gcd-duration" }
+local healthstoneItemUsable = true
 
 function InCombatLockdown() return false end
 function GetTime() return 100 end
@@ -114,10 +115,14 @@ local ns = {
     },
     CDMSources = {
         QuerySpellUsable = function(spellID)
-            if spellID == 11111 then
+            if spellID == 11111 or spellID == 6262 then
                 return false, false
             end
             return true, false
+        end,
+        QueryItemUsable = function(itemID)
+            assert(itemID == 5512, "consumable usability should query item 5512")
+            return healthstoneItemUsable, false
         end,
         QuerySpellCooldown = function()
             return { isActive = currentOnGCD, isOnGCD = currentOnGCD }
@@ -203,8 +208,15 @@ factory:EnsurePool("essential")
 local pool = factory:GetIconPool("essential")
 local first = makeIcon(11111)
 local second = makeIcon(22222)
+local healthstone = makeIcon(1711)
+healthstone._spellEntry.type = "consumable"
+healthstone._spellEntry.spellID = nil
+healthstone._spellEntry.overrideSpellID = nil
+healthstone._spellEntry.itemID = 5512
+healthstone._runtimeSpellID = 6262
 pool[#pool + 1] = first
 pool[#pool + 1] = second
+pool[#pool + 1] = healthstone
 
 -- _showingGCDSwipe is the icon-local GCD render lock. (The former _isOnGCD
 -- icon field is gone: isOnGCD is now read directly off cdInfo by the resolver,
@@ -233,6 +245,18 @@ assert(first._usabilityTinted == true, "SPELL_UPDATE_USABLE should immediately a
 local firstColor = first.vertexColors[#first.vertexColors]
 assert(firstColor and firstColor[1] == 0.4 and firstColor[2] == 0.4 and firstColor[3] == 0.4 and firstColor[4] == 1,
     "SPELL_UPDATE_USABLE should darken unusable icons without waiting for the range poll")
+assert(healthstone._usabilityTinted == nil,
+    "an item-usable Healthstone should not inherit runtime spell 6262's unusable state")
+
+healthstoneItemUsable = false
+icons.HandleRuntimeRefresh("SPELL_UPDATE_USABLE")
+
+assert(healthstone._usabilityTinted == true,
+    "an unusable Healthstone item should darken its category icon")
+local healthstoneColor = healthstone.vertexColors[#healthstone.vertexColors]
+assert(healthstoneColor and healthstoneColor[1] == 0.4 and healthstoneColor[2] == 0.4
+        and healthstoneColor[3] == 0.4 and healthstoneColor[4] == 1,
+    "an unusable Healthstone item should darken the category item icon")
 
 currentOnGCD = true
 gcdQueryable = true

--- a/tests/unit/cdm_icon_custom_bar_policy_test.lua
+++ b/tests/unit/cdm_icon_custom_bar_policy_test.lua
@@ -258,6 +258,12 @@ end
 assert(policy:ResolveUsability({ type = "item", id = 201 }, trackerSettings.custom, nil) == true,
     "secret item counts should be treated as usable instead of compared in Lua")
 
+sources.QueryLastCategoryCooldownSource = function() return 777, 301 end
+sources.QueryConsumableCategoryItem = function() return 302 end
+sources.QueryItemCount = function(itemID) return itemID == 302 and 1 or 0 end
+assert(policy:ResolveUsability({ type = "consumable", id = 4, itemID = 301 }, trackerSettings.custom, nil) == true,
+    "consumable usability should follow the owned item instead of a depleted recent source")
+
 sources.QueryItemSpell = function(itemID)
     if itemID == 301 then return "Item Spell", 777 end
     if itemID == 302 then return "Item Spell", 778 end

--- a/tests/unit/cdm_icon_item_visual_policy_test.lua
+++ b/tests/unit/cdm_icon_item_visual_policy_test.lua
@@ -6,10 +6,10 @@ local loadChunk = dofile("tests/helpers/load_cdm_consolidated_chunk.lua")
 loadChunk("QUI_CDM/cdm/cdm_icon_policies.lua", "cdm_icon_item_visual_policy.lua")("QUI", ns)
 local module = assert(ns.CDMIconItemVisualPolicy, "item visual policy module should be exported")
 
-local ncdm = {
-    variantItem = {},
-    slot = {},
-}
+local ncdm = { containers = {} }
+local variantItem = {}
+ncdm.containers.variantItem = variantItem
+ncdm.containers.slot = {}
 local bestOwnedItemID = 1001
 local secureUpdates = {}
 
@@ -142,7 +142,7 @@ assert(slotTextureWrites[#slotTextureWrites] == "slot-texture",
 assert(slotOverlay.atlas == "slot-atlas",
     "slot visual refresh should update the inventory item quality overlay")
 
-ncdm.variantItem.showProfessionQuality = false
+variantItem.showProfessionQuality = false
 controller:UpdateProfessionQuality(itemIcon)
 assert(overlayState.shown == false,
     "profession quality overlay should hide when the container disables it")

--- a/tests/unit/cdm_icon_range_item_usability_cache_test.lua
+++ b/tests/unit/cdm_icon_range_item_usability_cache_test.lua
@@ -1,0 +1,48 @@
+local function wipeTable(tbl)
+    for key in pairs(tbl) do tbl[key] = nil end
+end
+
+wipe = wipeTable
+UnitExists = function() return false end
+
+local ns = {}
+local loadChunk = dofile("tests/helpers/load_cdm_consolidated_chunk.lua")
+loadChunk("QUI_CDM/cdm/cdm_icon_policies.lua", "cdm_icon_range_policy.lua")("QUI", ns)
+
+local spellQueries = 0
+local itemQueries = 0
+local controller = assert(ns.CDMIconRangePolicy).Create({
+    resolveSettings = function()
+        return { usabilityIndicator = true }
+    end,
+    querySpellUsable = function()
+        spellQueries = spellQueries + 1
+        return true, false
+    end,
+    queryItemUsable = function()
+        itemQueries = itemQueries + 1
+        return true, false
+    end,
+    getItemIDForEntry = function() return 5512 end,
+})
+
+local function icon(entry)
+    return {
+        _spellEntry = entry,
+        Icon = { SetVertexColor = function() end },
+    }
+end
+
+controller:UpdateAllIconRanges({
+    essential = {
+        icon({ id = 5512, spellID = 5512, type = "spell", viewerType = "essential" }),
+        icon({ id = 1711, type = "consumable", viewerType = "essential" }),
+    },
+})
+
+assert(spellQueries == 1 and itemQueries == 1)
+assert(controller.usableCycleCache[5512] == true)
+assert(controller.itemUsableCycleCache[5512] == true)
+assert(controller.usableCycleCache["item:5512"] == nil)
+
+print("OK: cdm_icon_range_item_usability_cache_test")

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -149,6 +149,7 @@ local stableClears = 0
 local spellCacheInvalidations = {}
 local barAuraRefreshMarks = {}
 local customOverlayRefreshes = 0
+local consumableCategoryInvalidations = 0
 local trustedCooldownUpdates = {}
 local trustedBroadCooldownRefreshes = 0
 local forcedBroadCooldownRefreshes = 0
@@ -219,6 +220,9 @@ local controller = module.Create({
     end,
     getItemIDForEntry = function(entry)
         return entry and entry.itemID
+    end,
+    invalidateConsumableCategoryItems = function()
+        consumableCategoryInvalidations = consumableCategoryInvalidations + 1
     end,
     queryItemSpell = function(itemID)
         if itemID == 404 then return "Item Use", 707 end
@@ -345,6 +349,8 @@ barsDirty = false
 local dirtyRunsBeforeBagUpdate = dirtyBarRuns
 controller:Handle("BAG_UPDATE_DELAYED")
 assert(runtimeUpdated.item == 1, "bag inventory updates should refresh item runtime/texture state")
+assert(consumableCategoryInvalidations == 1,
+    "bag inventory updates should invalidate owned consumable identity")
 assert(runtimeUpdated.spell == nil, "bag inventory updates should stay scoped to item-backed icons")
 assert(applied.item == nil, "bag inventory updates should use the full item runtime path")
 assert(barsDirty == true, "bag inventory updates should mark item-backed bars dirty")
@@ -360,6 +366,8 @@ barsDirty = false
 local dirtyRunsBeforeItemCount = dirtyBarRuns
 controller:Handle("ITEM_COUNT_CHANGED", 404)
 assert(runtimeUpdated.item == 1, "item count changes should refresh item runtime/texture state")
+assert(consumableCategoryInvalidations == 2,
+    "item count changes should invalidate owned consumable identity")
 assert(runtimeUpdated.spell == nil, "item count changes should stay scoped to item-backed icons")
 assert(barsDirty == true, "item count changes should mark item-backed bars dirty")
 assert(dirtyBarRuns == dirtyRunsBeforeItemCount + 1, "item count changes should refresh dirty item-backed bars")
@@ -425,7 +433,8 @@ assert(auraApplied.aura == 1,
 reset(runtimeUpdated)
 controller:HandleCooldownChanged("CDM:COOLDOWN_CHANGED", 999999, 999998, "refresh", 808, nil, 909)
 assert(runtimeUpdated.consumable == 1
-        and consumableIcon._spellEntry.itemID == 909
+        and consumableIcon._spellEntry.itemID == 5512
+        and consumableIcon._spellEntry._runtimeItemID == 909
         and consumableIcon._spellEntry._runtimeSpellID == 999999
         and consumableIcon._spellEntry._runtimeBaseSpellID == 999998,
     "cooldown category and item payloads must refresh category-backed entries")

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -113,6 +113,7 @@ local customCooldownIcon = makeIcon("customCooldown", {
 })
 local consumableIcon = makeIcon("consumable", {
     id = 808,
+    itemID = 5512,
     kind = "cooldown",
     type = "consumable",
     viewerType = "essential",
@@ -221,6 +222,7 @@ local controller = module.Create({
     end,
     queryItemSpell = function(itemID)
         if itemID == 404 then return "Item Use", 707 end
+        if itemID == 5512 then return "Healthstone", 196277 end
         return nil
     end,
     queryCooldownAuraBySpellID = function(spellID)
@@ -368,9 +370,12 @@ reset(applied)
 reset(runtimeUpdated)
 reset(visibilityUpdated)
 wipe(stackWriteStates)
-controller:Handle("SPELL_UPDATE_USES", 196277)
-assert(runtimeUpdated.item == 1 and runtimeUpdated.consumable == 1,
-    "spell use-count changes should refresh item and category-consumable counts")
+controller:Handle("SPELL_UPDATE_USES", 196277, 196277)
+assert(next(runtimeUpdated) == nil,
+    "spell use-count events should refresh through the resolver bus only")
+controller:HandleChargesChanged("CDM:CHARGES_CHANGED", nil, 196277)
+assert(runtimeUpdated.item == nil and runtimeUpdated.consumable == 1,
+    "spell use-count changes should refresh only the associated category consumable")
 assert(runtimeUpdated.spell == nil,
     "spell use-count changes should stay scoped to item-backed icons")
 assert(#stackWriteStates == 2 and stackWriteStates[1] == true and stackWriteStates[2] == false,

--- a/tests/unit/cdm_icon_runtime_refresh_test.lua
+++ b/tests/unit/cdm_icon_runtime_refresh_test.lua
@@ -368,6 +368,18 @@ reset(applied)
 reset(runtimeUpdated)
 reset(visibilityUpdated)
 wipe(stackWriteStates)
+controller:Handle("SPELL_UPDATE_USES", 196277)
+assert(runtimeUpdated.item == 1 and runtimeUpdated.consumable == 1,
+    "spell use-count changes should refresh item and category-consumable counts")
+assert(runtimeUpdated.spell == nil,
+    "spell use-count changes should stay scoped to item-backed icons")
+assert(#stackWriteStates == 2 and stackWriteStates[1] == true and stackWriteStates[2] == false,
+    "spell use-count changes must enable then disable item-count writes")
+
+reset(applied)
+reset(runtimeUpdated)
+reset(visibilityUpdated)
+wipe(stackWriteStates)
 controller:Handle("PLAYER_EQUIPMENT_CHANGED", 13)
 assert(runtimeUpdated.item == 1, "equipment change should refresh item runtime/texture state")
 assert(runtimeUpdated.spell == nil, "equipment change should stay scoped to item-backed icons")

--- a/tests/unit/cdm_icons_realcd_desat_curve_test.lua
+++ b/tests/unit/cdm_icons_realcd_desat_curve_test.lua
@@ -68,7 +68,6 @@ local itemCdDurObj = {
         return ITEM_DESAT_FROM_CURVE
     end,
 }
-
 local curveAddPoints = {}
 C_CurveUtil = {
     CreateCurve = function()
@@ -238,11 +237,16 @@ local function makeIcon()
         function() return desatBool end
 end
 
-local function makeItemIcon()
+local function makeItemIcon(entryID, entryType)
     local desatAmount, desatBool
+    local durationCalls, lastClearWhenZero = 0, nil
     local icon = {
         Cooldown = {
-            SetCooldownFromDurationObject = noop,
+            SetCooldownFromDurationObject = function(_, value, clearWhenZero)
+                durationCalls = durationCalls + 1
+                lastClearWhenZero = clearWhenZero
+                assert(value ~= nil)
+            end,
             SetReverse = noop,
             SetSwipeTexture = noop,
             Clear = noop,
@@ -254,17 +258,19 @@ local function makeItemIcon()
         },
         PandemicGlow = { SetAlpha = noop },
         _spellEntry = {
-            id = ITEM_ID,
-            itemID = ITEM_ID,
+            id = entryID or ITEM_ID,
+            itemID = entryID or ITEM_ID,
             kind = "cooldown",
-            type = "item",
+            type = entryType or "item",
             viewerType = "essential",
             name = "Test Item",
         },
     }
     return icon,
         function() return desatAmount end,
-        function() return desatBool end
+        function() return desatBool end,
+        function() return durationCalls end,
+        function() return lastClearWhenZero end
 end
 
 -- Case 1: real CD rolling -> saturation is curve-driven off the real-CD-only
@@ -330,11 +336,13 @@ do
         return nil
     end
 
-    local icon, getAmount = makeItemIcon()
+    local icon, getAmount, _, _, getClearWhenZero = makeItemIcon()
     local applied = ns.CDMIcons.ApplyResolvedCooldown(icon)
     assert(applied == true, "case3: item cooldown should report an applied cooldown")
     assert(getAmount() == ITEM_DESAT_FROM_CURVE,
         "case3: item cooldown saturation must be driven by the item DurationObject curve")
+    assert(getClearWhenZero() == true,
+        "ordinary item duration objects should retain clear-when-zero behavior")
 end
 
 print("OK cdm_icons_realcd_desat_curve_test")

--- a/tests/unit/cdm_items_displaymode_ignored_on_builtin_test.lua
+++ b/tests/unit/cdm_items_displaymode_ignored_on_builtin_test.lua
@@ -38,6 +38,7 @@ C_Timer = {
 
 -- Per-item scanned-aura table.  Tests overwrite this table before each case.
 local scannedAuras = {}
+local itemCountQueries = {}
 
 local ns = {
     Helpers = {
@@ -69,7 +70,7 @@ local ns = {
             elseif key == "essential" then
                 return { containerType = "essential" }
             elseif key == "customBar:test" then
-                return { containerType = "customBar" }
+                return { containerType = "customBar", showItemCharges = true }
             end
             return nil
         end,
@@ -91,7 +92,16 @@ local ns = {
         QuerySpellInRange = function() return true end,
         QueryBestOwnedItemVariant = function(id) return id end,
         QueryInventoryItemID = function() return nil end,
-        QueryItemCount = function() return 1 end,
+        QueryItemIconByID = function(itemID) return "item-texture:" .. tostring(itemID) end,
+        QueryItemCount = function(itemID, includeBank, includeUses, forceUpdate)
+            itemCountQueries[#itemCountQueries + 1] = {
+                itemID = itemID,
+                includeBank = includeBank,
+                includeUses = includeUses,
+                forceUpdate = forceUpdate,
+            }
+            return itemID == 5512 and includeUses and 3 or 1
+        end,
         QueryItemInfoInstant = function() return nil end,
         QueryItemSpell = function() return nil, nil end,
         QueryCooldownAuraBySpellID = function() return nil end,
@@ -205,6 +215,7 @@ local icons = assert(ns.CDMIcons, "CDMIcons should be exported")
 
 -- Helper: create a minimal icon suitable for UpdateCooldownsForType.
 local function makeItemIcon(entry)
+    local textureWrites = {}
     local icon = {
         _spellEntry = entry,
         Cooldown = {
@@ -220,10 +231,10 @@ local function makeItemIcon(entry)
         Icon = {
             SetDesaturated = noop,
             SetVertexColor = noop,
-            SetTexture = noop,
+            SetTexture = function(_, value) textureWrites[#textureWrites + 1] = value end,
         },
         StackText = {
-            SetText = noop,
+            SetText = function(self, value) self.text = value end,
             Hide = noop,
             Show = noop,
             SetTextColor = noop,
@@ -235,6 +246,7 @@ local function makeItemIcon(entry)
     function icon:Show() self._shown = true end
     function icon:Hide() self._shown = false end
     function icon:SetAlpha(v) self._alpha = v end
+    icon._textureWrites = textureWrites
     return icon
 end
 
@@ -317,5 +329,30 @@ runUpdateForIcon(iconCase4, "essential")
 assert(getMode(iconCase4) == "item-cooldown",
     "Case 4: stray displayMode=auraOnly on built-in essential must be ignored, "
     .. "mode should remain 'item-cooldown' (got " .. tostring(getMode(iconCase4)) .. ")")
+
+itemCountQueries = {}
+local iconCase5 = makeItemIcon({
+    id = 1711, itemID = 5512, type = "consumable", kind = "cooldown",
+    viewerType = "customBar:test",
+})
+runUpdateForIcon(iconCase5, "customBar:test")
+assert(iconCase5.StackText.text == "3",
+    "Case 5: category consumable must show item 5512's remaining uses")
+assert(itemCountQueries[1] and itemCountQueries[1].itemID == 5512
+        and itemCountQueries[1].includeUses == true,
+    "Case 5: category consumable count must query item 5512 with uses enabled")
+assert(#iconCase5._textureWrites == 0,
+    "Case 5: category consumables must retain their fixed catalog texture")
+
+itemCountQueries = {}
+local iconCase6 = makeItemIcon({
+    id = 4, type = "consumable", kind = "cooldown",
+    viewerType = "customBar:test",
+})
+runUpdateForIcon(iconCase6, "customBar:test")
+assert(#itemCountQueries == 0,
+    "Case 6: consumables without a resolved item identity must not query a nil item count")
+assert(iconCase6.StackText.text ~= "0",
+    "Case 6: consumables without a resolved item identity must not show a zero item badge")
 
 print("PASS: cdm_items_displaymode_ignored_on_builtin_test")

--- a/tests/unit/cdm_items_displaymode_ignored_on_builtin_test.lua
+++ b/tests/unit/cdm_items_displaymode_ignored_on_builtin_test.lua
@@ -16,19 +16,26 @@ local BuildCooldownStateContext = dofile("tests/helpers/cdm_context_builder_stub
 
 local function noop() end
 local _now = 1000.0
+local inCombat = false
 
-function InCombatLockdown() return false end
+function InCombatLockdown() return inCombat end
 function GetTime() return _now end
 function wipe(tbl)
     for k in pairs(tbl) do tbl[k] = nil end
 end
 function CreateFrame()
-    return {
-        RegisterEvent = noop,
-        RegisterUnitEvent = noop,
-        UnregisterAllEvents = noop,
-        SetScript = noop,
-    }
+    local frame = { attributes = {}, scripts = {} }
+    frame.RegisterEvent = noop
+    frame.RegisterUnitEvent = noop
+    frame.UnregisterAllEvents = noop
+    frame.SetAllPoints = noop
+    frame.RegisterForClicks = noop
+    frame.EnableMouse = noop
+    frame.SetScript = function(self, name, callback) self.scripts[name] = callback end
+    frame.SetAttribute = function(self, name, value) self.attributes[name] = value end
+    frame.Show = function(self) self.shown = true end
+    frame.Hide = function(self) self.shown = false end
+    return frame
 end
 
 C_Timer = {
@@ -39,6 +46,9 @@ C_Timer = {
 -- Per-item scanned-aura table.  Tests overwrite this table before each case.
 local scannedAuras = {}
 local itemCountQueries = {}
+local categorySourceItemID
+local ownedCategoryItemID
+local itemNamesAvailable = true
 
 local ns = {
     Helpers = {
@@ -70,7 +80,7 @@ local ns = {
             elseif key == "essential" then
                 return { containerType = "essential" }
             elseif key == "customBar:test" then
-                return { containerType = "customBar", showItemCharges = true }
+                return { containerType = "customBar", showItemCharges = true, clickableIcons = true }
             end
             return nil
         end,
@@ -91,7 +101,12 @@ local ns = {
         QuerySpellHasRange = function() return false end,
         QuerySpellInRange = function() return true end,
         QueryBestOwnedItemVariant = function(id) return id end,
+        QueryBestOwnedConsumableCategoryItem = function() return ownedCategoryItemID end,
+        QueryLastCategoryCooldownSource = function() return nil, categorySourceItemID end,
         QueryInventoryItemID = function() return nil end,
+        QueryItemNameByID = function(itemID)
+            return itemNamesAvailable and itemID and ("item-" .. tostring(itemID))
+        end,
         QueryItemIconByID = function(itemID) return "item-texture:" .. tostring(itemID) end,
         QueryItemCount = function(itemID, includeBank, includeUses, forceUpdate)
             itemCountQueries[#itemCountQueries + 1] = {
@@ -354,5 +369,34 @@ assert(#itemCountQueries == 0,
     "Case 6: consumables without a resolved item identity must not query a nil item count")
 assert(iconCase6.StackText.text ~= "0",
     "Case 6: consumables without a resolved item identity must not show a zero item badge")
+
+ownedCategoryItemID = 245902
+local iconCase7 = makeItemIcon({
+    id = 4, type = "consumable", kind = "cooldown",
+    viewerType = "customBar:test",
+})
+local priorPool = ns.CDMIconFactory._iconPools["customBar:test"]
+ns.CDMIconFactory._iconPools["customBar:test"] = { iconCase7 }
+itemNamesAvailable = false
+icons:UpdateCooldownsForType("customBar:test")
+assert(iconCase7._lastConsumableSecureItemID == nil,
+    "Case 7: an unavailable item name must leave the secure action eligible for retry")
+itemNamesAvailable = true
+icons:UpdateCooldownsForType("customBar:test")
+assert(iconCase7.clickButton and iconCase7.clickButton.attributes.item == "item-245902",
+    "Case 7: an owned potion must create the initial secure item action")
+
+categorySourceItemID = 245910
+inCombat = true
+icons:UpdateCooldownsForType("customBar:test")
+assert(iconCase7._pendingSecureUpdate == true
+        and iconCase7.clickButton.attributes.item == "item-245902",
+    "Case 7: a combat item-source change must defer its secure action update")
+inCombat = false
+icons.HandleRuntimeRefresh("PLAYER_REGEN_ENABLED")
+assert(iconCase7._pendingSecureUpdate == nil
+        and iconCase7.clickButton.attributes.item == "item-245910",
+    "Case 7: combat end must apply the deferred consumable secure action")
+ns.CDMIconFactory._iconPools["customBar:test"] = priorPool
 
 print("PASS: cdm_items_displaymode_ignored_on_builtin_test")

--- a/tests/unit/cdm_items_displaymode_ignored_on_builtin_test.lua
+++ b/tests/unit/cdm_items_displaymode_ignored_on_builtin_test.lua
@@ -102,6 +102,10 @@ local ns = {
         QuerySpellInRange = function() return true end,
         QueryBestOwnedItemVariant = function(id) return id end,
         QueryBestOwnedConsumableCategoryItem = function() return ownedCategoryItemID end,
+        QueryConsumableCategoryItem = function(categoryID)
+            if categoryID == 1711 then return 5512 end
+            return ownedCategoryItemID
+        end,
         QueryLastCategoryCooldownSource = function() return nil, categorySourceItemID end,
         QueryInventoryItemID = function() return nil end,
         QueryItemNameByID = function(itemID)
@@ -370,9 +374,10 @@ assert(#itemCountQueries == 0,
 assert(iconCase6.StackText.text ~= "0",
     "Case 6: consumables without a resolved item identity must not show a zero item badge")
 
+categorySourceItemID = 245999
 ownedCategoryItemID = 245902
 local iconCase7 = makeItemIcon({
-    id = 4, type = "consumable", kind = "cooldown",
+    id = 4, itemID = 245999, type = "consumable", kind = "cooldown",
     viewerType = "customBar:test",
 })
 local priorPool = ns.CDMIconFactory._iconPools["customBar:test"]
@@ -386,7 +391,7 @@ icons:UpdateCooldownsForType("customBar:test")
 assert(iconCase7.clickButton and iconCase7.clickButton.attributes.item == "item-245902",
     "Case 7: an owned potion must create the initial secure item action")
 
-categorySourceItemID = 245910
+ownedCategoryItemID = 245910
 inCombat = true
 icons:UpdateCooldownsForType("customBar:test")
 assert(iconCase7._pendingSecureUpdate == true

--- a/tests/unit/cdm_renderers_secret_duration_test.lua
+++ b/tests/unit/cdm_renderers_secret_duration_test.lua
@@ -1,0 +1,30 @@
+local secret = dofile("tests/helpers/secret_sentinel.lua")
+local restore = secret.InstallSecretStub()
+local ns = {}
+local load = assert(secret.LoadInstrumented("QUI_CDM/cdm/cdm_frame_writes.lua"))
+load("QUI", ns)
+
+local renderers = assert(ns.CDMRenderers)
+local duration = secret.MakeSecretSentinel()
+local cooldownCalls = 0
+local timerCalls = 0
+local cooldown = {
+    SetCooldownFromDurationObject = function(_, value)
+        assert(value == duration)
+        cooldownCalls = cooldownCalls + 1
+    end,
+}
+local statusBar = {
+    SetTimerDuration = function(_, value)
+        assert(value == duration)
+        timerCalls = timerCalls + 1
+    end,
+}
+
+assert(renderers.ApplyDurationObjectCooldown(cooldown, duration, true, false) == true)
+assert(renderers.SetStatusBarTimerDuration(statusBar, duration) == true)
+assert(cooldownCalls == 1)
+assert(timerCalls == 1)
+
+secret.RestoreSecretStub(restore)
+print("OK: cdm_renderers_secret_duration_test")

--- a/tests/unit/cdm_resolvers_cooldown_state_test.lua
+++ b/tests/unit/cdm_resolvers_cooldown_state_test.lua
@@ -89,6 +89,9 @@ local slotCooldownDuration = 90
 local itemUseSpellCooldownActive = false
 local itemUseSpellCooldownDur = { token = "item-use-spell-cooldown-dur" }
 local healthstoneCooldownActive = true
+local healthstoneItemCooldownKnownInactive = false
+local healthstoneCategorySpellID = 91005
+local healthstoneScannerActive = false
 local gcdSpellActive = false
 local chargeQueryCounts = {}
 
@@ -366,7 +369,7 @@ local ns = {
             return nil, nil
         end,
         QueryLastCategoryCooldownSource = function(categoryID)
-            if categoryID == 1711 then return 91005, 90005 end
+            if categoryID == 1711 then return healthstoneCategorySpellID, 90005 end
             return nil, nil
         end,
         QueryInventoryItemID = function(unit, slotID)
@@ -376,6 +379,12 @@ local ns = {
             return nil
         end,
         QueryScannedItemAuraInfo = function(itemID, itemSpellID)
+            if itemID == 90005 and healthstoneScannerActive then
+                return {
+                    active = true,
+                    useSpellID = itemSpellID,
+                }
+            end
             if itemID == 90001 and itemSpellID == 91001 then
                 if itemRuntimeAuraInstanceActive then
                     return {
@@ -410,6 +419,9 @@ local ns = {
                 return 11418.804, 90, true
             end
             if itemID == 90005 and healthstoneCooldownActive then
+                if healthstoneItemCooldownKnownInactive then
+                    return 0, 0, 1
+                end
                 return 300, 60, 1
             end
             return nil, nil, nil
@@ -1068,6 +1080,50 @@ assert(state.spellID == 91005,
     "category consumables must retain the source spellID from the last cooldown source")
 assert(state.start == 300 and state.duration == 60,
     "category consumables must use the source item's cooldown timing")
+
+healthstoneItemCooldownKnownInactive = true
+healthstoneScannerActive = true
+state = resolve({
+    entry = {
+        type = "consumable",
+        kind = "cooldown",
+        id = 1711,
+        name = "Healthstone",
+        viewerType = "custom",
+    },
+    runtimeSpellID = 1711,
+    containerKey = "custom",
+    useBuffSwipe = true,
+    showGCDSwipe = true,
+})
+
+assert(state.mode == "inactive" and state.durObj == nil and state.sourceID == nil,
+    "cooldown-kind category consumables must ignore item-aura state and inactive category spell timing")
+healthstoneItemCooldownKnownInactive = false
+healthstoneScannerActive = false
+
+healthstoneCategorySpellID = 91006
+state = resolve({
+    entry = {
+        type = "consumable",
+        kind = "cooldown",
+        id = 1711,
+        itemID = 99999,
+        name = "Healthstone",
+        viewerType = "custom",
+    },
+    runtimeSpellID = 6262,
+    containerKey = "custom",
+    useBuffSwipe = true,
+    showGCDSwipe = true,
+})
+
+assert(state.mode == "item-cooldown"
+    and state.spellID == 91006
+    and state.start == 300
+    and state.duration == 60,
+    "category source spell and item must outrank mutable consumable entry identity")
+healthstoneCategorySpellID = 91005
 
 createdDurationObjects = {}
 durationObjectSetCalls = {}

--- a/tests/unit/cdm_shared_test.lua
+++ b/tests/unit/cdm_shared_test.lua
@@ -45,6 +45,20 @@ assert(Shared.GetContainerDB("essential") == core.db.profile.ncdm.essential, "bu
 assert(Shared.GetContainerDB("custom") == core.db.profile.ncdm.containers.custom, "custom container lookup failed")
 assert(Shared.GetContainerDB("missing") == nil, "missing container should return nil")
 
+core.db.profile.ncdm.containers.essential = { enabled = false }
+assert(Shared.GetContainerDB("essential") == core.db.profile.ncdm.essential,
+    "built-in containers must ignore the nested compatibility copy")
+
+local staleCustom = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } }
+local liveCustom = { containerType = "customBar", entries = { { type = "consumable", id = 1711 } } }
+core.db.profile.ncdm.staleCustom = staleCustom
+core.db.profile.ncdm.containers.staleCustom = liveCustom
+assert(Shared.GetContainerDB("staleCustom") == liveCustom,
+    "custom containers must prefer the canonical containers store")
+core.db.profile.ncdm.orphanCustom = staleCustom
+assert(Shared.GetContainerDB("orphanCustom") == nil,
+    "custom containers must not fall back to the legacy top-level store")
+
 assert(Shared.IsSafeNumeric(12.5) == true, "number should be safe numeric")
 assert(Shared.IsSafeNumeric("__secret__") == false, "secret should not be safe numeric")
 assert(Shared.IsSafeNumeric("12") == false, "string should not be safe numeric")

--- a/tests/unit/cdm_sources_item_quality_variant_test.lua
+++ b/tests/unit/cdm_sources_item_quality_variant_test.lua
@@ -80,6 +80,19 @@ assert(sources.QueryBestOwnedItemVariant(2000) == 2000,
 local sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
 assert(sourceSpellID == 6262 and sourceItemID == 5512,
     "category cooldown source should return the last spell and item")
+local categorySourceCache
+for index = 1, 20 do
+    local name, value = debug.getupvalue(sources.QueryLastCategoryCooldownSource, index)
+    if not name then break end
+    if name == "_lastCategoryCooldownSources" then
+        categorySourceCache = value
+        break
+    end
+end
+local cachedSource = assert(categorySourceCache and categorySourceCache[1711])
+sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
+assert(categorySourceCache[1711] == cachedSource,
+    "unchanged category cooldown sources should reuse their cache record")
 categorySourceAvailable = false
 sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
 assert(sourceSpellID == 6262 and sourceItemID == 5512,

--- a/tests/unit/cdm_sources_item_quality_variant_test.lua
+++ b/tests/unit/cdm_sources_item_quality_variant_test.lua
@@ -11,19 +11,52 @@ C_Item = {
     GetItemCount = function(itemID)
         return counts[itemID] or 0
     end,
+    GetItemCooldown = function(itemID)
+        return 400, 30, itemID == 5512 and 1 or 0
+    end,
 }
+local itemCooldownQueries = {}
+local containerCooldownAvailable = true
+C_Container = {
+    GetItemCooldown = function(itemID)
+        itemCooldownQueries[#itemCooldownQueries + 1] = itemID
+        if containerCooldownAvailable then
+            return 300, 60, 1
+        end
+    end,
+}
+local categorySourceAvailable = true
+local categoryMetadataAvailable = true
 C_Spell = {
     GetLastCategoryCooldownSource = function(categoryID)
-        if categoryID == 1711 then return 6262, 5512 end
+        if categoryID == 1711 then
+            if categorySourceAvailable then return 6262, 5512 end
+            return nil, nil
+        end
         return nil, nil
     end,
 }
-
 local ns = {
     ConsumableMacros = {
         GetVariantOrderForItem = function(itemID)
             if itemID == 1001 or itemID == 1002 or itemID == 1003 then
                 return { 1001, 1002, 1003 }
+            end
+            return nil
+        end,
+    },
+    CDMIndex = {
+        GetByCategory = function(categoryID)
+            if categoryID == 1711 and categoryMetadataAvailable then
+                return { cooldownID = 7001 }
+            end
+            return nil
+        end,
+    },
+    CDMCatalog = {
+        GetCooldownInfo = function(cooldownID)
+            if cooldownID == 7001 then
+                return { spellID = 6262, spellCategoryID = 1711 }
             end
             return nil
         end,
@@ -47,5 +80,18 @@ assert(sources.QueryBestOwnedItemVariant(2000) == 2000,
 local sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
 assert(sourceSpellID == 6262 and sourceItemID == 5512,
     "category cooldown source should return the last spell and item")
+categorySourceAvailable = false
+sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
+assert(sourceSpellID == 6262 and sourceItemID == 5512,
+    "category cooldown source should retain the last readable pair when combat values are opaque")
+categoryMetadataAvailable = false
+local startTime, duration, enabled = sources.QueryItemCooldown(5512)
+assert(startTime == 300 and duration == 60 and enabled == 1
+        and itemCooldownQueries[1] == 5512,
+    "item cooldowns should use C_Container's direct item-ID API")
+containerCooldownAvailable = false
+startTime, duration, enabled = sources.QueryItemCooldown(5512)
+assert(startTime == 400 and duration == 30 and enabled == 1,
+    "item cooldowns should fall back to C_Item when C_Container returns no tuple")
 
 print("OK: cdm_sources_item_quality_variant_test")

--- a/tests/unit/cdm_sources_item_quality_variant_test.lua
+++ b/tests/unit/cdm_sources_item_quality_variant_test.lua
@@ -41,6 +41,10 @@ C_Spell = {
 }
 local ns = {
     ConsumableMacros = {
+        GetCategoryItemCandidates = function(categoryID)
+            if categoryID == 4 then return { 1001, 1002, 1003 } end
+            return nil
+        end,
         GetVariantOrderForItem = function(itemID)
             if itemID == 1001 or itemID == 1002 or itemID == 1003 then
                 return { 1001, 1002, 1003 }
@@ -73,6 +77,9 @@ local loadChunk = dofile("tests/helpers/load_cdm_consolidated_chunk.lua")
 loadChunk("QUI_CDM/cdm/cdm_sources.lua", "cdm_sources.lua")("QUI", ns)
 
 local sources = assert(ns.CDMSources, "CDMSources should be exported")
+
+assert(sources.QueryBestOwnedConsumableCategoryItem(4) == 1002,
+    "category consumables should resolve the first owned item candidate")
 
 assert(sources.QueryBestOwnedItemVariant(1003) == 1002,
     "existing lower-rank item entries should resolve to the best owned variant in the macro order")

--- a/tests/unit/cdm_sources_item_quality_variant_test.lua
+++ b/tests/unit/cdm_sources_item_quality_variant_test.lua
@@ -27,6 +27,9 @@ C_Container = {
 }
 local categorySourceAvailable = true
 local categoryMetadataAvailable = true
+local categoryIndexQueries = 0
+local categoryMetadataQueries = 0
+local indexVersion = 1
 C_Spell = {
     GetLastCategoryCooldownSource = function(categoryID)
         if categoryID == 1711 then
@@ -46,7 +49,9 @@ local ns = {
         end,
     },
     CDMIndex = {
+        Version = function() return indexVersion end,
         GetByCategory = function(categoryID)
+            categoryIndexQueries = categoryIndexQueries + 1
             if categoryID == 1711 and categoryMetadataAvailable then
                 return { cooldownID = 7001 }
             end
@@ -55,6 +60,7 @@ local ns = {
     },
     CDMCatalog = {
         GetCooldownInfo = function(cooldownID)
+            categoryMetadataQueries = categoryMetadataQueries + 1
             if cooldownID == 7001 then
                 return { spellID = 6262, spellCategoryID = 1711 }
             end
@@ -97,7 +103,17 @@ categorySourceAvailable = false
 sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
 assert(sourceSpellID == 6262 and sourceItemID == 5512,
     "category cooldown source should retain the last readable pair when combat values are opaque")
+sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
+assert(categoryMetadataQueries == 1,
+    "unchanged category metadata should be queried once")
+indexVersion = indexVersion + 1
 categoryMetadataAvailable = false
+sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
+assert(sourceSpellID == 6262 and sourceItemID == 5512 and categoryIndexQueries == 2,
+    "category metadata cache should invalidate with the CDM index")
+sourceSpellID, sourceItemID = sources.QueryLastCategoryCooldownSource(1711)
+assert(categoryIndexQueries == 2,
+    "missing category metadata should be cached until the CDM index changes")
 local startTime, duration, enabled = sources.QueryItemCooldown(5512)
 assert(startTime == 300 and duration == 60 and enabled == 1
         and itemCooldownQueries[1] == 5512,

--- a/tests/unit/cdm_sources_item_quality_variant_test.lua
+++ b/tests/unit/cdm_sources_item_quality_variant_test.lua
@@ -6,9 +6,11 @@ local counts = {
     [1002] = 4,
     [1003] = 2,
 }
+local itemCountQueries = 0
 
 C_Item = {
     GetItemCount = function(itemID)
+        itemCountQueries = itemCountQueries + 1
         return counts[itemID] or 0
     end,
     GetItemCooldown = function(itemID)
@@ -32,6 +34,7 @@ local categoryMetadataQueries = 0
 local indexVersion = 1
 C_Spell = {
     GetLastCategoryCooldownSource = function(categoryID)
+        if categoryID == 4 then return 777, 1001 end
         if categoryID == 1711 then
             if categorySourceAvailable then return 6262, 5512 end
             return nil, nil
@@ -63,6 +66,10 @@ local ns = {
         end,
     },
     CDMCatalog = {
+        GetConsumableCategoryItemID = function(categoryID)
+            if categoryID == 1711 then return 5512 end
+            return nil
+        end,
         GetCooldownInfo = function(cooldownID)
             categoryMetadataQueries = categoryMetadataQueries + 1
             if cooldownID == 7001 then
@@ -80,11 +87,21 @@ local sources = assert(ns.CDMSources, "CDMSources should be exported")
 
 assert(sources.QueryBestOwnedConsumableCategoryItem(4) == 1002,
     "category consumables should resolve the first owned item candidate")
+local queriesAfterCategoryScan = itemCountQueries
+assert(sources.QueryConsumableCategoryItem(4) == 1002,
+    "consumable identity should prefer an owned item over the recent category source")
+assert(itemCountQueries == queriesAfterCategoryScan,
+    "unchanged consumable identity should reuse its owned-item cache")
+assert(sources.QueryConsumableCategoryItem(1711) == 5512,
+    "consumable identity should retain static category fallbacks")
 
 assert(sources.QueryBestOwnedItemVariant(1003) == 1002,
     "existing lower-rank item entries should resolve to the best owned variant in the macro order")
 
 counts[1002] = 0
+sources.InvalidateConsumableCategoryItems()
+assert(sources.QueryBestOwnedConsumableCategoryItem(4) == 1003,
+    "invalidating consumable identity should detect a newly preferred owned item")
 assert(sources.QueryBestOwnedItemVariant(1003) == 1003,
     "best-variant resolution should fall back to the configured item when no better variant is owned")
 

--- a/tests/unit/cdm_spelldata_dormant_foldback_test.lua
+++ b/tests/unit/cdm_spelldata_dormant_foldback_test.lua
@@ -189,4 +189,18 @@ assert(#specList == 2, "record must fold into the current spec list")
 assert(specList[1].id == QUELL, "record returns to its saved slot in the spec list")
 assert(next(specBarDB.dormantSpells) == nil, "specSpecific shelf must be emptied")
 
+specBarDB.entries = { { type = "consumable", id = 1711, kind = "cooldown" } }
+local beforeLegacyMerge = #specList
+local activeSpecEntries = ns.CDMSpellData:GetSpecEntries("spec_bar")
+assert(#activeSpecEntries == beforeLegacyMerge + 1,
+    "legacy shared entries must merge into an existing spec list")
+assert(activeSpecEntries[#activeSpecEntries].id == 1711,
+    "legacy category entry must reach the renderer's active spec list")
+assert(#specBarDB.entries == 0, "legacy shared entries must be drained after migration")
+
+specList[#specList + 1] = { type = "spell", id = 6201, kind = "cooldown" }
+local preservedEntries = ns.CDMSpellData:GetSpecEntries("spec_bar")
+assert(preservedEntries[#preservedEntries].id == 6201,
+    "Create Healthstone spell 6201 must remain a valid independent entry")
+
 print("OK: cdm_spelldata_dormant_foldback_test")

--- a/tests/unit/cdm_tooltip_secret_aura_fallback_test.lua
+++ b/tests/unit/cdm_tooltip_secret_aura_fallback_test.lua
@@ -27,7 +27,11 @@ local ns = {
         GetGeneralFont = function() return "Fonts\\FRIZQT__.TTF" end,
         GetGeneralFontOutline = function() return "" end,
     },
-    CDMSources = {},
+    CDMSources = {
+        QueryLastCategoryCooldownSource = function(categoryID)
+            if categoryID == 1711 then return 6262, 5512 end
+        end,
+    },
     CDMResolvers = {
         GetEntryTexture = function() return 134400 end,
         GetSpellTexture = function() return 134400 end,
@@ -47,6 +51,7 @@ GameTooltip = {
         self.anchor = anchor
     end,
     SetSpellByID = function(self, spellID) self.spellID = spellID end,
+    SetItemByID = function(self, itemID) self.itemID = itemID end,
     SetUnitAuraByAuraInstanceID = function(self, unit, auraInstanceID, filter)
         auraTooltipCalls = auraTooltipCalls + 1
         if issecretvalue(auraInstanceID) or issecretvalue(unit) or self._auraIsSecret then
@@ -66,7 +71,7 @@ local Factory = assert(ns.CDMIconFactory, "factory module must export CDMIconFac
 
 local function resetTooltip()
     GameTooltip.owner, GameTooltip.anchor = nil, nil
-    GameTooltip.spellID, GameTooltip.auraInstanceID = nil, nil
+    GameTooltip.spellID, GameTooltip.itemID, GameTooltip.auraInstanceID = nil, nil, nil
     GameTooltip.shown, GameTooltip._auraIsSecret = false, false
 end
 
@@ -104,6 +109,14 @@ assert(Factory.ShowEntryTooltip(liveOwner, { spellID = 777 }, "cdm") == true,
     "readable aura tooltip still shows")
 assert(GameTooltip.auraInstanceID == 42, "readable aura uses the aura-instance tooltip path")
 assert(GameTooltip.spellID == nil, "no spell fallback when the aura tooltip succeeded")
+
+-- Case D: consumable categories use the actual item for their tooltip.
+resetTooltip()
+local consumableOwner = { _runtimeSpellID = 6262 }
+assert(Factory.ShowEntryTooltip(consumableOwner, { type = "consumable", id = 1711 }, "cdm") == true,
+    "consumable tooltip shows")
+assert(GameTooltip.itemID == 5512 and GameTooltip.spellID == nil,
+    "consumable tooltip uses the Healthstone item")
 
 SecretSentinel.RestoreSecretStub(restoreSecret)
 print("OK: cdm_tooltip_secret_aura_fallback_test")

--- a/tests/unit/cdm_tooltip_secret_aura_fallback_test.lua
+++ b/tests/unit/cdm_tooltip_secret_aura_fallback_test.lua
@@ -29,7 +29,10 @@ local ns = {
     },
     CDMSources = {
         QueryLastCategoryCooldownSource = function(categoryID)
-            if categoryID == 1711 then return 6262, 5512 end
+            if categoryID == 1711 then return 6262, 999999 end
+        end,
+        QueryConsumableCategoryItem = function(categoryID)
+            if categoryID == 1711 then return 5512 end
         end,
     },
     CDMResolvers = {

--- a/tests/unit/consumablemacros_selected_item_test.lua
+++ b/tests/unit/consumablemacros_selected_item_test.lua
@@ -23,6 +23,13 @@ assert(loadfile("modules/utility/consumablemacros.lua"))("QUI", ns)
 local CM = assert(ns.ConsumableMacros, "ConsumableMacros should be exported on ns")
 assert(type(CM.GetSelectedItem) == "function", "GetSelectedItem should be a function")
 
+local potionCandidates = assert(CM.GetCategoryItemCandidates(4))
+local healthCandidates = assert(CM.GetCategoryItemCandidates(30))
+assert(potionCandidates[1] == 245902 and healthCandidates[1] == 245918,
+    "potion categories should reuse the ordered macro item definitions")
+assert(CM.GetCategoryItemCandidates(1711) == nil,
+    "categories with static catalog fallbacks should not synthesize candidates")
+
 -- Configured flask family -> first variant itemID + family label.
 local flask = CM.GetSelectedItem("selectedFlask")
 assert(flask and flask.itemID == 245930,

--- a/tests/unit/migration_schema62_custom_bar_store_test.lua
+++ b/tests/unit/migration_schema62_custom_bar_store_test.lua
@@ -4,7 +4,8 @@ local M = ns.Migrations
 local liveKey = "custom_1778883503_8224"
 local legacyKey = "customBar_old_tracker"
 local orphanKey = "custom_1776292480_7595"
-local live = { containerType = "customBar", entries = { { type = "consumable", id = 1711 } } }
+local shadow = { containerType = "customBar", entries = { { type = "consumable", id = 1711 } } }
+local active = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } }
 local profile = {
     _schemaVersion = M.CURRENT_SCHEMA_VERSION - 1,
     ncdm = {
@@ -14,10 +15,10 @@ local profile = {
             utility = { enabled = true },
             buff = { enabled = true },
             trackedBar = { enabled = true },
-            [liveKey] = live,
+            [liveKey] = shadow,
             [legacyKey] = { containerType = "customBar", entries = {} },
         },
-        [liveKey] = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } },
+        [liveKey] = active,
         [legacyKey] = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } },
         [orphanKey] = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } },
     },
@@ -28,8 +29,9 @@ M.RunOnProfile(profile)
 assert(profile._schemaVersion == M.CURRENT_SCHEMA_VERSION)
 assert(profile.ncdm[liveKey] == nil)
 assert(profile.ncdm[legacyKey] == nil)
-assert(profile.ncdm.containers[liveKey] == live)
-assert(profile.ncdm.containers[liveKey].entries[1].id == 1711)
+assert(profile.ncdm.containers[liveKey] == active)
+assert(profile.ncdm.containers[liveKey].entries[1].id == 6201)
+assert(profile.ncdm.containers[legacyKey].entries[1].id == 6201)
 assert(profile.ncdm[orphanKey] ~= nil)
 assert(profile.ncdm.essential ~= nil)
 

--- a/tests/unit/migration_schema62_custom_bar_store_test.lua
+++ b/tests/unit/migration_schema62_custom_bar_store_test.lua
@@ -1,0 +1,41 @@
+local ns = dofile("tools/_addon_env.lua").LoadCore()
+local M = ns.Migrations
+
+local liveKey = "custom_1778883503_8224"
+local legacyKey = "customBar_old_tracker"
+local orphanKey = "custom_1776292480_7595"
+local live = { containerType = "customBar", entries = { { type = "consumable", id = 1711 } } }
+local profile = {
+    _schemaVersion = M.CURRENT_SCHEMA_VERSION - 1,
+    ncdm = {
+        essential = { enabled = true },
+        containers = {
+            essential = { enabled = true },
+            utility = { enabled = true },
+            buff = { enabled = true },
+            trackedBar = { enabled = true },
+            [liveKey] = live,
+            [legacyKey] = { containerType = "customBar", entries = {} },
+        },
+        [liveKey] = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } },
+        [legacyKey] = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } },
+        [orphanKey] = { containerType = "customBar", entries = { { type = "spell", id = 6201 } } },
+    },
+}
+
+M.RunOnProfile(profile)
+
+assert(profile._schemaVersion == M.CURRENT_SCHEMA_VERSION)
+assert(profile.ncdm[liveKey] == nil)
+assert(profile.ncdm[legacyKey] == nil)
+assert(profile.ncdm.containers[liveKey] == live)
+assert(profile.ncdm.containers[liveKey].entries[1].id == 1711)
+assert(profile.ncdm[orphanKey] ~= nil)
+assert(profile.ncdm.essential ~= nil)
+
+M.RunOnProfile(profile)
+assert(profile.ncdm[liveKey] == nil)
+assert(profile.ncdm[legacyKey] == nil)
+assert(profile.ncdm[orphanKey] ~= nil)
+
+print("migration_schema62_custom_bar_store_test: all checks passed")

--- a/tests/unit/utils_ncdm_custom_entries_profile_fallback_test.lua
+++ b/tests/unit/utils_ncdm_custom_entries_profile_fallback_test.lua
@@ -1,0 +1,33 @@
+function LibStub() return nil end
+
+local ns = {}
+assert(loadfile("core/utils.lua"))("QUI", ns)
+
+local profileEntries = {
+    enabled = true,
+    placement = "before",
+    entries = { { type = "spell", id = 12345 } },
+}
+local core = {
+    db = {
+        char = {},
+        profile = {
+            ncdm = {
+                customEntriesSpecSpecific = false,
+                essential = { customEntries = profileEntries },
+            },
+        },
+        GetCurrentProfile = function() return "Imported" end,
+    },
+}
+
+ns.Helpers.GetCore = function() return core end
+
+local result = ns.Helpers.GetNCDMCustomEntries("essential")
+assert(result ~= profileEntries, "profile custom entries should be cloned into character storage")
+assert(result.enabled == true and result.placement == "before",
+    "profile custom-entry settings should seed a missing per-profile bucket")
+assert(result.entries[1] and result.entries[1].id == 12345,
+    "profile custom entries should survive first access on an imported profile")
+
+print("utils_ncdm_custom_entries_profile_fallback_test: all checks passed")


### PR DESCRIPTION
Summary:
- preserve built-in CDM profile settings while migrating custom containers to canonical nested storage
- resolve item-backed consumable cooldowns, counts, usability, tooltips, clicks, and debug probes consistently
- handle secret duration values without unsafe comparisons

Validation:
- bash tools/test.sh
- ALL GATES PASSED: 12 fixtures, 859 unit tests, strict taint, lint, generated artifacts
- independent storage and runtime reviews report no actionable findings