### PR TITLE
release: v5.2.2-beta5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.2-beta5 - 2026-08-23
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Profile sharing, aura-display visibility, and combat-reload hardening for the
+5.2.2 beta line.
+
+### Added
+
+- **Feature settings can be shared across profiles.** Aura Displays and Group /
+  Raid Frames can copy settings and anchors from another profile or stay pinned
+  to a source profile without replacing click-cast bindings.
+- **Tracked aura displays can keep inactive icons visible.** Choose active-only,
+  instance-only, or always-visible placeholders with desaturated icon styling.
+
+### Fixed
+
+- **Combat reloads preserve protected UI ownership.** Cooldown Manager, Chat,
+  Info Bar, Minimap, and Travel initialize or refresh through their safe startup
+  paths without blocked geometry or stale native frames.
+- **Cooldown charge and aura-phase state follows Blizzard's live sources.** Owned
+  icons retain native charge metadata and suppress eligible inactive aura phases.
+- **Bank and guild-bank controls use native protected flows.** Tab purchases,
+  guild-money dialogs, combat state, cursor deposits, and item tooltips stay in
+  sync with Blizzard's bank APIs.
+- **Group-frame names refresh their live layout.** Anchor, justification, bottom
+  padding, and party/raid preview context update without requiring a reload.
+
 ## v5.2.2-beta4 - 2026-08-22
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta4
+## Version: 5.2.2-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,27 +8,34 @@ nav_order: 5
 
 This page summarizes the user-facing changes since the last mainline release. For every beta entry and technical fix, see the full [CHANGELOG.md](https://github.com/zol-wow/QUI/blob/main/CHANGELOG.md).
 
-## Current Release: 5.2.2-beta4
+## Current Release: 5.2.2-beta5
 
 {: .warning }
 **WoW 12.1 only.** This build targets patch 12.1 (interface 120100) and will not load on the 12.0.x client.
 
-QUI 5.2.2-beta4 continues the 5.2.2 beta line with Cooldown Manager target
-debuff, custom-bar storage, and consumable fixes.
+QUI 5.2.2-beta5 continues the 5.2.2 beta line with profile sharing, aura-display
+visibility controls, and safer combat reloads.
 
 {: .important }
 Back up your `WTF` folder before updating. Manual installs must copy every `QUI*` folder from the release zip into `Interface\AddOns\`.
 
-## What's New in 5.2.2-beta4
+## What's New in 5.2.2-beta5
+
+### Profiles and aura displays
+
+- **Feature settings can be shared across profiles** for Aura Displays and
+  Group / Raid Frames without replacing click-cast bindings.
+- **Tracked aura displays can keep inactive icons visible** with active-only,
+  instance-only, or always-visible placeholder modes.
 
 ### Beta fixes
 
-- **Target-debuff cooldowns** repair stale linked state while preserving
-  Blizzard's native cooldown ownership.
-- **Custom Cooldown Manager bars** use canonical profile storage without
-  overwriting built-in container settings during migration.
-- **Consumable categories** consistently resolve owned items for cooldowns,
-  counts, usability, tooltips, and secure clicks.
+- **Combat reloads preserve protected UI ownership** across Cooldown Manager,
+  Chat, Info Bar, Minimap, and Travel startup paths.
+- **Cooldown charge and aura-phase state follows Blizzard's live sources**
+  while QUI preserves native ownership.
+- **Bank, guild-bank, and group-frame controls refresh safely** through native
+  protected flows and live layout state.
 
 ## What's New in 5.2.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ nav_order: 1
 A modular World of Warcraft UI suite for Midnight 12.1+ that you can install, understand, and tune from one settings experience.
 {: .fs-6 .fw-300 }
 
-**Current Release: 5.2.2-beta4**
+**Current Release: 5.2.2-beta5**
 {: .label .label-purple }
 
 [Get Started](getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }


### PR DESCRIPTION
## Release

- bump 11 shipped TOCs to `5.2.2-beta5`
- add the `v5.2.2-beta5` changelog section

## Testing

- `bash tools/test.sh` on the worktree
- `bash tools/test.sh` from an isolated shared clone of the release commit
- release-note extractor dry run
- `lua tools/generate_event_allowlist.lua`