### PR TITLE
fix(cdm): contain native viewer taint

### DIFF
--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -3171,7 +3171,6 @@ function ownedEngine:BootstrapReanchorRuntime()
                 shouldTrackCooldownID = function(key) return key == "buff" end,
                 ignoreIndexReasons = { refresh_layout = true },
                 immediateRefreshLayoutKeys = { buff = true },
-                immediateAcquireKeys = { buff = true },
                 blank = BlankReanchoredNativeItemFrame,
                 blankKeys = { buff = true },
                 isClaimed = function(frame)
@@ -3209,7 +3208,6 @@ function ownedEngine:BootstrapReanchorRuntime()
                 schedule = function(fn) C_Timer.After(0.05, fn) end,
                 scheduleActiveState = scheduleActiveState,
                 immediateRefreshLayoutKeys = { trackedBar = true },
-                immediateAcquireKeys = { trackedBar = true },
                 blank = BlankReanchoredNativeItemFrame,
                 blankKeys = { trackedBar = true },
                 isInitWindow = function() return ns._inInitSafeWindow == true end,

--- a/QUI_CDM/cdm/cdm_editmode_policy.lua
+++ b/QUI_CDM/cdm/cdm_editmode_policy.lua
@@ -39,6 +39,38 @@ end
 
 local _applied = false
 
+local function RequireReload()
+    local function reloadUI()
+        if _G.ReloadUI then _G.ReloadUI() end
+    end
+    local function showPopup()
+        if not (_G.StaticPopupDialogs and _G.StaticPopup_Show) then
+            reloadUI()
+            return
+        end
+        _G.StaticPopupDialogs["QUI_CDM_EDITMODE_RELOAD"] = {
+            text = "QUI has updated your Cooldown Manager Edit Mode settings"
+                .. " (viewers must be Always visible with Hide When Inactive on"
+                .. " for cooldown tracking to work).\n\nA UI reload is required"
+                .. " to apply them.",
+            button1 = "Reload UI",
+            OnAccept = reloadUI,
+            timeout = 0,
+            whileDead = 1,
+            hideOnEscape = false,
+            preferredIndex = 3,
+        }
+        if not _G.StaticPopup_Show("QUI_CDM_EDITMODE_RELOAD") then
+            reloadUI()
+        end
+    end
+    if _G.C_Timer and _G.C_Timer.After then
+        _G.C_Timer.After(0, showPopup)
+    else
+        showPopup()
+    end
+end
+
 function CDMEditModePolicy.Enforce()
     if _applied then return end
     if _G.QUI_IsCDMMasterEnabled and not _G.QUI_IsCDMMasterEnabled() then return end
@@ -122,23 +154,7 @@ function CDMEditModePolicy.Enforce()
 
     C_EditMode.SaveLayouts(layoutInfo)
     if db then db.cdmEditModeSavePending = true end
-
-    if not (_G.StaticPopupDialogs and _G.StaticPopup_Show) then return end
-
-    _G.StaticPopupDialogs["QUI_CDM_EDITMODE_RELOAD"] = {
-        text = "QUI has updated your Cooldown Manager Edit Mode settings"
-            .. " (viewers must be Always visible with Hide When Inactive on"
-            .. " for cooldown tracking to work).\n\nA UI reload is required"
-            .. " to apply them.",
-        button1 = "Reload UI",
-        OnAccept = function()
-            if _G.ReloadUI then _G.ReloadUI() end
-        end,
-        timeout = 0,
-        whileDead = 1,
-        preferredIndex = 3,
-    }
-    _G.StaticPopup_Show("QUI_CDM_EDITMODE_RELOAD")
+    RequireReload()
 end
 
 local enforceFrame = CreateFrame("Frame")

--- a/QUI_CDM/cdm/cdm_reanchor_hooks.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_hooks.lua
@@ -72,7 +72,6 @@ function CDMReanchorHooks.New(deps)
         _getMixinForKey = deps.getMixinForKey,
         _blankKeys = deps.blankKeys or {},
         _immediateRefreshLayoutKeys = deps.immediateRefreshLayoutKeys or deps.immediateKeys or {},
-        _immediateAcquireKeys = deps.immediateAcquireKeys or {},
         _isClaimed = deps.isClaimed,
         _installGuard = deps.installGuard,
         _installGuardKeys = deps.installGuardKeys or {},
