### PR TITLE
release: v5.5.0-ptr-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.5.0-ptr-alpha1 - 2026-09-03
+
+> ⚠️ **WoW 12.1.5 PTR ONLY.** This alpha targets PTR build 12.1.5.69594
+> (interface 120105) and will not load on the live 12.1 client.
+
+Opens the 5.5 PTR alpha line with 12.1.5 API compatibility and protected-frame
+hardening.
+
+### Changed
+
+- **QUI now targets the WoW 12.1.5 PTR**, including refreshed Blizzard API and
+  FrameXML corpora plus regenerated LuaLS and taint metadata.
+- **Protected cooldown updates use each receiver's native mutation verdict.**
+  Unprotected addon cooldowns continue updating during combat, while protected
+  receivers defer and repaint when combat ends.
+- **Settings and Blizzard-frame chrome use a unified higher-contrast visual
+  treatment**, including clearer controls, smoother scrolling, and shared
+  Character panel styling.
+
+### Fixed
+
+- **Action Bars, Group Frames, Bags, and world-map teleports recover deferred
+  cooldowns after combat** instead of leaving missing or stale swipes.
+- **Incoming targeted-cast markers avoid combat allocations**, preserve active
+  casts across combat exit, and repaint protected cooldowns when legal.
+- **Cooldown Manager leaves the native viewer enable state to Blizzard** and
+  suppresses native buff bars before data readiness, avoiding tainted callbacks
+  and startup flicker.
+
 ## v5.3-beta2 - 2026-09-01
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta2
+## Version: 5.5.0-ptr-alpha1
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
## Summary
- open the 5.5 PTR alpha line for WoW 12.1.5
- set all 11 shipped TOCs to `5.5.0-ptr-alpha1`
- add alpha release notes for PTR compatibility and the changes since `v5.3-beta2`

## Channel
- GitHub prerelease: yes
- CurseForge release type: alpha
- WoW game version: 12.1.5

## Verification
- exact changelog extraction succeeds
- dynamic shipped-TOC set is exact; Debug/Logger excluded
- isolated committed checkout: all 9 gates passed, including 891 unit files and 32 strict-taint shards