### PR TITLE
fix(nameplates): show absorb bar on fresh plates

### DIFF
--- a/QUI_Nameplates/nameplates/driver.lua
+++ b/QUI_Nameplates/nameplates/driver.lua
@@ -403,6 +403,8 @@ function ClearUnit(plate)
     plate.npLastMaxHP = nil
     plate.npLastAbsorbMax = nil
     plate.npAbsorbHidden = nil
+    if plate.absorbBar then plate.absorbBar:Hide() end
+    if plate.npAbsorbText then plate.npAbsorbText:Hide() end
     if plate.healPredictBar then plate.healPredictBar:Hide() end
     if plate.powerBar then plate.powerBar:Hide() end
     plate.npLastR, plate.npLastG, plate.npLastB = nil, nil, nil

--- a/QUI_Nameplates/nameplates/plate_health.lua
+++ b/QUI_Nameplates/nameplates/plate_health.lua
@@ -349,7 +349,12 @@ function NPHealth.UpdateAbsorbs(plate)
         return
     end
 
-    if plate.npAbsorbHidden then
+    -- npAbsorbHidden is tri-state: nil means unknown (fresh build or recycled
+    -- plate), so anything but a confirmed-shown state must call Show(). Under
+    -- 12.1 combat restrictions the amount stays secret, the readable-zero hide
+    -- path never runs, and a nil flag would otherwise pin the bar hidden for
+    -- the whole fight.
+    if plate.npAbsorbHidden ~= false then
         plate.npAbsorbHidden = false
         absorbBar:Show()
     end


### PR DESCRIPTION
The absorb overlay show path was gated on a tri-state flag that treated nil (fresh/recycled plate) as "already shown", so freshly bound plates never showed the bar. Under 12.1 combat secrets the readable-zero path that primed the flag never runs, pinning the bar hidden all fight. Now nil is treated as unknown and Show() fires; ClearUnit also hides absorbBar/npAbsorbText on recycle. Includes tests submodule bump (regression test in QUI-tests#