### PR TITLE
fix(objectives): avoid LayoutContents aura taint

### DIFF
--- a/modules/skinning/gameplay/objectivetracker.lua
+++ b/modules/skinning/gameplay/objectivetracker.lua
@@ -875,10 +875,6 @@ local function SkinObjectiveTracker()
                 hooksecurefunc(tracker, "SetCollapsed", DeferredScheduleBackdropUpdate)
             end
 
-            if tracker.LayoutContents then
-                hooksecurefunc(tracker, "LayoutContents", DeferredScheduleBackdropUpdate)
-            end
-
             if tracker.AddBlock and not SkinBase.GetFrameData(tracker, "addBlockHooked") then
                 hooksecurefunc(tracker, "AddBlock", function(trackerSelf, block)
                     C_Timer.After(0, function()


### PR DESCRIPTION
## Summary
- stop hooking Blizzard objective-module `LayoutContents` methods
- rely on the existing parent `ObjectiveTrackerFrame:Update` hook for deferred skin work
- pin the boundary through merged QUI-tests PR #25

## Cause
The Scenario tracker reaches restricted Maw aura access from `LayoutContents`. QUI retained a redundant per-module hook after retreating from Scenario/UIWidget tracker internals.

## Verification
- regression failed before the deletion and passes after it
- `bash tools/test.sh` — all 9 gates passed with 870 unit files
- independent exact-diff review: ALLOW

## Live follow-up
A fresh `/reload` plus M+ entry remains the final runtime confirmation because taint persists for the current session.