### PR TITLE
fix(keybinds): exclude editor widgets from action sweep

### DIFF
--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -719,6 +719,8 @@ local function ProcessCachedActionButton(button)
 end
 
 local function LooksLikeActionButton(frame)
+    local objectType = frame:GetObjectType()
+    if objectType ~= "Button" and objectType ~= "CheckButton" then return false end
     if frame.action then return true end
     return type(frame.GetAction) == "function"
 end


### PR DESCRIPTION
## Summary
- restrict the catch-all action-button sweep to Button and CheckButton widgets
- avoid invoking OPie's editor-only GetAction(into) API during keybind cache rebuilds
- pin QUI-tests coverage proving the OPie editor is skipped while real action buttons remain discoverable

## Verification
- focused keybind regression failed before the source fix and passes afterward
- bash tools/test.sh (all nine gates; 870 unit files)

Sidecar: zol-wow/QUI-tests#26