### PR TITLE
fix(cdm): preserve native buff suppression and combat castbars

### DIFF
--- a/QUI_CDM/cdm/cdm_blizzard_buffbar_suppression.lua
+++ b/QUI_CDM/cdm/cdm_blizzard_buffbar_suppression.lua
@@ -93,6 +93,14 @@ local function InstallParkHooks(frame, state)
     end
 
     state.parkHooked = true
+    if frame.SetAlpha then
+        hooksecurefunc(frame, "SetAlpha", function()
+            if not state.hidden or state.restoring or state.alphaGuard then return end
+            state.alphaGuard = true
+            frame:SetAlpha(0)
+            state.alphaGuard = nil
+        end)
+    end
     if frame.SetPoint then hooksecurefunc(frame, "SetPoint", QueueRepark) end
     if frame.SetAllPoints then hooksecurefunc(frame, "SetAllPoints", QueueRepark) end
     if frame.SetParent then hooksecurefunc(frame, "SetParent", QueueRepark) end
@@ -265,6 +273,7 @@ function Suppressor:CheckParkIntegrity(frame)
     if not frame then return false end
     local state = self._states[frame]
     if not state or not state.hidden or state.restoring or state.parkQueued then return false end
+    if frame.SetAlpha then frame:SetAlpha(0) end
     if IsParked(frame) then return true end
     return self:Suppress(frame)
 end

--- a/QUI_CDM/cdm/cdm_buff_layout.lua
+++ b/QUI_CDM/cdm/cdm_buff_layout.lua
@@ -12,8 +12,6 @@ local tostring = tostring
 local CreateFrame = CreateFrame
 local InCombatLockdown = InCombatLockdown
 local C_Timer = C_Timer
-local hooksecurefunc = hooksecurefunc
-local _securecall = securecallfunction or function(fn, ...) return fn(...) end
 local table_insert = table.insert
 
 local CDMBuffLayout = {}
@@ -664,8 +662,6 @@ end
 
 local trackedBarReadyFrame
 local trackedBarReadyQueued = false
-local barViewerLayoutHooked = false
-local InstallBarViewerLayoutHook
 
 local function IsCooldownViewerReady()
     local catalog = ns.CDMCatalog
@@ -696,30 +692,8 @@ local function QueueTrackedBarLayoutWhenReady()
         trackedBarReadyQueued = false
         local ready = IsCooldownViewerReady()
         if not ready then return end
-        if InstallBarViewerLayoutHook then InstallBarViewerLayoutHook() end
         if LayoutBuffBars then LayoutBuffBars() end
     end)
-end
-
-InstallBarViewerLayoutHook = function()
-    if barViewerLayoutHooked then return end
-    if not IsCooldownViewerReady() then
-        QueueTrackedBarLayoutWhenReady()
-        return
-    end
-
-    local blizzBarViewer = _G["BuffBarCooldownViewer"]
-    if blizzBarViewer and blizzBarViewer.Layout then
-        local function onBarViewerLayout()
-            if InCombatLockdown() then return end
-            C_Timer.After(0.1, function()
-                if isBarLayoutRunning then return end
-                LayoutBuffBars()
-            end)
-        end
-        hooksecurefunc(blizzBarViewer, "Layout", function(...) _securecall(onBarViewerLayout, ...) end)
-        barViewerLayoutHooked = true
-    end
 end
 
 local function GetBuffIconFrames()
@@ -1150,7 +1124,6 @@ local function Initialize()
         end
     end
 
