### PR TITLE
release: v5.2.2-beta6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.2-beta6 - 2026-08-23
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Combat UI additions, search-routing fixes, and completed locale coverage for
+the 5.2.2 beta line.
+
+### Added
+
+- **Group-frame click-casting supports items.** Drag an item into a binding and
+  trigger it with a mouse button, keyboard key, or mouse wheel.
+- **Tracked nameplate debuffs can tint health bars.** Configure the color and
+  opacity applied while a tracked aura is active.
+- **Damage Meter tooltips show player item level.** Hovered player rows use the
+  shared inspection cache and refresh when asynchronous inspection completes.
+- **Totem Bar buttons can be resized.** A new Button Size setting updates the
+  bar layout.
+
+### Changed
+
+- **Translations cover previously missing UI text.** All ten non-English locale
+  overlays now include the previously untranslated settings and interface text.
+
+### Fixed
+
+- **Stopped boss castbars stay hidden.** HUD visibility refreshes no longer
+  reveal a castbar after its boss frame disappears.
+- **Settings search opens the intended destination.** Group Frames, Nameplates,
+  and Action Bars results now resolve to their correct subpages.
+
 ## v5.2.2-beta5 - 2026-08-23
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta5
+## Version: 5.2.2-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,34 +8,34 @@ nav_order: 5
 
 This page summarizes the user-facing changes since the last mainline release. For every beta entry and technical fix, see the full [CHANGELOG.md](https://github.com/zol-wow/QUI/blob/main/CHANGELOG.md).
 
-## Current Release: 5.2.2-beta5
+## Current Release: 5.2.2-beta6
 
 {: .warning }
 **WoW 12.1 only.** This build targets patch 12.1 (interface 120100) and will not load on the 12.0.x client.
 
-QUI 5.2.2-beta5 continues the 5.2.2 beta line with profile sharing, aura-display
-visibility controls, and safer combat reloads.
+QUI 5.2.2-beta6 continues the 5.2.2 beta line with combat UI additions,
+search-routing fixes, and complete localization coverage.
 
 {: .important }
 Back up your `WTF` folder before updating. Manual installs must copy every `QUI*` folder from the release zip into `Interface\AddOns\`.
 
-## What's New in 5.2.2-beta5
+## What's New in 5.2.2-beta6
 
-### Profiles and aura displays
+### Combat UI
 
-- **Feature settings can be shared across profiles** for Aura Displays and
-  Group / Raid Frames without replacing click-cast bindings.
-- **Tracked aura displays can keep inactive icons visible** with active-only,
-  instance-only, or always-visible placeholder modes.
+- **Group-frame click-casting supports items** alongside spell bindings.
+- **Tracked nameplate debuffs can tint health bars** with configurable color and
+  opacity.
+- **Damage Meter tooltips show player item level** from the shared inspection
+  cache.
+- **Totem Bar buttons can be resized** with a new Button Size setting.
 
 ### Beta fixes
 
-- **Combat reloads preserve protected UI ownership** across Cooldown Manager,
-  Chat, Info Bar, Minimap, and Travel startup paths.
-- **Cooldown charge and aura-phase state follows Blizzard's live sources**
-  while QUI preserves native ownership.
-- **Bank, guild-bank, and group-frame controls refresh safely** through native
-  protected flows and live layout state.
+- **Stopped boss castbars stay hidden** after their boss frame disappears.
+- **Settings search opens the intended Group Frames, Nameplates, and Action Bars
+  subpages.**
+- **All ten translated locale overlays cover the current settings surface.**
 
 ## What's New in 5.2.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ nav_order: 1
 A modular World of Warcraft UI suite for Midnight 12.1+ that you can install, understand, and tune from one settings experience.
 {: .fs-6 .fw-300 }
 
-**Current Release: 5.2.2-beta5**
+**Current Release: 5.2.2-beta6**
 {: .label .label-purple }
 
 [Get Started](getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }


### PR DESCRIPTION
## Summary

- bump all 11 shipped TOCs to 5.2.2-beta6
- add the beta6 changelog and documentation summary

## Verification

- release-note extractor dry run
- generated search, i18n, and event artifacts current
- `bash tools/test.sh` on the working tree and committed tree
- 865 unit tests passed; all nine gates passed