### PR TITLE
fix: clear stale action bar range tint

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_events.lua
+++ b/QUI_ActionBars/actionbars/actionbars_events.lua
@@ -598,6 +598,7 @@ function OnOwnedEvent(self, event, ...)
 
     elseif event == "PLAYER_MOUNT_DISPLAY_CHANGED" then
         ScheduleABVisualUpdate()
+        ScheduleUsabilityUpdate()
 
     elseif event == "PET_BATTLE_OPENING_START" then
         if not InCombatLockdown() then

--- a/QUI_ActionBars/actionbars/actionbars_usability.lua
+++ b/QUI_ActionBars/actionbars/actionbars_usability.lua
@@ -23,10 +23,10 @@ else
 end
 
 local function ClearButtonTint(state)
-    if state.tinted then
-        if state.tintOverlay then state.tintOverlay:Hide() end
-        state.tinted = nil
-    end
+    if state.tintOverlay then state.tintOverlay:Hide() end
+    state.tinted = nil
+    state._fhTint = nil
+    state._fadeTint = nil
 end
 
 function GetTintOverlay(button)
@@ -54,7 +54,7 @@ function UpdateButtonUsability(button, settings, inRange, rangeKnown)
         return
     end
 
-    if state.fadeHidden or state.hiddenEmpty then
+    if state.hiddenEmpty then
         return
     end
 
@@ -86,6 +86,10 @@ function UpdateButtonUsability(button, settings, inRange, rangeKnown)
         end
     end
 
+    if not newTint then
+        ClearButtonTint(state)
+        return
+    end
     if state.tinted == newTint then return end
 
     if newTint == "range" then
@@ -112,9 +116,6 @@ function UpdateButtonUsability(button, settings, inRange, rangeKnown)
             overlay:Show()
         end
         state.tinted = "unusable"
-    else
-        if state.tintOverlay then state.tintOverlay:Hide() end
-        state.tinted = nil
     end
 end
 


### PR DESCRIPTION
## Summary
- repaint action-bar usability after mount display changes
- consume range changes while bars are faded and retire deferred tint restores
- pin QUI-tests regression coverage from zol-wow/QUI-tests#8

## Verification
- bash tools/test.sh: ALL GATES PASSED
- focused mutation: removing partial-fade cleanup fails the intended assertion