### PR TITLE
fix(groupframes): defer aura layering in combat

### DIFF
--- a/QUI_GroupFrames/groupframes/groupframes_auras.lua
+++ b/QUI_GroupFrames/groupframes/groupframes_auras.lua
@@ -1337,15 +1337,12 @@ local function ApplyElementPass(frame, allowCreate)
             AnchorElementContainer(container, host, element)
         end,
         onContainerReady = function(container, host)
+            if InCombatLockdown() then return false end
             local desiredLevel = host:GetFrameLevel() + CHROME_LEVELS.AURA_HOST
             local desiredStrata = host.healthBar and host.healthBar:GetFrameStrata()
-            if not InCombatLockdown() then
-                if desiredStrata then container:SetFrameStrata(desiredStrata) end
-                container:SetFrameLevel(desiredLevel)
-                return true
-            end
-            return container:GetFrameLevel() == desiredLevel
-                and (not desiredStrata or container:GetFrameStrata() == desiredStrata)
+            if desiredStrata then container:SetFrameStrata(desiredStrata) end
+            container:SetFrameLevel(desiredLevel)
+            return true
         end,
         onIncomplete = QueueContainerCombatWork,
     })


### PR DESCRIPTION
## Summary
- stop GroupFrames aura containers from reading secret-capable frame layering during combat
- keep the existing out-of-combat strata and level writes
- mark the pass incomplete so the existing deduplicated regen replay repairs layering afterward
- pin zol-wow/QUI-tests#22 with behavioral regression coverage

## Testing
- mutation check: restoring the unsafe combat comparison fails aura_surface_call_site_contract_test.lua
- bash tools/test.sh