@@ -110,14 +109,6 @@ function CDMReanchorHooks:MarkImmediate(key)
         self._refreshMany({ key })
     elseif self._refresh then
         self._refresh(key)
-    end
-end
-
-function CDMReanchorHooks:MarkAcquire(key)
-    if self._immediateAcquireKeys[key] then
-        self:MarkImmediate(key)
-    else
-        self:MarkDirty(key)
     end
 end
 
@@ -292,7 +283,7 @@ function CDMReanchorHooks:InstallViewerHooks(getViewer)
                 local function onAcquire(_, itemFrame)
                     hooks:_InstallFrameHooks(itemFrame, key)
                     hooks:MaybeBlankOnAcquire(key, itemFrame)
-                    hooks:MarkAcquire(key)
+                    hooks:MarkDirty(key)
                 end
                 hooksec(viewer, "OnAcquireItemFrame", function(...) _securecall(onAcquire, ...) end)
             end
@@ -311,7 +302,7 @@ function CDMReanchorHooks:InstallViewerHooks(getViewer)
                     EnumerateViewerFrames(viewer, function(frame)
                         hooks:_InstallFrameHooks(frame, key)
                     end)
-                    hooks:MarkAcquire(key)
+                    hooks:MarkDirty(key)
                 end
                 hooksec(pool, "Acquire", function(...) _securecall(onPoolAcquire, ...) end)
                 if pool.Release then

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -208,8 +208,6 @@ local function _DecorateWork(decorator, live, shell, rowConfig)
     return decorator:Decorate(live, rowConfig)
 end
 
-local _barHooked = setmetatable({}, { __mode = "k" })
-
 local _barWidgets = setmetatable({}, { __mode = "k" })
 
 local function _ResolveBarIconTexture(live, entry)
@@ -373,31 +371,6 @@ CDMReanchorRealEnv._DecorateWork    = _DecorateWork
 CDMReanchorRealEnv._BarDecorateWork = _BarDecorateWork
 CDMReanchorRealEnv._BarReskinWork   = _BarReskinWork
 
-local function _InstallBarReskinHooks(live, getSettingsFn, key)
-    if _barHooked[live] or not hooksecurefunc then return end
-    _barHooked[live] = true
-    local function reapply()
-        _BarReskinWork(live, getSettingsFn and getSettingsFn(key) or nil)
-    end
-    if live.SetBarContent then hooksecurefunc(live, "SetBarContent", function() _securecall(reapply) end) end
-    if live.SetBarWidth then hooksecurefunc(live, "SetBarWidth", function() _securecall(reapply) end) end
-    local function hideOnShow(region)
-        if region and region.Show then
-            hooksecurefunc(region, "Show", function(self)
-                _securecall(function()
-                    if self.Hide then self:Hide() end
-                    if self.SetAlpha then self:SetAlpha(0) end
-                end)
-            end)
-        end
-    end
-    if live.Bar then
-        hideOnShow(live.Bar.Pip)
-        hideOnShow(live.Bar.BarBG)
-    end
-    hideOnShow(live.DebuffBorder)
-end
-
 function CDMReanchorRealEnv.BuildEnv(ctx)
     ctx = ctx or {}
     local Containers = ctx.CDMContainers or ns.CDMContainers
@@ -503,7 +476,6 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
     local decorate = function(live, shell, rowConfig, key)
         if key == "trackedBar" then
             _securecall(_BarDecorateWork, live, shell, ctx.getSettings and ctx.getSettings(key) or nil)
-            _InstallBarReskinHooks(live, ctx.getSettings, key)
             return true
         end
         if decorator then


### PR DESCRIPTION
## Summary
- require a reload immediately after the one automatic CDM Edit Mode save
- fall back to direct ReloadUI when the reload prompt cannot be shown
- defer Buff and Tracked Bar acquisition through the existing dirty scheduler
- retain reference-compatible immediate RefreshLayout and widget observation hooks
- remove unreachable native tracked-bar reskin hooks
- pin QUI-tests coverage merged in zol-wow/QUI-tests#19

## Verification
- bash tools/test.sh
  - Lua 5.1 compile: clean
  - strict taint analysis: no findings
  - profile fixtures: 12 passed
  - unit tests: 867 passed
  - luacheck: clean
  - generated search cache and i18n base: current
- focused CDM tests: 51 passed