### PR TITLE
fix(mail): keep Open All above moved panels

### DIFF
--- a/modules/qol/blizzard_mover.lua
+++ b/modules/qol/blizzard_mover.lua
@@ -1123,6 +1123,19 @@ function M.functions.createHooks(root, entry)
 		if not InCombatLockdown() and frame.Raise then frame:Raise() end
 	end
 
+	local openAllMail = panel.id == "MailFrame" and _G.OpenAllMail
+	if openAllMail and openAllMail.HookScript then
+		openAllMail:HookScript("OnClick", function()
+			if RunNextFrame then
+				RunNextFrame(function() raiseShownFrame(root) end)
+			elseif C_Timer and C_Timer.After then
+				C_Timer.After(0, function() raiseShownFrame(root) end)
+			else
+				raiseShownFrame(root)
+			end
+		end)
+	end
+
 	if panel.secureFrame then
 		local function savedPositionDrifted(f)
 			if c.dragging or c.applyingLayout then return false end

--- a/modules/qol/blizzard_mover.lua
+++ b/modules/qol/blizzard_mover.lua
@@ -1125,13 +1125,16 @@ function M.functions.createHooks(root, entry)
 
 	local openAllMail = panel.id == "MailFrame" and _G.OpenAllMail
 	if openAllMail and openAllMail.HookScript then
+		local function raiseActiveMailFrame()
+			if panelIsActive(panel) then raiseShownFrame(root) end
+		end
 		openAllMail:HookScript("OnClick", function()
 			if RunNextFrame then
-				RunNextFrame(function() raiseShownFrame(root) end)
+				RunNextFrame(raiseActiveMailFrame)
 			elseif C_Timer and C_Timer.After then
-				C_Timer.After(0, function() raiseShownFrame(root) end)
+				C_Timer.After(0, raiseActiveMailFrame)
 			else
-				raiseShownFrame(root)
+				raiseActiveMailFrame()
 			end
 		end)
 	end


### PR DESCRIPTION
## Summary\n- defer MailFrame stacking repair until Blizzard's Open All click work finishes\n- advance QUI-tests to the merged regression and beta/main compatibility coverage\n\n## Verification\n- mutation test fails at the missing Open All hook without the production change\n- exact beta candidate: all nine local gates passed\n- committed tree: all nine local gates passed