### PR TITLE
fix(cdm): refresh duration bindings across batches

### DIFF
--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -890,7 +890,12 @@ local function DurationBindingMatches(icon, mode, sourceID, durObj)
     if mode == "aura" then
         return durObj == icon._lastDurObj
     end
-    return true
+
+    local getEpoch = RuntimeQueries and RuntimeQueries.GetActiveBatchEpoch
+    local epoch = getEpoch and getEpoch()
+    return epoch ~= nil
+        and icon._lastDurationBindingEpoch == epoch
+        and durObj == icon._lastDurObj
 end
 
 local function GetDurationBindingKey(icon, mode, sourceID)
@@ -1262,6 +1267,12 @@ ApplyResolvedCooldown = function(icon, preResolvedState, trustIsOnGCD)
         icon._lastResolvedSpellID = nil
         CancelCooldownExpiryRefresh(icon)
         return false
+    end
+
+    if mode ~= "aura" and RuntimeQueries and RuntimeQueries.GetActiveBatchEpoch then
+        icon._lastDurationBindingEpoch = RuntimeQueries.GetActiveBatchEpoch()
+    else
+        icon._lastDurationBindingEpoch = nil
     end
 
     if shouldScheduleExpiry then

--- a/QUI_CDM/cdm/cdm_runtime_queries.lua
+++ b/QUI_CDM/cdm/cdm_runtime_queries.lua
@@ -124,6 +124,12 @@ function CDMRuntimeQueries.ResetRuntimeQueryBatch()
     AdvanceRuntimeQueryEpoch()
 end
 
+function CDMRuntimeQueries.GetActiveBatchEpoch()
+    if runtimeQueryBatchDepth > 0 then
+        return runtimeQueryEpoch
+    end
+end
+
 local batchSharedCache = {
     cooldown = {},
     charge = {},


### PR DESCRIPTION
Fixes QUI-owned cooldown swipes disappearing while the icon remains correctly desaturated.\n\n- scopes non-aura DurationObject deduplication to one runtime-query batch\n- preserves aura and same-batch binding behavior\n- pins QUI-tests coverage for fresh and reused cross-batch duration objects\n\nLocal result: all nine repository gates pass.