### PR TITLE
chore: refresh FrameXML corpus to 12.1.0.69465

### DIFF
--- a/meta/wow-api.lua
+++ b/meta/wow-api.lua
@@ -18935,9 +18935,11 @@ function UnitBattlePetSpeciesID(unit, ...) end
 function UnitBattlePetType(unit, ...) end
 ---@param unit? any
 ---@param target? any
+---@param canAssistImmunePC? boolean
+---@param canAssistUninteractable? boolean
 ---@param ... any
 ---@return boolean result
-function UnitCanAssist(unit, target, ...) end
+function UnitCanAssist(unit, target, canAssistImmunePC, canAssistUninteractable, ...) end
 ---@param unit? any
 ---@param target? any
 ---@param ... any
@@ -19373,6 +19375,11 @@ function UnitIsPVPSanctuary(unit, ...) end
 ---@param ... any
 ---@return boolean result
 function UnitIsPlayer(unit, partyIndex, ...) end
+--- Returns true for 'player', 'pet', 'vehicle', or any of 'partyn', 'partypetn', 'raidn', 'raidpetn'
+---@param unit? any
+---@param ... any
+---@return boolean result
+function UnitIsPlayerControlledOrGroupMember(unit, ...) end
 ---@param unit? any
 ---@param ... any
 ---@return boolean result

--- a/meta/wow-globals.lua
+++ b/meta/wow-globals.lua
@@ -677,6 +677,7 @@ SELL_ALL_JUNK_ITEMS_EXCLUDE_FLAG = nil ---@type any
 SHAMAN_TOTEM_PRIORITIES = nil ---@type any
 SLASH_QUICLEARSCAN1 = nil ---@type any
 SLASH_QUIDATAPANELS1 = nil ---@type any
+SLASH_QUIIC1 = nil ---@type any
 SLASH_QUIIMPLUSTIMER1 = nil ---@type any
 SLASH_QUIKB1 = nil ---@type any
 SLASH_QUILOG1 = nil ---@type any


### PR DESCRIPTION
## Summary

- pin QUI-tests to the merged 12.1.0.69465 FrameXML and Blizzard API corpus refresh
- regenerate LuaLS API definitions for the new Unit API surface
- restore the generated slash-command global already declared by the lint contract

Sidecar: zol-wow/QUI-tests#12

## Testing

- lua tests/api-docs/extract_test.lua
- lua tools/lua_defs_gen_test.lua
- lua tools/test_taint.lua --self-test
- bash tools/test.sh