### PR TITLE
feat(alts): improve window table layout

### DIFF
--- a/core/defaults.lua
+++ b/core/defaults.lua
@@ -546,7 +546,7 @@ local defaults = {
 
         alts = {
             enabled = true,
-            window = { point = "CENTER", x = 0, y = 0, width = 920, height = 540 },
+            window = { point = "CENTER", relativePoint = "CENTER", x = 0, y = 0, width = 920, height = 540 },
             columns = {
                 ilvl = true, gold = true, played = true, rested = true,
                 zone = true, lastSeen = true, professions = true,

--- a/modules/alts/views/currencies.lua
+++ b/modules/alts/views/currencies.lua
@@ -13,9 +13,8 @@ local UIKit = ns.UIKit
 local CurrenciesView = {}
 Alts.CurrenciesView = CurrenciesView
 
-local ROW_H, FOOTER_H = 22, 22
+local ROW_H, TOP_H, FOOTER_H = 22, 28, 22
 local CELL_PAD = 6
-local NAME_W = 280
 local ICON_SIZE = 16
 
 local function CommaNumber(n)
@@ -55,6 +54,22 @@ function CurrenciesView.BuildDisplayRows(characters, names, filter)
     return rows
 end
 
+function CurrenciesView.ValueText(qty, info)
+    local text = CurrenciesView.FormatQuantity(qty, info and info.max)
+    if info and info.account then text = text .. " (account)" end
+    return text
+end
+
+function CurrenciesView.ColumnWidths(rows, measure)
+    local nameWidth, valueWidth = 0, 0
+    for _, row in ipairs(rows or {}) do
+        nameWidth = math.max(nameWidth, measure(row.label or "") or 0)
+        valueWidth = math.max(valueWidth, measure(row.valueText or "") or 0)
+    end
+    return math.ceil(nameWidth) + CELL_PAD * 2 + ICON_SIZE + 6,
+        math.ceil(valueWidth) + CELL_PAD * 2
+end
+
 local function Builder(parent)
     local Store = ns.Storage and ns.Storage.Store
     local Bus   = ns.Storage and ns.Storage.Bus
@@ -67,6 +82,8 @@ local function Builder(parent)
     local rows        = {}
     local rowPool     = {}
     local selectedKey = nil
+    local nameWidth   = CELL_PAD * 2 + ICON_SIZE + 6
+    local valueWidth  = CELL_PAD * 2
 
     local cachedChars = {}
     local liveInfo = {}
@@ -92,7 +109,7 @@ local function Builder(parent)
 
     local function VisibleRows()
         local h = frame:GetHeight() or 0
-        local usable = h - FOOTER_H
+        local usable = h - TOP_H - FOOTER_H
         if usable < ROW_H then return 1 end
         return math.max(1, math.floor(usable / ROW_H))
     end
@@ -100,6 +117,16 @@ local function Builder(parent)
     local footer = MakeFS(frame, 11)
     footer:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", CELL_PAD, 4)
     footer:SetTextColor(0.8, 0.8, 0.8)
+
+    local measure = MakeFS(frame, 11)
+    measure:Hide()
+    local function Measure(text)
+        measure:SetText(text or "")
+        if measure.GetUnboundedStringWidth then
+            return measure:GetUnboundedStringWidth() or 0
+        end
+        return measure:GetStringWidth() or 0
+    end
 
     local selector = CreateFrame("Button", nil, frame)
     selector:SetHeight(22)
@@ -237,7 +264,9 @@ local function Builder(parent)
         r._icon:SetPoint("LEFT", r, "LEFT", CELL_PAD, 0)
         r._name  = MakeFS(r, 11)
         r._name:SetPoint("LEFT", r, "LEFT", CELL_PAD + ICON_SIZE + 6, 0)
+        r._name:SetJustifyH("LEFT")
         r._value = MakeFS(r, 11)
+        r._value:SetJustifyH("LEFT")
         r:RegisterForClicks("LeftButtonUp", "RightButtonUp")
         r:SetScript("OnClick", function(self, button)
             if button ~= "RightButton" then return end
@@ -260,8 +289,7 @@ local function Builder(parent)
         if offset > maxOff then offset = maxOff end
         if offset < 0 then offset = 0 end
 
-        local topY = -28
-        local selRec = selectedKey and cachedChars[selectedKey]
+        local topY = -TOP_H
 
         for i = 1, visible do
             local r   = GetRow(i)
@@ -275,7 +303,7 @@ local function Builder(parent)
                 r:Hide()
             else
                 r._row = row
-                local info = ResolveInfo(row.currencyID)
+                local info = row.info
                 if info and info.icon then
                     r._icon:SetTexture(info.icon)
                     r._icon:Show()
@@ -283,18 +311,15 @@ local function Builder(parent)
                     r._icon:Hide()
                 end
 
-                r._name:SetWidth(NAME_W - CELL_PAD - ICON_SIZE - 6)
+                r._name:SetWidth(math.max(1, nameWidth - CELL_PAD * 2 - ICON_SIZE - 6))
                 r._name:SetText(row.label)
                 r._name:SetTextColor(0.9, 0.9, 0.9)
 
-                local qty = selRec and selRec.currencies
-                    and selRec.currencies[row.currencyID]
-                local text = CurrenciesView.FormatQuantity(qty, info and info.max)
-                if info and info.account then text = text .. " (account)" end
+                local qty = row.quantity
                 r._value:ClearAllPoints()
-                r._value:SetPoint("LEFT", r, "LEFT", NAME_W + CELL_PAD, 0)
-                r._value:SetWidth(math.max(1, (frame:GetWidth() or 0) - NAME_W - CELL_PAD * 2 - Shared.SCROLLBAR_RESERVE))
-                r._value:SetText(text)
+                r._value:SetPoint("LEFT", r, "LEFT", nameWidth + CELL_PAD, 0)
+                r._value:SetWidth(math.max(1, valueWidth - CELL_PAD * 2))
+                r._value:SetText(row.valueText)
                 if qty == nil then
                     r._value:SetTextColor(0.5, 0.5, 0.5)
                 else
@@ -350,6 +375,13 @@ local function Builder(parent)
         end
         local filter = (Alts.GetSettings and Alts.GetSettings() or {}).currencyFilter
         rows = CurrenciesView.BuildDisplayRows(cachedChars, names, filter)
+        local selRec = selectedKey and cachedChars[selectedKey]
+        for _, row in ipairs(rows) do
+            row.info = ResolveInfo(row.currencyID)
+            row.quantity = selRec and selRec.currencies and selRec.currencies[row.currencyID]
+            row.valueText = CurrenciesView.ValueText(row.quantity, row.info)
+        end
+        nameWidth, valueWidth = CurrenciesView.ColumnWidths(rows, Measure)
 
         UpdateSelectorLabel()
         RenderRows()

--- a/modules/alts/views/weeklies.lua
+++ b/modules/alts/views/weeklies.lua
@@ -13,13 +13,16 @@ local RD = Alts.RosterData
 local WeekliesView = {}
 Alts.WeekliesView = WeekliesView
 
-local ROW_H, FOOTER_H = 22, 22
+local ROW_H, HDR_H, FOOTER_H = 22, 20, 22
 local CELL_PAD = 6
 local LOCKOUT_INDENT = 24
 
-local NAME_W    = 160
-local RATING_W  = 60
-local KEYSTONE_W = 180
+local COLUMN_LABELS = {
+    ns.L["Character"],
+    ns.L["M+ Rating"],
+    ns.L["Mythic+ Keystone"],
+    ns.L["Great Vault"],
+}
 
 local VAULT_TYPE_LABEL = {
     [1] = "Raid",
@@ -165,6 +168,35 @@ function WeekliesView.BuildDisplayRows(characters)
     return rows
 end
 
+function WeekliesView.CellTexts(row)
+    if not (row and row.kind == "char") then return nil end
+    local w = row.weeklies
+    local rating = w and w.mplusRating
+    return {
+        row.name or row.key or "?",
+        rating and rating > 0 and string.format("%d", rating) or "—",
+        WeekliesView.KeystoneText(w),
+        WeekliesView.VaultSummary(w),
+    }
+end
+
+function WeekliesView.ColumnWidths(rows, measure)
+    local widths = {}
+    for i, label in ipairs(COLUMN_LABELS) do
+        widths[i] = math.ceil(measure(label) or 0) + CELL_PAD * 2
+    end
+    for _, row in ipairs(rows or {}) do
+        local texts = row.cellTexts or WeekliesView.CellTexts(row)
+        row.cellTexts = texts
+        if texts then
+            for i, text in ipairs(texts) do
+                widths[i] = math.max(widths[i], math.ceil(measure(text) or 0) + CELL_PAD * 2)
+            end
+        end
+    end
+    return widths
+end
+
 local function Builder(parent)
     local Store = ns.Storage and ns.Storage.Store
     local Bus   = ns.Storage and ns.Storage.Bus
@@ -177,10 +209,11 @@ local function Builder(parent)
     local rows    = {}
     local rowPool = {}
     local charCount = 0
+    local colWidths = {}
 
     local function VisibleRows()
         local h = frame:GetHeight() or 0
-        local usable = h - FOOTER_H
+        local usable = h - HDR_H - FOOTER_H
         if usable < ROW_H then return 1 end
         return math.max(1, math.floor(usable / ROW_H))
     end
@@ -188,6 +221,35 @@ local function Builder(parent)
     local footer = MakeFS(frame, 11)
     footer:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", CELL_PAD, 4)
     footer:SetTextColor(0.8, 0.8, 0.8)
+
+    local measure = MakeFS(frame, 11)
+    measure:Hide()
+    local function Measure(text)
+        measure:SetText(text or "")
+        if measure.GetUnboundedStringWidth then
+            return measure:GetUnboundedStringWidth() or 0
+        end
+        return measure:GetStringWidth() or 0
+    end
+
+    local headers = {}
+    for i, label in ipairs(COLUMN_LABELS) do
+        local header = MakeFS(frame, 11)
+        header:SetText(label)
+        header:SetTextColor(1, 0.82, 0)
+        header:SetJustifyH("LEFT")
+        headers[i] = header
+    end
+
+    local function LayoutHeaders()
+        local x = 0
+        for i, header in ipairs(headers) do
+            header:ClearAllPoints()
+            header:SetPoint("TOPLEFT", frame, "TOPLEFT", x + CELL_PAD, 0)
+            header:SetWidth(math.max(1, colWidths[i] - CELL_PAD * 2))
+            x = x + colWidths[i]
+        end
+    end
 
     local function GetRow(i)
         local r = rowPool[i]
@@ -198,6 +260,11 @@ local function Builder(parent)
         r._keystone = MakeFS(r, 11)
         r._vault   = MakeFS(r, 11)
         r._lockout = MakeFS(r, 11)
+        r._name:SetJustifyH("LEFT")
+        r._rating:SetJustifyH("LEFT")
+        r._keystone:SetJustifyH("LEFT")
+        r._vault:SetJustifyH("LEFT")
+        r._lockout:SetJustifyH("LEFT")
         rowPool[i] = r
         return r
     end
@@ -212,46 +279,41 @@ local function Builder(parent)
             local r   = GetRow(i)
             local row = rows[offset + i]
             r:ClearAllPoints()
-            r:SetPoint("TOPLEFT",  frame, "TOPLEFT",  0, -(i - 1) * ROW_H)
-            r:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -Shared.SCROLLBAR_RESERVE, -(i - 1) * ROW_H)
+            r:SetPoint("TOPLEFT",  frame, "TOPLEFT",  0, -HDR_H - (i - 1) * ROW_H)
+            r:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -Shared.SCROLLBAR_RESERVE, -HDR_H - (i - 1) * ROW_H)
 
             if not row then
                 r._row = nil
                 r:Hide()
             elseif row.kind == "char" then
                 r._row = row
+                local texts = row.cellTexts
                 r._name:ClearAllPoints()
                 r._name:SetPoint("LEFT", r, "LEFT", CELL_PAD, 0)
-                r._name:SetWidth(NAME_W - CELL_PAD * 2)
-                r._name:SetText(row.name or row.key or "?")
+                r._name:SetWidth(math.max(1, colWidths[1] - CELL_PAD * 2))
+                r._name:SetText(texts[1])
                 local cr, cg, cb = ClassColor(row.class)
                 r._name:SetTextColor(cr, cg, cb)
                 r._name:Show()
 
-                local w = row.weeklies
-                local rating = w and w.mplusRating
                 r._rating:ClearAllPoints()
-                r._rating:SetPoint("LEFT", r, "LEFT", NAME_W + CELL_PAD, 0)
-                r._rating:SetWidth(RATING_W - CELL_PAD * 2)
-                if rating and rating > 0 then
-                    r._rating:SetText(string.format("%d", rating))
-                else
-                    r._rating:SetText("—")
-                end
+                r._rating:SetPoint("LEFT", r, "LEFT", colWidths[1] + CELL_PAD, 0)
+                r._rating:SetWidth(math.max(1, colWidths[2] - CELL_PAD * 2))
+                r._rating:SetText(texts[2])
                 r._rating:SetTextColor(0.9, 0.9, 0.9)
                 r._rating:Show()
 
                 r._keystone:ClearAllPoints()
-                r._keystone:SetPoint("LEFT", r, "LEFT", NAME_W + RATING_W + CELL_PAD, 0)
-                r._keystone:SetWidth(KEYSTONE_W - CELL_PAD * 2)
-                r._keystone:SetText(WeekliesView.KeystoneText(w))
+                r._keystone:SetPoint("LEFT", r, "LEFT", colWidths[1] + colWidths[2] + CELL_PAD, 0)
+                r._keystone:SetWidth(math.max(1, colWidths[3] - CELL_PAD * 2))
+                r._keystone:SetText(texts[3])
                 r._keystone:SetTextColor(0.9, 0.9, 0.9)
                 r._keystone:Show()
 
                 r._vault:ClearAllPoints()
-                r._vault:SetPoint("LEFT", r, "LEFT", NAME_W + RATING_W + KEYSTONE_W + CELL_PAD, 0)
-                r._vault:SetPoint("RIGHT", r, "RIGHT", -CELL_PAD, 0)
-                r._vault:SetText(WeekliesView.VaultSummary(w))
+                r._vault:SetPoint("LEFT", r, "LEFT", colWidths[1] + colWidths[2] + colWidths[3] + CELL_PAD, 0)
+                r._vault:SetWidth(math.max(1, colWidths[4] - CELL_PAD * 2))
+                r._vault:SetText(texts[4])
                 r._vault:SetTextColor(0.9, 0.9, 0.9)
                 r._vault:Show()
 
@@ -297,7 +359,9 @@ local function Builder(parent)
         end
 
         rows = WeekliesView.BuildDisplayRows(chars)
+        colWidths = WeekliesView.ColumnWidths(rows, Measure)
 
+        LayoutHeaders()
         RenderRows()
         footer:SetText(string.format("%d characters", charCount))
     end
@@ -306,7 +370,7 @@ local function Builder(parent)
         orientation = "vertical",
         onScroll = function(n) offset = n; RenderRows() end,
     })
-    scrollbar.track:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -2, 0)
+    scrollbar.track:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -2, -HDR_H)
     scrollbar.track:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -2, FOOTER_H)
 
     frame:EnableMouseWheel(true)
