### PR TITLE
fix(damage-meter): preserve combat labels and healing rows

### DIFF
--- a/QUI_DamageMeter/damage_meter/damage_meter.lua
+++ b/QUI_DamageMeter/damage_meter/damage_meter.lua
@@ -647,6 +647,9 @@ local function NormalizeSpells(rawSpells, out, limit)
             n = n + 1
             local info = ResolveSpellInfo(spell.spellID)
             local name = info and info.name
+            if IsSecretValue(spell.spellID) and C_Spell and C_Spell.GetSpellName then
+                name = C_Spell.GetSpellName(spell.spellID)
+            end
             if not IsSecretValue(name) and name == nil then
                 name = spell.creatureName
             end
@@ -877,6 +880,17 @@ function Data:GetPlayerTargetBreakdown(sessionType, playerName, targetGUID, targ
     return view
 end
 
+local function CanCombineHealingView(view, IsSecret)
+    if IsSecret and IsSecret(view.totalAmount) then return false end -- @secret-policy: reject-restricted-healing-merge
+    for _, source in ipairs(view.sources or {}) do
+        if IsSecret and (IsSecret(source.sourceGUID) or IsSecret(source.totalAmount)
+            or IsSecret(source.amountPerSecond)) then return false end
+        if source.sourceGUID == nil or type(source.totalAmount) ~= "number"
+            or type(source.amountPerSecond) ~= "number" then return false end
+    end
+    return true
+end
+
 function Data:GetCombinedHealingView(sessionType, sessionID)
     local T = Enum and Enum.DamageMeterType
     local hType = T and T.HealingDone
@@ -898,6 +912,15 @@ function Data:GetCombinedHealingView(sessionType, sessionID)
     end
 
     local IsSecret = Helpers and Helpers.IsSecretValue
+    if not (CanCombineHealingView(hView, IsSecret) and CanCombineHealingView(aView, IsSecret)) then
+        self._combinedHealingViews[selectorKey] = {
+            healingGeneration = hView.generation,
+            absorbGeneration = aView.generation,
+            view = hView,
+        }
+        return hView
+    end
+
     local merged, byGuid = {}, {}
     local function isIndexableKey(v)
         if IsSecret and IsSecret(v) then return false end -- @secret-policy: reject-secret-ids
@@ -2147,10 +2170,11 @@ function Window:Refresh()
     else
         view = Data:GetView(self.sessionType, self.damageMeterType, self.sessionID)
     end
-    if view.generation == self._lastGeneration then
+    if view == self._lastView and view.generation == self._lastGeneration then
         self:_BindVisibleRows()
         return
     end
+    self._lastView = view
     self._lastGeneration = view.generation
 
     local d = view.duration


### PR DESCRIPTION
Combat meter spell rows can lose their labels when spell IDs are restricted, and combining Healing/HPS with Absorbs can duplicate players when their identities cannot be compared. Resolve restricted spell names through the native API and preserve the native healing view when merge inputs are restricted or missing. Readable data continues to combine healing and absorbs.

Refresh rows when the selected view changes even if its generation matches, preventing stale combined totals during the fallback. Reuse cached combined and native fallback views before validation, avoiding repeated source scans and temporary validation tables.

Validation: all nine local gates passed, including 895 unit files, Lua 5.1 compile checks, strict taint, lint, profiles, and generated-file checks. Includes instrumented regressions in the tests submodule. Live-client rendering remains unverified.

Test companion: https://github.com/zol-wow/QUI-tests/pull/114. The submodule pins its isolated tested commit, excluding unrelated aura feature tests already on the tests repository beta branch.
