### PR TITLE
fix(actionbars): defer tints while bars are hidden

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_mouseover.lua
+++ b/QUI_ActionBars/actionbars/actionbars_mouseover.lua
@@ -49,6 +49,10 @@ function SetBarAlpha(barKey, alpha)
         elseif state.fadeHidden then
             FadeShowTextures(state, button)
         end
+        if not hidden and alpha >= 1 and state._fadeTint and state.tintOverlay then
+            state.tintOverlay:Show()
+            state._fadeTint = nil
+        end
     end
 
     local barFrame = GetBarFrame(barKey)

--- a/QUI_ActionBars/actionbars/actionbars_usability.lua
+++ b/QUI_ActionBars/actionbars/actionbars_usability.lua
@@ -92,30 +92,41 @@ function UpdateButtonUsability(button, settings, inRange, rangeKnown)
     end
     if state.tinted == newTint then return end
 
+    local overlay = GetTintOverlay(button)
     if newTint == "range" then
-        local overlay = GetTintOverlay(button)
         if overlay then
             local c = settings.rangeColor
             overlay:SetColorTexture(c and c[1] or 0.8, c and c[2] or 0.1, c and c[3] or 0.1, c and c[4] or 1)
-            overlay:Show()
         end
         state.tinted = "range"
     elseif newTint == "mana" then
-        local overlay = GetTintOverlay(button)
         if overlay then
             local c = settings.manaColor
             overlay:SetColorTexture(c and c[1] or 0.5, c and c[2] or 0.5, c and c[3] or 1.0, c and c[4] or 1)
-            overlay:Show()
         end
         state.tinted = "mana"
     elseif newTint == "unusable" then
-        local overlay = GetTintOverlay(button)
         if overlay then
             local c = settings.usabilityColor
             overlay:SetColorTexture(c and c[1] or 0.4, c and c[2] or 0.4, c and c[3] or 0.4, c and c[4] or 1)
-            overlay:Show()
         end
         state.tinted = "unusable"
+    end
+
+    if not overlay then return end
+    if state.fadeHidden then
+        overlay:Hide()
+        state._fhTint = true
+        return
+    end
+
+    local barKey = GetBarKeyFromButton(button)
+    local barFadeState = barKey and ActionBarsOwned.fadeState[barKey]
+    if barFadeState and barFadeState.currentAlpha < 1 then
+        overlay:Hide()
+        state._fadeTint = true
+    else
+        overlay:Show()
     end
 end
 


### PR DESCRIPTION
## Summary
- keep newly created usability tint overlays hidden while an owned action bar is fully hidden
- defer tint visibility during partial fades until the bar returns to full alpha
- add full-hide and partial-fade regressions in the pinned QUI-tests sidecar

## Verification
- bash tools/test.sh: all nine gates passed
- independent exact-delta review: no findings