@@ -327,6 +391,9 @@ local function Builder(parent)
         Bus.Subscribe("CharacterChanged", OnBus)
         Bus.Subscribe("CharacterDeleted", OnBus)
     end
+
+    colWidths = WeekliesView.ColumnWidths({}, Measure)
+    LayoutHeaders()
 
     return view
 end

--- a/modules/alts/views/window.lua
+++ b/modules/alts/views/window.lua
@@ -16,6 +16,7 @@ local Window = {}
 Alts.Window = Window
 
 local HEADER_H, SIDEBAR_W, TAB_H, TAB_GAP, PAD = 32, 120, 26, 2, 10
+local MIN_W, MIN_H = 900, 300
 
 local win
 local tabs = {}
@@ -130,6 +131,28 @@ local function SelectTab(id)
     end
 end
 
+local function RefreshActiveView()
+    if not (win and win:IsShown()) then return end
+    for _, t in ipairs(tabs) do
+        if t.id == activeTab and t.view and t.view.Refresh then t.view.Refresh() end
+    end
+end
+
+local function SaveGeometry(includeSize)
+    local s = Settings()
+    if not s then return end
+    local point, _, relativePoint, x, y = win:GetPoint()
+    if point then
+        local core = Helpers.GetCore()
+        if core and core.PixelRound then x, y = core:PixelRound(x), core:PixelRound(y) end
+        s.point, s.relativePoint, s.x, s.y = point, relativePoint or point, x, y
+    end
+    if includeSize then
+        s.width = math.floor((win:GetWidth() or MIN_W) + 0.5)
+        s.height = math.floor((win:GetHeight() or MIN_H) + 0.5)
+    end
+end
+
 local function BuildSidebarTabs()
     local fontPath = Helpers.GetGeneralFont() or STANDARD_TEXT_FONT
     local outline = Helpers.GetGeneralFontOutline() or "OUTLINE"
