### PR TITLE
release: v5.2.3-beta9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.3-beta9 - 2026-08-28
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Aura Display visibility plus Bags, Chat, and Blizzard panel interaction
+improvements for the 5.2.3 beta line.
+
+### Added
+
+- **Aura Displays now have their own HUD Visibility controls.** Configure
+  combat, target, group, instance, mouseover, mounted, vehicle, flight, fade,
+  and hidden-opacity rules without revealing inactive displays.
+- **QUI Bags currency tooltips can show tracked totals for every character.**
+  Character-specific currencies list saved per-character amounts and a combined
+  total, while account-wide currencies show one live Warband total.
+
+### Changed
+
+- **Overflowing QUI Chat tabs are directly selectable.** The overflow menu
+  lists every saved and conversation tab with unread counts, and selecting a
+  hidden tab scrolls it into view.
+- **Whisper conversation tabs are easier to close.** Active and hovered
+  conversations expose a close button, and closing the active conversation
+  selects the nearest remaining tab.
+
+### Fixed
+
+- **Moved Blizzard panels open above overlapping panels.** Newly shown
+  supported panels raise to the front outside combat.
+
 ## v5.2.3-beta8 - 2026-08-27
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta8
+## Version: 5.2.3-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Prepare v5.2.3-beta9.\n\n- Add the beta9 changelog section for Aura Displays HUD visibility, currency tooltip totals, QUI Chat tab overflow, and moved-panel stacking\n- Bump all 11 shipped TOCs to 5.2.3-beta9\n- Pin the merged beta9 documentation at zol-wow/QUI-docs@4557ce21\n\nVerification: `bash tools/test.sh` passed all nine gates on the worktree and exact release commit (872 unit files, 12 profile fixtures).