### PR TITLE
fix(bags): repair bank money and guild transfers

### DIFF
--- a/QUI_Bags/bags/views/bank_window.lua
+++ b/QUI_Bags/bags/views/bank_window.lua
@@ -286,6 +286,10 @@ local function ShowMoneyPopup(kind, bankType)
     end)
 end
 
+local function HideMoneyPopup()
+    StaticPopup_Hide("QUI_BANK_MONEY")
+end
+
 local function ApplyTabHover(bagID)
     hoverTabBagID = bagID
     local function sweep(pool)
@@ -414,6 +418,7 @@ local function EnsureWindow()
         onClose = function(w)
             w:SetScript("OnUpdate", nil)
             w._updateScheduled = false
+            HideMoneyPopup()
             if Bags.BankTakeover and Bags.BankTakeover.IsLive() then
                 Bags.BankTakeover.UserClosedWindow()
             end
@@ -642,6 +647,7 @@ local FOOTER_ROW_H = 18
 
 local function RenderFooter()
     if not liveMode then
+        HideMoneyPopup()
         win._bankMoney:Hide()
         win._depositBtn:Hide()
         win._withdrawBtn:Hide()

--- a/QUI_Bags/bags/views/chassis.lua
+++ b/QUI_Bags/bags/views/chassis.lua
@@ -1,3 +1,4 @@
+-- luacheck: read globals MoneyInputFrame_GetCopper MoneyInputFrame_ResetMoney
 local ADDON_NAME, ns = ...
 local Bags = ns.Bags or {}; ns.Bags = Bags
 local UIKit = ns.UIKit
@@ -89,31 +90,24 @@ end
 
 function Chassis.ShowMoneyPopup(key, kind, onAccept)
     local depositing = (kind == "deposit")