@@ -183,17 +206,35 @@ end
 
 local function Build()
     local cfg = Settings()
+    local interaction
     win = CreateFrame("Frame", "QUI_AltsWindow", UIParent)
     win:SetSize((cfg and cfg.width) or 920, (cfg and cfg.height) or 540)
-    win:SetPoint((cfg and cfg.point) or "CENTER", UIParent, (cfg and cfg.point) or "CENTER",
+    win:SetPoint((cfg and cfg.point) or "CENTER", UIParent,
+        (cfg and (cfg.relativePoint or cfg.point)) or "CENTER",
         (cfg and cfg.x) or 0, (cfg and cfg.y) or 0)
     win:SetFrameStrata("HIGH")
     win:SetToplevel(true)
     win:SetMovable(true)
+    win:SetResizable(true)
+    win:SetResizeBounds(MIN_W, MIN_H)
     win:EnableMouse(true)
     win:SetClampedToScreen(true)
     if win.SetDontSavePosition then win:SetDontSavePosition(true) end
     win:Hide()
+
+    local function FinishInteraction()
+        if not interaction then return end
+        local active = interaction
+        interaction = nil
+        win:StopMovingOrSizing()
+        SaveGeometry(active == "resize")
+        if active == "resize" then RefreshActiveView() end
+    end
+
+    win:SetScript("OnEvent", function(_, event)
+        if event == "PLAYER_REGEN_DISABLED" then FinishInteraction() end
+    end)
+    win:RegisterEvent("PLAYER_REGEN_DISABLED")
 
     win._bg = win:CreateTexture(nil, "BACKGROUND")
     win._bg:SetAllPoints()
@@ -207,15 +248,14 @@ local function Build()
     header:SetHeight(HEADER_H)
     header:EnableMouse(true)
     header:RegisterForDrag("LeftButton")
-    header:SetScript("OnDragStart", function() win:StartMoving() end)
+    header:SetScript("OnDragStart", function()
+        if InCombatLockdown and InCombatLockdown() then return end
+        win:StartMoving()
+        interaction = "move"
+    end)
     header:SetScript("OnDragStop", function()
-        win:StopMovingOrSizing()
-        local point, _, _, x, y = win:GetPoint()
-        if not point then return end
-        local core = Helpers.GetCore()
-        if core and core.PixelRound then x, y = core:PixelRound(x), core:PixelRound(y) end
-        local s = Settings()
-        if s then s.point, s.x, s.y = point, x, y end
+        if interaction ~= "move" then return end
+        FinishInteraction()
     end)
     win._header = header
 
@@ -271,6 +311,30 @@ local function Build()
     win._body:SetPoint("TOPLEFT", 8, -8)
     win._body:SetPoint("BOTTOMRIGHT", -8, 8)
 
+    local resize = CreateFrame("Button", nil, win)
+    resize:SetSize(16, 16)
+    resize:SetPoint("BOTTOMRIGHT", -4, 4)
+    resize:SetFrameLevel(win:GetFrameLevel() + 10)
+    resize:SetNormalTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Up")
+    resize:SetHighlightTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Highlight")
+    resize:SetPushedTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Down")
+    resize:SetScript("OnMouseDown", function(_, button)
+        if button ~= "LeftButton" or interaction then return end
+        if InCombatLockdown and InCombatLockdown() then return end
+        local left, top = win:GetLeft(), win:GetTop()
+        if left and top then
+            win:ClearAllPoints()
+            win:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", left, top)
+        end
+        win:StartSizing("BOTTOMRIGHT")
+        interaction = "resize"
+    end)
+    resize:SetScript("OnMouseUp", function(_, button)
+        if button ~= "LeftButton" or interaction ~= "resize" then return end
+        FinishInteraction()
+    end)
+    win._resize = resize
+
     BuildSidebarTabs()
     for _, t in ipairs(tabs) do
         t.view = t.builder(win._body)
@@ -279,7 +343,7 @@ local function Build()
     end
 
     win:SetScript("OnHide", function()
-        win:StopMovingOrSizing()
+        if interaction then FinishInteraction() end
     end)
 
     Reskin()
@@ -309,10 +373,7 @@ function Window.Toggle()
 end
 
 function Window.RefreshActive()
-    if not (win and win:IsShown()) then return end
-    for _, t in ipairs(tabs) do
-        if t.id == activeTab and t.view and t.view.Refresh then t.view.Refresh() end
-    end
+    RefreshActiveView()
 end
 
 if ns.Registry then
@@ -331,6 +392,8 @@ function Window.OnProfileChanged()
     local cfg = Settings()
     if not cfg then return end
     win:ClearAllPoints()
-    win:SetPoint(cfg.point or "CENTER", UIParent, cfg.point or "CENTER", cfg.x or 0, cfg.y or 0)
+    win:SetPoint(cfg.point or "CENTER", UIParent, cfg.relativePoint or cfg.point or "CENTER",
+        cfg.x or 0, cfg.y or 0)
     win:SetSize(cfg.width or 920, cfg.height or 540)
+    RefreshActiveView()
 end


### PR DESCRIPTION
## Summary
- size Weeklies and Currencies columns from rendered content
- add localized Weeklies headers and left-align table text
- add persistent bottom-right Alts window resizing with a 900x300 floor
- pin the merged QUI-tests regression coverage from zol-wow/QUI-tests#32

## Validation
- `bash tools/test.sh` — all 9 gates passed