### PR TITLE
release: v5.2.3-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.3-beta1 - 2026-08-24
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Opens the 5.2.3 beta line with account-wide feature pins, automatic runtime
+refreshes, and Cooldown Manager taint containment.
+
+### Added
+
+- **Aura Display and Group / Raid Frame settings can be pinned across every
+  profile.** The current profile supplies the shared settings, while individual
+  profiles can Ignore or Apply the pin without changing the source.
+
+### Fixed
+
+- **Action Bar range and usability tints clear when their live condition
+  ends.** Buttons repaint after mount and display changes and no longer retain
+  stale range or unusable overlays.
+- **Druid Resource Bars follow automatic form changes.** Fluid Form transitions
+  rebuild the active resource and reveal Cat Form combo points.
+- **Cooldown Manager Edit Mode corrections no longer leave native viewers
+  running in a tainted session.** QUI requires a reload after saving the
+  corrected layout and defers pooled-frame reclaims until Blizzard finishes
+  acquisition.
+
+## v5.2.2 - 2026-08-24
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+QUI 5.2.2 expands profile sharing, combat feedback, and group tools while
+hardening Cooldown Manager, protected UI, and native event handling.
+
+### Added
+
+- **Feature settings can be shared across profiles.** Aura Displays and Group /
+  Raid Frames can copy or pin settings without replacing click-cast bindings.
+- **Tracked aura displays can keep inactive icons visible.** Choose active-only,
+  instance-only, or always-visible placeholders with desaturated styling.
+- **Group-frame click-casting supports items.** Bind items to mouse buttons,
+  keyboard keys, or the mouse wheel.
+- **Group tools expose more actionable state.** Debuff gradients show
+  non-dispellable types, and raid releases can require Ctrl after a safety delay.
+- **Combat modules gain focused controls.** Cooldown Manager pressed effects,
+  Totem Bar sizing, and Damage Meter item-level tooltips are configurable.
+
+### Changed
+
+- **Action Bar range and usability colors follow native state events.** Updates
+  stay current through slot and paging changes without disabling shared events.
+- **Translations cover the complete settings surface.** All ten non-English
+  locale overlays include the previously missing interface text.
+
+### Fixed
+
+- **Cooldown Manager follows Blizzard's live cooldown sources.** Consumables,
+  charges, aura phases, item counts, cast highlights, and partial source updates
+  remain correct through combat, pooling, and remapping.
+- **Protected UI paths remain safe and current.** The Lust Timer, castbars, bank
+  controls, and combat-reload startup avoid restricted mutations and stale state.
+- **Group-frame visuals refresh consistently.** Names, range fades, life-state
+  colors, debuff indicators, and hidden aura buttons track their live state.
+- **Inactive tracked buff bars hide after Layout Mode exits.** Preview state no
+  longer leaves inactive owned bars visible.
+
 ## v5.2.2-beta9 - 2026-08-24
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.2-beta9
+## Version: 5.2.3-beta1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
## Summary\n\n- open the 5.2.3 beta line with account-wide profile pins and runtime fixes\n- stamp all 11 shipped TOCs as 5.2.3-beta1\n- pin the merged v5.2.3-beta1 docs update from QUI-docs PR #5\n- restore the stable v5.2.2 changelog section on beta\n\n## Prerequisite\n\n- QUI PR #820 refreshed the generated event allowlist\n\n## Tests\n\n- bash tools/i18n/gen_all_caches.sh\n- lua5.1 tools/generate_event_allowlist.lua\n- bash tools/test.sh (worktree)\n- bash tools/test.sh (detached shared clone of the committed tree)\n- ALL GATES PASSED