### PR TITLE
release: v5.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.2.3 - 2026-08-28
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+QUI 5.2.3 expands shared HUD visibility, cross-profile controls, and utility
+windows while hardening Action Bars, Cooldown Manager, Objective Tracker, and
+Blizzard-owned UI transitions.
+
+### Added
+
+- **Aura Displays and Group / Raid Frames can be pinned across every profile.**
+  Individual destination profiles can Ignore the shared source for local edits
+  and Apply it again later.
+- **Aura Displays have dedicated HUD Visibility controls** for combat, target,
+  group, instance, mouseover, mounted, vehicle, flight, opacity, and fade rules.
+- **The Alts window is resizable**, preserves its position and dimensions, and
+  stops active moves or resizes cleanly when combat begins.
+- **Currency tooltips show saved per-character balances**, while account-wide
+  currencies show one live Warband total.
+
+### Changed
+
+- **Overflowing QUI Chat tabs open a direct picker**, and conversation tabs
+  have close buttons with predictable adjacent-tab selection.
+- **Mythic+ enemy forces follow the selected Count, Percentage, or Both
+  format**, including current and required counts alongside percentage.
+- **Moved Blizzard panels rise above overlapping panels** after QUI restores
+  their saved positions.
+- **The custom Info Bar Micro Menu no longer duplicates Blizzard's Shop
+  button.** Blizzard's native Micro Menu remains the supported Shop path.
+
+### Fixed
+
+- **Action Bar proc glows track the current action immediately** through paging,
+  special bars, flyouts, duplicate slots, hidden-bar reveals, and Rotation
+  Assist ownership changes.
+- **Action Bar range and usability tints respect live and autohide state**, and
+  deferred Micro Menu cold starts complete after Blizzard releases temporary
+  ownership.
+- **Cooldown Manager swipes remain synchronized without full-overlay flashes**
+  across ordinary cooldowns, charge recharges, item cooldowns, and GCD-only
+  refreshes.
+- **Objective Tracker and Mythic+ transitions preserve Blizzard's Scenario
+  ownership**, restore the native tracker when QUI's timer closes, and retain
+  configured castbar widths.
+- **Protected UI updates stay in their native lifecycle.** Cooldown Viewer is no
+  longer force-loaded, Group Frame aura layering waits for combat to end, and
+  OPie editor widgets are excluded from action-button scans.
+- **Freshly shown nameplates initialize absorb bars immediately**, and resource
+  bars rebuild automatically after Fluid Form changes.
+- **Blizzard's vehicle exit button remains available when leaving is allowed**
+  while QUI continues to skin the surrounding override bar.
+
 ## v5.2.3-beta10 - 2026-08-28
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.2.3-beta10
+## Version: 5.2.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
## Summary
- bump all 11 shipped suite TOCs from `5.2.3-beta10` to stable `5.2.3`
- add the consolidated `v5.2.3` release notes, including post-beta10 fixes
- pin the landed QUI-docs stable main SHA from docs PRs #17–#19

## Verification
- exact release extractor: 52 lines / 2,679 bytes; stops before beta10
- `bash tools/test.sh` on the worktree: all 9 gates passed
- `bash tools/test.sh` on amended committed `543e53cf` in an isolated clone: all 9 gates passed (872 unit files)
- event allowlist regenerated with no diff

## Publish
After rebase merge and final tree parity, tag the rewritten main SHA as `v5.2.3`; this is the stable GitHub/CurseForge/Discord publish trigger.