-    InstallBarViewerLayoutHook()
     local barAuraCoalesce = CreateFrame("Frame")
     barAuraCoalesce:Hide()
     barAuraCoalesce:SetScript("OnUpdate", function(self)

--- a/QUI_CDM/cdm/cdm_catalog.lua
+++ b/QUI_CDM/cdm/cdm_catalog.lua
@@ -198,17 +198,22 @@ function CDMCatalog.GetTrackedCategorySet(category, allowUnlearned)
             return nil, false
         end
 
-        if provider.GetOrderedCooldownIDsForCategory then
-            local ok, ids = pcall(
-                provider.GetOrderedCooldownIDsForCategory,
-                provider,
-                category,
-                allowUnlearned and true or false)
-            if ok and type(ids) == "table" then
-                return ids, true
+        local displayData = provider.displayData
+        local ordered = type(displayData) == "table" and displayData.orderedCooldownIDs
+        local infoByID = type(displayData) == "table" and displayData.cooldownInfoByID
+        if type(ordered) ~= "table" or type(infoByID) ~= "table" then
+            return nil, false
+        end
+        local ids = {}
+        for _, cooldownID in ipairs(ordered) do
+            local info = infoByID[cooldownID]
+            if not info then return nil, false end
+            if not (_G.CDM_HIDE_INVISIBLE_ITEMS and info.isInvisible)
+                and info.category == category and (info.isKnown or allowUnlearned) then
+                ids[#ids + 1] = cooldownID
             end
         end
-        return nil, false
+        return ids, true
     end
 
     local ids = CDMCatalog.GetCategorySet(category, allowUnlearned)

--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -3230,7 +3230,14 @@ function ownedEngine:BootstrapReanchorRuntime()
                 EventRegistry:RegisterCallback("CooldownViewerSettings.OnShow",
                     reanchorAfterSettings, ns._cdmReanchorSettingsCallbackOwner)
                 EventRegistry:RegisterCallback("CooldownViewerSettings.OnHide",
-                    reanchorAfterSettings, ns._cdmReanchorSettingsCallbackOwner)
+                    function()
+                        C_Timer.After(0.1, reanchorAfterSettings)
+                        C_Timer.After(0.3, function()
+                            if ns._cdmTrackedBarLifecycleHooks then
+                                ns._cdmTrackedBarLifecycleHooks:MarkAllDirty()
+                            end
+                        end)
+                    end, ns._cdmReanchorSettingsCallbackOwner)
             end
         end
         self:InstallReanchorProcGlowHooks(boot)

--- a/QUI_CDM/cdm/cdm_index.lua
+++ b/QUI_CDM/cdm/cdm_index.lua
@@ -274,16 +274,18 @@ local function BuildOrderedMaps()
         return
     end
 
-    if CooldownViewerSettings and CooldownViewerSettings.GetDataProvider then
-        local provider = CooldownViewerSettings:GetDataProvider()
-        if provider and (provider.displayDataDirty or provider.displayData == nil) then
-            if not _orderedSpellMap then
-                _orderedSpellMap, _orderedEquipSlotMap, _orderedCategoryMap = {}, {}, {}
-                _orderedSpellMapByCategory, _orderedEquipSlotMapByCategory, _orderedCategoryMapByCategory =
-                    {}, {}, {}
-            end
-            return
+    local provider = CooldownViewerSettings and CooldownViewerSettings.GetDataProvider
+        and CooldownViewerSettings:GetDataProvider()
+    local displayData = provider and not provider.displayDataDirty and provider.displayData
+    local ordered = type(displayData) == "table" and displayData.orderedCooldownIDs
+    local infoByID = type(displayData) == "table" and displayData.cooldownInfoByID
+    if provider and (type(ordered) ~= "table" or type(infoByID) ~= "table") then
+        if not _orderedSpellMap then
+            _orderedSpellMap, _orderedEquipSlotMap, _orderedCategoryMap = {}, {}, {}
+            _orderedSpellMapByCategory, _orderedEquipSlotMapByCategory, _orderedCategoryMapByCategory =
+                {}, {}, {}
         end
+        return
     end
 
     local spellMap, equipSlotMap, categoryMap = {}, {}, {}
@@ -303,8 +305,7 @@ local function BuildOrderedMaps()
     if not (api and api.GetCooldownViewerCooldownInfo) then
         return
     end
-    local provider = CooldownViewerSettings:GetDataProvider()
-    if not (provider and provider.GetOrderedCooldownIDsForCategory) then
+    if not provider then
         return
     end
     if not (Enum and Enum.CooldownViewerCategory) then return end
@@ -323,9 +324,10 @@ local function BuildOrderedMaps()
             spellMapByCategory[cat] = catSpellMap
             equipSlotMapByCategory[cat] = catEquipSlotMap
             categoryMapByCategory[cat] = catCategoryMap
-            local ids = provider.GetOrderedCooldownIDsForCategory(provider, cat, true)
-            if ids then
-                for _, cdID in ipairs(ids) do
+            for _, cdID in ipairs(ordered) do
+                local snapshotInfo = infoByID[cdID]
+                if snapshotInfo and snapshotInfo.category == cat
+                    and not (_G.CDM_HIDE_INVISIBLE_ITEMS and snapshotInfo.isInvisible) then
                     local info = api.GetCooldownViewerCooldownInfo(cdID)
                     if info then
                         local entry = { cooldownID = cdID, category = cat }

--- a/QUI_CDM/cdm/hud_visibility.lua
+++ b/QUI_CDM/cdm/hud_visibility.lua
@@ -131,7 +131,7 @@ end
 local _viewerAlphaProxy = CreateFrame and CreateFrame("Frame") or nil
 local _rawViewerSetAlpha = _viewerAlphaProxy and _viewerAlphaProxy.SetAlpha or nil
 local _securecall = securecallfunction or function(fn, ...) return fn(...) end
-local REANCHOR_VIEWER_KEYS = { "essential", "utility", "buff", "trackedBar" }
+local REANCHOR_VIEWER_KEYS = { "essential", "utility", "buff" }
 
 local function ApplyReanchorViewerAlpha(alpha)
     if not _rawViewerSetAlpha then return end

--- a/QUI_UnitFrames/unitframes/castbar.lua
+++ b/QUI_UnitFrames/unitframes/castbar.lua
@@ -380,8 +380,11 @@ local function SetCastbarFrameVisible(frame, shouldShow)
 
     if shouldShow then
         frame:SetAlpha(1)
-        if not frame:IsShown() and not inCombat then
-            frame:Show()
+        if not frame:IsShown() then
+            local check = _G.C_RestrictedActions and _G.C_RestrictedActions.CheckAllowProtectedFunctions
+            if (check and check(frame, true)) or (not check and not inCombat) then
+                frame:Show()
+            end
         end
         return
     end


### PR DESCRIPTION
Native buff bars could reappear during HUD fades, and castbars hidden after previews could remain invisible during combat even after protected calls became allowed. Keep the native buff bar suppressed and permit castbars to show when the client allows protected operations.

Read built cooldown-provider snapshots without entering native lazy builders, remove the legacy native buff-bar layout hook, and refresh owned bars after cooldown settings finish closing. Pin the regression coverage merged in https://github.com/zol-wow/QUI-tests/pull/111.

Validation: `bash tools/test.sh` passed all nine gates, including 894 unit files, strict taint analysis, Lua 5.1 compilation, lint, profiles, and generated-file checks. Independent source review found no introduced defects. Live-client behavior has not been verified.