+    local function submit(dialog)
+        local amount = MoneyInputFrame_GetCopper(dialog.MoneyInputFrame)
+        if amount > 0 then onAccept(depositing, amount) end
+    end
+    StaticPopup_Hide(key)
     StaticPopupDialogs[key] = {
         text = depositing and ns.L["Deposit gold:"] or ns.L["Withdraw gold:"],
         button1 = ACCEPT,
         button2 = CANCEL,
-        hasEditBox = true,
-        maxLetters = 10,
-        OnShow = function(self)
-            local box = self.editBox or self.EditBox
-            if box then box:SetText("") end
-        end,
-        OnAccept = function(self)
-            local box = self.editBox or self.EditBox
-            local text = box and box:GetText() or ""
-            if not text:match("^%d+$") then return end
-            local gold = tonumber(text)
-            if not gold then return end
-            gold = math.floor(gold)
-            if gold <= 0 then return end
-            onAccept(depositing, gold * 10000)
+        hasMoneyInputFrame = true,
+        OnAccept = submit,
+        OnHide = function(self)
+            MoneyInputFrame_ResetMoney(self.MoneyInputFrame)
         end,
         EditBoxOnEnterPressed = function(box)
-            StaticPopup_OnClick(box:GetParent(), 1)
-        end,
-        EditBoxOnEscapePressed = function(box)
-            box:GetParent():Hide()
+            local dialog = box:GetParent():GetParent()
+            submit(dialog)
+            dialog:Hide()
         end,
         timeout = 0,
         whileDead = true,

--- a/QUI_Bags/bags/views/guild_window.lua
+++ b/QUI_Bags/bags/views/guild_window.lua
@@ -1,6 +1,7 @@
 -- luacheck: read globals MAX_GUILDBANK_TABS QueryGuildBankLog QueryGuildBankTab GetGuildBankTabCost
 -- luacheck: read globals ACCEPT CANCEL BuyGuildBankTab SetGuildBankTabInfo StaticPopup_OnClick
--- luacheck: read globals CanWithdrawGuildBankMoney InCombatLockdown StaticPopup_Hide
+-- luacheck: read globals DepositGuildBankMoney CanWithdrawGuildBankMoney WithdrawGuildBankMoney
+-- luacheck: read globals InCombatLockdown StaticPopup_Hide
 -- luacheck: read globals UNKNOWN HIGHLIGHT_FONT_COLOR_CODE GUILD_BANK_LOG_TIME RecentTimeDate
 -- luacheck: read globals GetNumGuildBankTransactions GetGuildBankTransaction
 -- luacheck: read globals GUILDBANK_DEPOSIT_FORMAT GUILDBANK_WITHDRAW_FORMAT GetGuildBankTabInfo
@@ -169,19 +170,18 @@ local function ShowRenamePopup(entry)
 end
 
 local function HideMoneyPopups()
-    StaticPopup_Hide("GUILDBANK_DEPOSIT")
-    StaticPopup_Hide("GUILDBANK_WITHDRAW")
+    StaticPopup_Hide("QUI_GUILDBANK_MONEY")
 end
 
 local function ShowMoneyPopup(kind)
     if InCombatLockdown() then return end
-    local key = kind == "deposit" and "GUILDBANK_DEPOSIT" or "GUILDBANK_WITHDRAW"
-    StaticPopup_Hide(kind == "deposit" and "GUILDBANK_WITHDRAW" or "GUILDBANK_DEPOSIT")
-    if StaticPopup_Visible(key) then
-        StaticPopup_Hide(key)
-    else
-        StaticPopup_Show(key)
-    end
+    Bags.Chassis.ShowMoneyPopup("QUI_GUILDBANK_MONEY", kind, function(depositing, amount)
+        if depositing then
+            DepositGuildBankMoney(amount)
+        elseif CanWithdrawGuildBankMoney() then
+            WithdrawGuildBankMoney(amount)
+        end
+    end)
 end
 
 function GuildWindow.CanWithdrawMoney(bankMoney, withdrawLimit, permitted, inCombat)

--- a/QUI_Bags/bags/views/item_buttons.lua
+++ b/QUI_Bags/bags/views/item_buttons.lua
@@ -2,6 +2,7 @@
 -- luacheck: read globals HandleModifiedItemClick GetGuildBankItemLink IsModifiedClick CursorHasItem
 -- luacheck: read globals GetGuildBankItemInfo StackSplitFrame DepositGuildBankMoney
 -- luacheck: read globals AutoStoreGuildBankItem PickupGuildBankItem DropCursorMoney SetItemButtonTexture
+-- luacheck: read globals GetCurrentGuildBankTab SetCurrentGuildBankTab
 -- luacheck: read globals SetItemButtonCount SetItemButtonDesaturated
 -- luacheck: read globals SetItemButtonOverlay ClearItemButtonOverlay
 -- luacheck: read globals C_AuctionHouse ItemButtonUtil ItemLocation
@@ -225,6 +226,12 @@ function ItemButtons.DressCached(button, entry, searchResult)
     ItemButtons.SetSearchDim(button, searchResult)
 end
 
+local function ActivateGuildTab(button)
+    if button._tab and button._tab ~= GetCurrentGuildBankTab() then
+        SetCurrentGuildBankTab(button._tab)
+    end
+end
+
 function ItemButtons.CreateGuildLive(parent)
     local button = CreateFrame("Button", nil, parent)
     ItemButtons.AddSlotBackground(button)
@@ -249,6 +256,7 @@ function ItemButtons.CreateGuildLive(parent)
         if HandleModifiedItemClick(GetGuildBankItemLink(self._tab, self._slot)) then
             return
         end
+        ActivateGuildTab(self)
         if IsModifiedClick("SPLITSTACK") then
             if not CursorHasItem() then
                 local _, count, locked = GetGuildBankItemInfo(self._tab, self._slot)
@@ -272,9 +280,11 @@ function ItemButtons.CreateGuildLive(parent)
         end
     end)
     button:SetScript("OnDragStart", function(self)
+        ActivateGuildTab(self)
         PickupGuildBankItem(self._tab, self._slot)
     end)
     button:SetScript("OnReceiveDrag", function(self)
+        ActivateGuildTab(self)
         PickupGuildBankItem(self._tab, self._slot)
     end)
     button:SetScript("OnEnter", function(self)


### PR DESCRIPTION
## Summary

- use Blizzard denomination inputs for bank and guild-bank money transfers
- close money dialogs when their bank view closes or becomes cached
- activate each guild-bank item's owning tab before click, split, auto-store, drag, or drop

## Validation

- `bash tools/test.sh` — all nine gates passed (891 unit files)
- QUI-tests PR #98 merged to `beta` as one commit