### PR TITLE
fix: backport alpha incoming cast review fixes

### DIFF
--- a/QUI_GroupFrames/groupframes/groupframes.lua
+++ b/QUI_GroupFrames/groupframes/groupframes.lua
@@ -129,6 +129,10 @@ local function AddFrameToMap(unit, frame)
             _state.RegisterUnitEventsForUnit(unit)
         end
     end
+    local targetedSpells = ns.QUI_GroupFrameTargetedSpells
+    if targetedSpells and targetedSpells.PrepareFrame then
+        targetedSpells:PrepareFrame(frame, #QUI_GF.unitFrameMap[unit])
+    end
 end
 
 local function RemoveFrameFromMap(unit, frame)

--- a/QUI_GroupFrames/groupframes/groupframes_targeted_spells.lua
+++ b/QUI_GroupFrames/groupframes/groupframes_targeted_spells.lua
@@ -5,6 +5,7 @@ if not GroupFrames then return end
 
 local CreateFrame = CreateFrame
 local GetTime = GetTime
+local InCombatLockdown = InCombatLockdown
 local IsInGroup = IsInGroup
 local IsInRaid = IsInRaid
 local UnitClass = UnitClass
@@ -160,7 +161,6 @@ local Roster = {
     race = {},
     sex = {},
     candidates = {},
-    lastIndexedAt = 0,
 }
 
 local function ClearRosterIndex()
@@ -210,8 +210,6 @@ local function IndexRoster()
             end
         end
     end
-
-    Roster.lastIndexedAt = GetTime()
 end
 
 local function LoadClassCandidates(classToken)
@@ -270,10 +268,6 @@ local function UnitFromCasterTarget(caster)
     end
 
     local candidates = LoadClassCandidates(classToken)
-    if #candidates == 0 and GetTime() - Roster.lastIndexedAt > 1 then
-        IndexRoster()
-        candidates = LoadClassCandidates(classToken)
-    end
     if #candidates == 0 then
         return nil
     end
@@ -295,7 +289,18 @@ local function UnitFromCasterTarget(caster)
     return candidates[1]
 end
 
+local MAX_NAMEPLATE_CASTERS = 150
 local markerPools = setmetatable({}, { __mode = "k" })
+local markerListsByCaster = {}
+local activeByCaster = {}
+local markerListCapacity = 0
+local poolGrowthPending = false
+
+for i = 1, MAX_NAMEPLATE_CASTERS do
+    local caster = "nameplate" .. i
+    markerListsByCaster[caster] = { count = 0, unit = false }
+    activeByCaster[caster] = false
+end
 
 local function MarkerSize(isRaid)
     return ClampNumber(Option(isRaid, "iconSize"), OPTION_DEFAULTS.iconSize, 4, 96)
@@ -330,6 +335,7 @@ end
 local function NewMarker(frame, isRaid)
     local marker = CreateFrame("Frame", nil, frame)
     marker._quiTargetedRaid = isRaid and true or false
+    marker._targetedCaster = false
     marker:Hide()
 
     local texture = marker:CreateTexture(nil, "ARTWORK")
@@ -367,22 +373,76 @@ local function MarkerPool(frame, isRaid)
     return pool
 end
 
-local function AcquireMarker(frame, isRaid)
-    local pool = MarkerPool(frame, isRaid)
-
-    for i = 1, #pool do
-        if not pool[i]._targetedCaster then
-            return pool[i]
+local function EnsureMarkerListCapacity(capacity)
+    if capacity <= markerListCapacity then
+        return
+    end
+    for _, markers in pairs(markerListsByCaster) do
+        for i = markerListCapacity + 1, capacity do
+            markers[i] = false
         end
     end
+    markerListCapacity = capacity
+end
 
-    if #pool >= MarkerLimit(isRaid) then
-        return nil
+local function PrepareFrame(frame, frameCopies)
+    if not frame then
+        return
+    end
+    if InCombatLockdown() then
+        poolGrowthPending = true
+        return
     end
 
-    local marker = NewMarker(frame, isRaid)
-    pool[#pool + 1] = marker
-    return marker
+    EnsureMarkerListCapacity(frameCopies or 1)
+    local isRaid = frame._isRaid and true or false
+    local pool = MarkerPool(frame, isRaid)
+    local limit = MarkerLimit(isRaid)
+    for i = #pool + 1, limit do
+        pool[i] = NewMarker(frame, isRaid)
+    end
+end
+
+local function PrepareMarkerPools()
+    if InCombatLockdown() then
+        poolGrowthPending = true
+        return
+    end
+
+    poolGrowthPending = false
+    for _, frameList in pairs(GroupFrames.unitFrameMap or {}) do
+        for i = 1, #frameList do
+            PrepareFrame(frameList[i], #frameList)
+        end
+    end
+end
+
+local function AcquireMarker(frame, isRaid)
+    local pool = markerPools[frame]
+    if not pool then
+        if InCombatLockdown() then
+            poolGrowthPending = true
+            return nil
+        end
+        pool = MarkerPool(frame, isRaid)
+    end
+
+    local limit = MarkerLimit(isRaid)
+    for i = 1, limit do
+        local marker = pool[i]
+        if not marker then
+            if InCombatLockdown() then
+                poolGrowthPending = true
+                return nil
+            end
+            marker = NewMarker(frame, isRaid)
+            pool[i] = marker
+        end
+        if not marker._targetedCaster then
+            return marker
+        end
+    end
+    return nil
 end
 
 local function PlaceFirstMarker(marker, host, point, x, y)
@@ -514,8 +574,6 @@ end
 -- resolves which group member a cast is aimed at and renders the markers.
 local SUBSCRIBER_KEY = "groupFrameTargetedSpells"
 
-local activeByCaster = {}
-local relayoutFrames = {}
 local subscribed = false
 
 local function HideMarkerSet(markers)
@@ -523,25 +581,26 @@ local function HideMarkerSet(markers)
         return
     end
 
-    wipe(relayoutFrames)
-    for i = 1, #markers do
+    for i = 1, markers.count do
         local marker = markers[i]
-        marker._targetedCaster = nil
+        local frame = marker:GetParent()
+        marker._targetedCaster = false
         marker:Hide()
         StopCooldown(marker._cooldown)
-        relayoutFrames[marker:GetParent()] = true
-    end
-
-    for frame in pairs(relayoutFrames) do
+        markers[i] = false
         LayoutFrameMarkers(frame)
     end
-    wipe(relayoutFrames)
+
+    markers.count = 0
+    markers.unit = false
 end
 
 local function ClearAllMarkers()
     for caster, markers in pairs(activeByCaster) do
-        activeByCaster[caster] = nil
-        HideMarkerSet(markers)
+        if markers then
+            activeByCaster[caster] = false
+            HideMarkerSet(markers)
+        end
     end
 end
 
@@ -551,10 +610,30 @@ local function ShowCastOnUnit(caster, unit, texture, durationObject, startMS, en
         return
     end
 
-    local markers
+    local markers = markerListsByCaster[caster]
+    if not markers then
+        if InCombatLockdown() then
+            poolGrowthPending = true
+            return
+        end
+        markers = { count = 0, unit = false }
+        markerListsByCaster[caster] = markers
+        for i = 1, markerListCapacity do
+            markers[i] = false
+        end
+    end
+
+    local markerCount = 0
     for i = 1, #frameList do
         local frame = frameList[i]
         if frame and frame:IsShown() then
+            if markerCount >= markerListCapacity then
+                if InCombatLockdown() then
+                    poolGrowthPending = true
+                    break
+                end
+                EnsureMarkerListCapacity(markerCount + 1)
+            end
             local isRaid = frame._isRaid and true or false
             local marker = AcquireMarker(frame, isRaid)
             if marker then
@@ -573,15 +652,14 @@ local function ShowCastOnUnit(caster, unit, texture, durationObject, startMS, en
                 marker:Show()
                 LayoutFrameMarkers(frame)
 
-                if not markers then
-                    markers = {}
-                end
-                markers[#markers + 1] = marker
+                markerCount = markerCount + 1
+                markers[markerCount] = marker
             end
         end
     end
 
-    if markers then
+    markers.count = markerCount
+    if markerCount > 0 then
         markers.unit = unit
         activeByCaster[caster] = markers
     end
@@ -590,7 +668,7 @@ end
 local function OnCastShow(caster, unit, cast)
     local current = activeByCaster[caster]
     if current then
-        activeByCaster[caster] = nil
+        activeByCaster[caster] = false
         HideMarkerSet(current)
     end
     ShowCastOnUnit(caster, unit, cast.texture, cast.durationObj, cast.startMS, cast.endMS)
@@ -599,7 +677,7 @@ end
 local function OnCastHide(caster)
     local markers = activeByCaster[caster]
     if markers then
-        activeByCaster[caster] = nil
+        activeByCaster[caster] = false
         HideMarkerSet(markers)
     end
 end
@@ -631,6 +709,9 @@ local function RefreshRuntimeState()
     end
 
     local shouldRun = FeatureShouldRun()
+    if shouldRun then
+        PrepareMarkerPools()
+    end
     if shouldRun and not subscribed then
         IndexRoster()
         subscribed = IncomingCasts.Subscribe(SUBSCRIBER_KEY, {
@@ -672,6 +753,12 @@ function TargetedSpells:ApplySettings()
     end
 end
 
+function TargetedSpells:PrepareFrame(frame, frameCopies)
+    if subscribed then
+        PrepareFrame(frame, frameCopies)
+    end
+end
+
 -- Roster shape, roles, and world changes invalidate both the class-bucket
 -- index and any marker-to-frame mapping; markers rebuild from the engine's
 -- in-flight casts via ResetSubscriber.
@@ -688,4 +775,17 @@ eventFrame:RegisterEvent("PLAYER_LOGIN")
 eventFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
 eventFrame:RegisterEvent("PLAYER_ROLES_ASSIGNED")
 eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-eventFrame:SetScript("OnEvent", HandleContextChanged)
+eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+eventFrame:SetScript("OnEvent", function(_, event)
+    if event == "PLAYER_REGEN_ENABLED" then
+        if poolGrowthPending then
+            if FeatureShouldRun() then
+                PrepareMarkerPools()
+            else
+                poolGrowthPending = false
+            end
+        end
+        return
+    end
+    HandleContextChanged()
+end)

--- a/core/incoming_casts.lua
+++ b/core/incoming_casts.lua
@@ -3,7 +3,7 @@ local Helpers = ns.Helpers
 
 local CreateFrame = CreateFrame
 local C_NamePlate = C_NamePlate
-local C_Timer = C_Timer
+local GetTime = GetTime
 local UnitCanAttack = UnitCanAttack
 local UnitCastingDuration = UnitCastingDuration
 local UnitCastingInfo = UnitCastingInfo
@@ -54,6 +54,8 @@ local TIMING = {
     targetChangeRead = 0.05,
 }
 
+local MAX_NAMEPLATE_CASTERS = 150
+
 local subscribers = {}
 local shownTargets = {}
 local plateUnits = {}
@@ -61,7 +63,34 @@ local watchedCaster = {}
 local serialByCaster = {}
 local castRecords = {}
 local clearQueue = {}
+local resolveFirstAt = {}
+local resolveSecondAt = {}
+local resolveSerial = {}
+local pendingResolveCount = 0
 local running = false
+
+local function NewCastRecord()
+    return {
+        spellName = false,
+        texture = false,
+        isChannel = false,
+        startMS = false,
+        endMS = false,
+        durationObj = false,
+        evidence = false,
+    }
+end
+
+for i = 1, MAX_NAMEPLATE_CASTERS do
+    local caster = "nameplate" .. i
+    plateUnits[caster] = false
+    watchedCaster[caster] = false
+    serialByCaster[caster] = 0
+    castRecords[caster] = NewCastRecord()
+    resolveFirstAt[caster] = false
+    resolveSecondAt[caster] = false
+    resolveSerial[caster] = false
+end
 
 local eventFrame = CreateFrame("Frame")
 
@@ -164,8 +193,8 @@ end
 local function NotifyHide(caster)
     for key, subscriber in pairs(subscribers) do
         local shown = shownTargets[key]
-        if shown and shown[caster] ~= nil then
-            shown[caster] = nil
+        if shown and shown[caster] then
+            shown[caster] = false
             SubStats(key).hides = SubStats(key).hides + 1
             DebugPrint("hide ", caster, " [", key, "]")
             subscriber.onHide(caster)
@@ -173,20 +202,37 @@ local function NotifyHide(caster)
     end
 end
 
+local function CancelResolve(caster)
+    if resolveSerial[caster] then
+        pendingResolveCount = pendingResolveCount - 1
+    end
+    resolveFirstAt[caster] = false
+    resolveSecondAt[caster] = false
+    resolveSerial[caster] = false
+    if pendingResolveCount == 0 then
+        eventFrame:SetScript("OnUpdate", nil)
+    end
+end
+
 local function ClearCaster(caster)
+    CancelResolve(caster)
     NextSerial(caster)
-    watchedCaster[caster] = nil
+    watchedCaster[caster] = false
     NotifyHide(caster)
 end
 
 local function ClearAllCasts()
     wipe(clearQueue)
-    for caster in pairs(watchedCaster) do
-        clearQueue[#clearQueue + 1] = caster
+    for caster, watched in pairs(watchedCaster) do
+        if watched then
+            clearQueue[#clearQueue + 1] = caster
+        end
     end
     for key in pairs(shownTargets) do
-        for caster in pairs(shownTargets[key]) do
-            clearQueue[#clearQueue + 1] = caster
+        for caster, shown in pairs(shownTargets[key]) do
+            if shown then
+                clearQueue[#clearQueue + 1] = caster
+            end
         end
     end
 
@@ -194,7 +240,8 @@ local function ClearAllCasts()
         ClearCaster(clearQueue[i])
     end
     wipe(clearQueue)
-    wipe(watchedCaster)
+    pendingResolveCount = 0
+    eventFrame:SetScript("OnUpdate", nil)
 end
 
 local function ResolveCaster(caster, expectedSerial)
@@ -231,7 +278,7 @@ local function ResolveCaster(caster, expectedSerial)
     -- two-read verify pass and target-change rechecks allocate nothing.
     local cast = castRecords[caster]
     if not cast then
-        cast = {}
+        cast = NewCastRecord()
         castRecords[caster] = cast
     end
     cast.spellName = spellName
@@ -248,7 +295,7 @@ local function ResolveCaster(caster, expectedSerial)
         local subStats = SubStats(key)
 
         if subscriber.allCasts then
-            if shown[caster] == nil then
+            if not shown[caster] then
                 shown[caster] = true
                 subStats.shows = subStats.shows + 1
                 DebugPrint("show ", caster, " [", evidence, "] ", key)
@@ -272,8 +319,8 @@ local function ResolveCaster(caster, expectedSerial)
                     subStats.hit = subStats.hit + 1
                     DebugPrint("resolve ", caster, " [", evidence, "] ", key, " -> ", target)
                     if shown[caster] ~= target then
-                        if shown[caster] ~= nil then
-                            shown[caster] = nil
+                        if shown[caster] then
+                            shown[caster] = false
                             subStats.hides = subStats.hides + 1
                             subscriber.onHide(caster)
                         end
@@ -284,8 +331,8 @@ local function ResolveCaster(caster, expectedSerial)
                 elseif target == false then
                     subStats.miss = subStats.miss + 1
                     DebugPrint("resolve ", caster, " [", evidence, "] ", key, " -> not-my-target")
-                    if shown[caster] ~= nil then
-                        shown[caster] = nil
+                    if shown[caster] then
+                        shown[caster] = false
                         subStats.hides = subStats.hides + 1
                         subscriber.onHide(caster)
                     end
@@ -298,10 +345,39 @@ local function ResolveCaster(caster, expectedSerial)
     end
 end
 
-local function QueueResolve(caster, serial, delay)
-    C_Timer.After(delay, function()
-        ResolveCaster(caster, serial)
-    end)
+local function ProcessResolveQueue()
+    local now = GetTime()
+    for caster, serial in pairs(resolveSerial) do
+        if serial then
+            local firstAt = resolveFirstAt[caster]
+            if firstAt and now >= firstAt then
+                resolveFirstAt[caster] = false
+                ResolveCaster(caster, serial)
+            end
+
+            local secondAt = resolveSecondAt[caster]
+            if resolveSerial[caster] == serial and secondAt and now >= secondAt then
+                resolveSecondAt[caster] = false
+                resolveSerial[caster] = false
+                pendingResolveCount = pendingResolveCount - 1
+                ResolveCaster(caster, serial)
+            end
+        end
+    end
+    if pendingResolveCount == 0 then
+        eventFrame:SetScript("OnUpdate", nil)
+    end
+end
+
+local function QueueResolves(caster, serial, firstDelay)
+    local now = GetTime()
+    if not resolveSerial[caster] then
+        pendingResolveCount = pendingResolveCount + 1
+    end
+    resolveSerial[caster] = serial
+    resolveFirstAt[caster] = now + firstDelay
+    resolveSecondAt[caster] = now + firstDelay + TIMING.verifyRead
+    eventFrame:SetScript("OnUpdate", ProcessResolveQueue)
 end
 
 local function BeginCastWatch(caster)
@@ -318,8 +394,7 @@ local function BeginCastWatch(caster)
     DebugPrint("watch ", caster)
     watchedCaster[caster] = true
     local serial = serialByCaster[caster] or 0
-    QueueResolve(caster, serial, TIMING.firstRead)
-    QueueResolve(caster, serial, TIMING.firstRead + TIMING.verifyRead)
+    QueueResolves(caster, serial, TIMING.firstRead)
 end
 
 local function RecheckCasterTarget(caster)
@@ -328,8 +403,7 @@ local function RecheckCasterTarget(caster)
     end
 
     local serial = NextSerial(caster)
-    QueueResolve(caster, serial, TIMING.targetChangeRead)
-    QueueResolve(caster, serial, TIMING.targetChangeRead + TIMING.verifyRead)
+    QueueResolves(caster, serial, TIMING.targetChangeRead)
 end
 
 local function AdoptLiveCast(unit)
@@ -355,6 +429,12 @@ local function SeedVisibleNameplates()
             plateUnits[unit] = true
             AdoptLiveCast(unit)
         end
+    end
+end
+
+local function ResetPlateUnits()
+    for unit in pairs(plateUnits) do
+        plateUnits[unit] = false
     end
 end
 
@@ -393,6 +473,10 @@ local WATCHED_EVENTS = {
     "PLAYER_REGEN_ENABLED",
 }
 
+for i = 1, #WATCHED_EVENTS do
+    stats.events[WATCHED_EVENTS[i]] = 0
+end
+
 local function SetRunning(enabled)
     if enabled == running then
         return
@@ -412,19 +496,21 @@ local function SetRunning(enabled)
         SeedVisibleNameplates()
     else
         ClearAllCasts()
-        wipe(plateUnits)
+        ResetPlateUnits()
     end
 end
 
 eventFrame:SetScript("OnEvent", function(_, event, unit)
     if event == "PLAYER_ENTERING_WORLD" then
         ClearAllCasts()
-        wipe(plateUnits)
+        ResetPlateUnits()
         SeedVisibleNameplates()
         return
     end
     if event == "PLAYER_REGEN_ENABLED" then
         ClearAllCasts()
+        ResetPlateUnits()
+        SeedVisibleNameplates()
         return
     end
     if event == "NAME_PLATE_UNIT_ADDED" then
@@ -435,7 +521,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit)
         return
     end
     if event == "NAME_PLATE_UNIT_REMOVED" then
-        plateUnits[unit] = nil
+        plateUnits[unit] = false
         DebugPrint("plate removed ", unit)
         ClearCaster(unit)
         return
@@ -470,7 +556,15 @@ function IncomingCasts.Subscribe(key, subscriber)
     end
 
     subscribers[key] = subscriber
-    shownTargets[key] = shownTargets[key] or {}
+    local shown = shownTargets[key]
+    if not shown then
+        shown = {}
+        shownTargets[key] = shown
+        for i = 1, MAX_NAMEPLATE_CASTERS do
+            shown["nameplate" .. i] = false
+        end
+    end
+    SubStats(key)
     SetRunning(true)
     return true
 end
@@ -484,9 +578,13 @@ function IncomingCasts.ResetSubscriber(key)
     if not shown then
         return
     end
-    wipe(shown)
-    for caster in pairs(watchedCaster) do
-        RecheckCasterTarget(caster)
+    for caster in pairs(shown) do
+        shown[caster] = false
+    end
+    for caster, watched in pairs(watchedCaster) do
+        if watched then
+            RecheckCasterTarget(caster)
+        end
     end
 end
 
@@ -514,12 +612,16 @@ function IncomingCasts.DebugDump(out)
     out(prefix .. "engine running: " .. tostring(running) .. "  verbose log: " .. tostring(debugLog))
 
     local plates = {}
-    for unit in pairs(plateUnits) do
-        plates[#plates + 1] = unit
+    for unit, tracked in pairs(plateUnits) do
+        if tracked then
+            plates[#plates + 1] = unit
+        end
     end
     local watched = {}
-    for caster in pairs(watchedCaster) do
-        watched[#watched + 1] = caster
+    for caster, active in pairs(watchedCaster) do
+        if active then
+            watched[#watched + 1] = caster
+        end
     end
     out(prefix .. "plates tracked: " .. #plates .. " (" .. table.concat(plates, " ") .. ")  seen total: " .. stats.platesSeen)
     if running and #plates == 0 then
@@ -529,7 +631,9 @@ function IncomingCasts.DebugDump(out)
 
     local eventBits = {}
     for event, count in pairs(stats.events) do
-        eventBits[#eventBits + 1] = event .. "=" .. count
+        if count > 0 then
+            eventBits[#eventBits + 1] = event .. "=" .. count
+        end
     end
     out(prefix .. "plate events: " .. (#eventBits > 0 and table.concat(eventBits, " ") or "none")
         .. "  untracked-unit events: " .. stats.eventsUntracked)
@@ -547,8 +651,10 @@ function IncomingCasts.DebugDump(out)
         local shownCount = 0
         local shown = shownTargets[key]
         if shown then
-            for _ in pairs(shown) do
-                shownCount = shownCount + 1
+            for _, target in pairs(shown) do
+                if target then
+                    shownCount = shownCount + 1
+                end
             end
         end
         out(prefix .. "subscriber " .. key .. (subscribers[key] and "" or " (inactive)")

--- a/modules/trackers/incoming_casts.lua
+++ b/modules/trackers/incoming_casts.lua
@@ -18,6 +18,7 @@ local IsSecretValue = Helpers.IsSecretValue
 local SUBSCRIBER_KEY = "personalIncomingCasts"
 local FALLBACK_ICON = "Interface\\Icons\\INV_Misc_QuestionMark"
 local PREVIEW_ICON = 136048 -- Lightning Bolt
+local MAX_NAMEPLATE_CASTERS = 150
 
 local DEFAULTS = {
     enabled = false,
@@ -97,18 +98,19 @@ host:SetSize(DEFAULTS.iconSize, DEFAULTS.iconSize)
 host:SetPoint("CENTER", UIParent, "CENTER", 0, -180)
 
 -- Visibility is secret (alpha-sunk), so Lua can never tell which icons are
--- showing — capping slots at the user's maxIcons would let invisible casts
--- aimed at other players exhaust the pool and silently suppress a cast aimed
--- at us. Slots therefore grow uncapped, one per concurrently tracked cast;
--- the pool is naturally bounded by the client's visible-nameplate limit and
--- never shrinks, so growth is a one-time cost. maxIcons governs the reserved
--- layout extent and the preview; overflow slots extend past it.
+-- showing. Reserve the full Blizzard nameplate token range out of combat;
+-- maxIcons governs only the layout extent and preview count.
 local icons = {}
 local activeByCaster = {}
 local previewActive = false
 local subscribed = false
+local deferredPoolGrowth = 0
 local debugShows = 0
 local debugHides = 0
+
+for i = 1, MAX_NAMEPLATE_CASTERS do
+    activeByCaster["nameplate" .. i] = false
+end
 
 local function ApplyIconStyle(icon)
     local size = IconSize()
@@ -146,6 +148,7 @@ end
 
 local function NewIcon()
     local icon = CreateFrame("Frame", nil, host)
+    icon._inUse = false
     icon:Hide()
 
     local texture = icon:CreateTexture(nil, "ARTWORK")
@@ -179,6 +182,10 @@ local function AcquireIcon()
         if not icons[i]._inUse then
             return icons[i]
         end
+    end
+    if InCombatLockdown() then
+        deferredPoolGrowth = deferredPoolGrowth + 1
+        return nil
     end
     local icon = NewIcon()
     icon._slot = #icons + 1
@@ -323,7 +330,7 @@ local function LayoutIcons()
 end
 
 local function ReleaseIcon(icon)
-    icon._inUse = nil
+    icon._inUse = false
     icon:Hide()
     icon:SetAlpha(1)
     ResetIconScale(icon)
@@ -332,8 +339,10 @@ end
 
 local function ClearActive()
     for caster, icon in pairs(activeByCaster) do
-        activeByCaster[caster] = nil
-        ReleaseIcon(icon)
+        if icon then
+            activeByCaster[caster] = false
+            ReleaseIcon(icon)
+        end
     end
 end
 
@@ -392,6 +401,9 @@ local function OnCastShow(caster, _, cast)
     local icon = activeByCaster[caster]
     if not icon then
         icon = AcquireIcon()
+        if not icon then
+            return
+        end
         icon._inUse = true
         activeByCaster[caster] = icon
     end
@@ -414,7 +426,7 @@ local function OnCastHide(caster)
     if not icon then
         return
     end
-    activeByCaster[caster] = nil
+    activeByCaster[caster] = false
     ReleaseIcon(icon)
     debugHides = debugHides + 1
 end
@@ -445,13 +457,16 @@ local function UpdateSubscription()
     end
 end
 
--- Keep the common case allocation-free in combat: the first maxIcons slots
--- are built ahead of time; only overflow slots are still created lazily.
 local function EnsurePool()
     if InCombatLockdown() then
         return
     end
-    for i = 1, MaxIcons() do
+    local target = #icons + deferredPoolGrowth
+    if target < MAX_NAMEPLATE_CASTERS then
+        target = MAX_NAMEPLATE_CASTERS
+    end
+    deferredPoolGrowth = 0
+    for i = 1, target do
         if not icons[i] then
             local icon = NewIcon()
             icon._slot = i
@@ -473,7 +488,9 @@ local function Refresh()
     end
     LayoutIcons()
     for caster, icon in pairs(activeByCaster) do
-        ApplyTargetVisibility(icon, caster)
+        if icon then
+            ApplyTargetVisibility(icon, caster)
+        end
     end
 end
 
@@ -527,8 +544,13 @@ end
 -- in-flight casts via ResetSubscriber).
 local previewGuard = CreateFrame("Frame")
 previewGuard:RegisterEvent("PLAYER_REGEN_DISABLED")
-previewGuard:SetScript("OnEvent", function()
-    if previewActive then
+previewGuard:RegisterEvent("PLAYER_REGEN_ENABLED")
+previewGuard:SetScript("OnEvent", function(_, event)
+    if event == "PLAYER_REGEN_ENABLED" then
+        if subscribed then
+            EnsurePool()
+        end
+    elseif previewActive then
         DisablePreview()
     end
 end)
@@ -575,8 +597,10 @@ SlashCmdList["QUIIC"] = function(msg)
         .. " preview=" .. tostring(previewActive)
         .. " engineLoaded=" .. tostring(IC ~= nil))
     local activeIcons = 0
-    for _ in pairs(activeByCaster) do
-        activeIcons = activeIcons + 1
+    for _, icon in pairs(activeByCaster) do
+        if icon then
+            activeIcons = activeIcons + 1
+        end
     end
     print(prefix .. "display: activeIcons=" .. activeIcons
         .. " shows=" .. debugShows .. " hides=" .. debugHides


### PR DESCRIPTION
Backports the five Codex review fixes from #869 without merging alpha history into beta.

- preserves incoming casts across combat exit and pre-seeds engine bookkeeping
- preallocates personal and group-frame marker state outside combat
- removes roster rebuilding from cast resolution
- pins QUI-tests beta PR #94 at 629cdbba

The four runtime files exactly match reviewed alpha. Docs and Aura Displays wizard content are excluded. Local tools/test.sh passes all 9 gates with 890 unit files.