### PR TITLE
fix(cdm): prevent swipe texture reset flashes

### DIFF
--- a/QUI_CDM/cdm/cdm_effects.lua
+++ b/QUI_CDM/cdm/cdm_effects.lua
@@ -1862,8 +1862,10 @@ local function ApplySwipeToIcon(icon, settings)
         if not cd then return end
         cd._quiIntendedDrawSwipe = showSwipe and true or false
         cd._quiIntendedDrawEdge  = showEdge and true or false
-        cd._quiIntendedSwipeTexture = FULL_FRAME_SWIPE_TEXTURE
-        cd.SetSwipeTexture(cd, FULL_FRAME_SWIPE_TEXTURE)
+        if cd._quiIntendedSwipeTexture ~= FULL_FRAME_SWIPE_TEXTURE then
+            cd._quiIntendedSwipeTexture = FULL_FRAME_SWIPE_TEXTURE
+            cd.SetSwipeTexture(cd, FULL_FRAME_SWIPE_TEXTURE)
+        end
         cd.SetDrawSwipe(cd, showSwipe and true or false)
         cd.SetDrawEdge(cd, showEdge and true or false)
 

--- a/QUI_CDM/cdm/cdm_icon_policies.lua
+++ b/QUI_CDM/cdm/cdm_icon_policies.lua
@@ -1809,7 +1809,6 @@ function CDMIconCustomBarPolicy.Create(callbacks)
             icon.Cooldown:SetDrawSwipe(showRecharge)
             icon.Cooldown:SetDrawEdge(false)
             if showRecharge then
-                icon.Cooldown:SetSwipeTexture("Interface\\Buttons\\WHITE8X8")
                 icon.Cooldown:SetSwipeColor(0, 0, 0, 0.6)
             else
                 icon.Cooldown:SetSwipeColor(0, 0, 0, 0)
@@ -1818,7 +1817,6 @@ function CDMIconCustomBarPolicy.Create(callbacks)
             and icon._lastAuraDurObj and containerDB.showAuraSwipe == true
             and ns.CDMRenderers and ns.CDMRenderers.ApplyDurationObjectCooldown then
             icon.Cooldown:SetDrawEdge(false)
-            icon.Cooldown:SetSwipeTexture("Interface\\Buttons\\WHITE8X8")
             icon.Cooldown:SetSwipeColor(0, 0, 0, 0.6)
             icon.Cooldown:SetDrawSwipe(true)
             ns.CDMRenderers.ApplyDurationObjectCooldown(icon.Cooldown, icon._lastAuraDurObj, true, false)

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -425,9 +425,6 @@ end
 
 local function ReapplySwipeStyle(cd, icon)
     if not cd then return end
-    if cd.SetSwipeTexture then
-        cd.SetSwipeTexture(cd, "Interface\\Buttons\\WHITE8X8")
-    end
     local CooldownSwipe = ns._OwnedSwipe or (QUI and QUI.CooldownSwipe)
     if CooldownSwipe and CooldownSwipe.ApplyToIcon then
         CooldownSwipe.ApplyToIcon(icon)


### PR DESCRIPTION
Keeps swipe texture ownership in the effects module, removes duplicate renderer/custom-bar writes, and pins QUI-tests coverage for unchanged texture refreshes. Local nine-gate suite passes.