### PR TITLE
Fix CDM proc-glow cleanup on release

### DIFF
--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -4180,6 +4180,9 @@ function CDMIcons.OnFactoryIconReleased(icon)
         ns.CDMRuntimeStore.ClearFrame(icon)
     end
     UnmirrorBlizzCooldown(icon)
+    if ns._OwnedGlows and ns._OwnedGlows.StopGlow then
+        ns._OwnedGlows.StopGlow(icon)
+    end
     if ns._OwnedGlows and ns._OwnedGlows.ClearPandemicState then
         ns._OwnedGlows.ClearPandemicState(icon)
     end

--- a/QUI_CDM/cdm/cdm_reanchor_hooks.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_hooks.lua
@@ -310,6 +310,15 @@ function CDMReanchorHooks:InstallViewerHooks(getViewer)
                     hooks:MarkAcquire(key)
                 end
                 hooksec(pool, "Acquire", function(...) _securecall(onPoolAcquire, ...) end)
+                if pool.Release then
+                    local function onPoolRelease(_, itemFrame)
+                        local procGlow = ns._cdmReanchorProcGlow
+                        if procGlow and procGlow.OnRelease then
+                            procGlow:OnRelease(itemFrame)
+                        end
+                    end
+                    hooksec(pool, "Release", function(...) _securecall(onPoolRelease, ...) end)
+                end
             end
             EnumerateViewerFrames(viewer, function(frame)
                 self:_InstallFrameHooks(frame, key)
@@ -460,6 +469,11 @@ function CDMReanchorProcGlow:OnClaim(frame, entry)
     if current ~= nil and current ~= ProcGlowLatchKey(entry) then
         self:_StopFor(frame)
     end
+end
+
+function CDMReanchorProcGlow:OnRelease(frame)
+    if not frame or self._active[frame] == nil then return end
+    self:_StopFor(frame)
 end
 
 function CDMReanchorProcGlow:Install(manager)


### PR DESCRIPTION
## Summary
- stop owned proc glows when factory icons are released
- stop reanchor proc glows when native item pools release frames
- pin  beta to the regression coverage commit

## Validation
- focused CDM tests pass
- == gate 1/9: compile check (luac 5.1) ==
luac (5.1): 1499 QUI-authored + 39 vendored lib Lua files compile cleanly
== gate 2/9: taint analyzer (strict, 32 shards) ==
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
taint: [32mno strict findings[0m
== gate 3/9: taint analyzer unit tests (tests/taint/) ==
taint tests: 7 files passed
== gate 4/9: profile fixture tests ==
QUI profile tests — 12 fixtures discovered

current/
  basic_fresh                           [32mok   [0m (174ms)
  cdm_item_auraonly_override            [32mok   [0m (109ms)
  cdm_item_in_buff_container            [32mok   [0m (110ms)
  channel-colors                        [32mok   [0m (118ms)
  damage_meter_appearance_default       [32mok   [0m (108ms)
  damage_meter_appearance_set           [32mok   [0m (111ms)
  damage_meter_set_default              [32mok   [0m (115ms)
  fresh_install_seed                    [32mok   [0m (185ms)
  skin_damage_meter_default             [32mok   [0m (108ms)
edge/
  empty_composer                        [32mok   [0m (116ms)
  idempotency_check                     [32mok   [0m (108ms)
  migration_backup_present              [32mok   [0m (117ms)

────────────────────────────────────────────────────────────
12 passed, 0 failed, 0 errored — 1543ms
== gate 5/9: unit tests (tests/unit/) ==
unit tests: 865 files passed
== gate 6/9: tooling + i18n unit tests ==
tooling tests: 5 files passed
locale overlays: match their writer
enUS parsers: agree with a real Lua load
delta translator: Codex provider wiring passed
== gate 7/9: luacheck (CI lint scope) ==
luacheck: clean across 18 CI targets
== gate 8/9: generated search cache is not stale ==
search cache: up to date
== gate 9/9: i18n base is not stale ==
i18n base: up to date
ALL GATES PASSED: ALL GATES PASSED
- 865 unit tests and 18 lint targets pass