### PR TITLE
release: v5.3-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## v5.3-beta1 - 2026-08-31
+## v5.3-beta2 - 2026-09-01
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
 > will not load on the 12.0.x client.
 
-Opens the 5.3 beta line with a modern Damage Meter detail workspace, broader
-Blizzard-frame styling, and focused combat UI corrections.
+Alert customization, tighter combat HUD layouts, and detail-view refinements
+for the 5.3 beta line.
 
 ### Added
 
@@ -22,6 +22,36 @@ Blizzard-frame styling, and focused combat UI corrections.
   gains stacks, or is removed.
 - **Cooldown Manager entries have QUI-owned sound and text-to-speech alerts**
   for cooldown and aura state changes, with searchable sounds and previews.
+- **The Battle Res Counter can hide without charge information**, removing its
+  unavailable icon between supported encounters and in unsupported content.
+
+### Changed
+
+- **Incoming Casts can collapse readable hidden icons** so visible casts pack
+  together while restricted targets retain fixed-width gaps.
+- **The Damage Meter detail workspace is resizable and remembers its size.**
+  Target rows drill down to their spells, and player hover details refresh item
+  levels.
+
+### Fixed
+
+- **Cooldown Manager no longer writes Blizzard's Edit Mode layouts during
+  login.** Layout mismatches are detected without mutation and corrected through
+  guided Edit Mode steps, preventing protected aura-map and cooldown-cache
+  errors.
+- **QUI Chat preserves literal player messages**, including apostrophes and
+  percent tokens, instead of treating chat bodies as format templates.
+
+## v5.3-beta1 - 2026-08-31
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Opens the 5.3 beta line with a modern Damage Meter detail workspace, broader
+Blizzard-frame styling, and focused combat UI corrections.
+
+### Added
+
 - **Damage Meter rows open a reusable five-pane detail workspace** for spells,
   targets, attackers, and death recaps while row-hover details remain
   independent and interactive.
@@ -40,10 +70,6 @@ Blizzard-frame styling, and focused combat UI corrections.
 
 ### Fixed
 
-- **Cooldown Manager no longer writes Blizzard's Edit Mode layouts during
-  login.** Layout mismatches are detected without mutation and corrected through
-  guided Edit Mode steps, preventing protected aura-map and cooldown-cache
-  errors.
 - **Group Frame summon indicators handle secret status values safely** and
   refresh when combat ends.
 - **Mail's Open All action keeps the Mail window above overlapping moved

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta1
+## Version: 5.3-beta2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
## Summary
- publish the post-beta1 alert, Damage Meter, Chat, incoming-cast, battle-rez, and death-alert changes
- bump all 11 shipped TOCs to 5.3-beta2
- pin the merged v5.3-beta2 docs

## Verification
- bash tools/test.sh
- isolated committed-tree bash tools/test.sh
- 880 unit files, 12 profile fixtures, 32 strict-taint shards, clean luacheck
- release-note extractor and dynamic shipped-TOC audit