### PR TITLE
fix(cdm): honor per-spell duration overrides on native icons

### DIFF
--- a/QUI_CDM/cdm/cdm_reanchor_decorate.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_decorate.lua
@@ -21,10 +21,10 @@ function CDMReanchorDecorate.New(deps)
     return setmetatable(self, InstanceMT)
 end
 
-function CDMReanchorDecorate:Decorate(frame, rowConfig)
+function CDMReanchorDecorate:Decorate(frame, rowConfig, spellOverride)
     local deps = self._deps
     if self._done[frame] then
-        if deps.applyChrome then deps.applyChrome(frame, rowConfig, false) end
+        if deps.applyChrome then deps.applyChrome(frame, rowConfig, false, spellOverride) end
         return false
     end
     self._done[frame] = true
@@ -33,7 +33,7 @@ function CDMReanchorDecorate:Decorate(frame, rowConfig)
             deps.hideRegion(frame, HIDDEN_REGIONS[i])
         end
     end
-    if deps.applyChrome then deps.applyChrome(frame, rowConfig, true) end
+    if deps.applyChrome then deps.applyChrome(frame, rowConfig, true, spellOverride) end
     return true
 end
 

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -203,9 +203,9 @@ local function _StyleStackText(frame, rowConfig, baseFont, outline)
     end
 end
 
-local function _DecorateWork(decorator, live, shell, rowConfig)
+local function _DecorateWork(decorator, live, shell, rowConfig, spellOverride)
     if shell and shell.Border and shell.Border.Hide then shell.Border:Hide() end
-    return decorator:Decorate(live, rowConfig)
+    return decorator:Decorate(live, rowConfig, spellOverride)
 end
 
 local _barWidgets = setmetatable({}, { __mode = "k" })
@@ -386,7 +386,7 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
 
     local Helpers = ns.Helpers
     local _chrome = setmetatable({}, { __mode = "k" })
-    local function applyChrome(frame, rowConfig, _firstChrome)
+    local function applyChrome(frame, rowConfig, _firstChrome, spellOverride)
         -- applyChrome is the alpha authority for reanchored live icons:
         -- OverlayRect resets alpha to 1 each layout pass, so row opacity
         -- must be reapplied here on every call.
@@ -421,10 +421,14 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
                 cd:SetCountdownFont(countFontName)
             end
         end
-        if cd and cd.SetHideCountdownNumbers then
-            cd:SetHideCountdownNumbers(rowConfig.hideDurationText and true or false)
+        local hideDurationText = rowConfig.hideDurationText
+        if spellOverride and spellOverride.hideDurationText ~= nil then
+            hideDurationText = spellOverride.hideDurationText
         end
-        if not rowConfig.hideDurationText then
+        if cd and cd.SetHideCountdownNumbers then
+            cd:SetHideCountdownNumbers(hideDurationText and true or false)
+        end
+        if not hideDurationText then
             _AnchorCountdownText(cd, frame, rowConfig)
         end
         _StyleStackText(frame, rowConfig, generalFont, generalOutline)
@@ -479,7 +483,13 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
             return true
         end
         if decorator then
-            return _securecall(_DecorateWork, decorator, live, shell, rowConfig)
+            local entry = shell and shell._spellEntry
+            -- The settings panel keys overrides by the stored ID, even when
+            -- the live aura resolves to a different display spell.
+            local spellID = entry and (entry.id or entry.spellID)
+            local spellOverride = key and spellID and SpellData and SpellData.GetSpellOverride
+                and SpellData:GetSpellOverride(key, spellID) or nil
+            return _securecall(_DecorateWork, decorator, live, shell, rowConfig, spellOverride)
         end
     end
 


### PR DESCRIPTION
Enabling Hide Duration Text for a spell such as Benediction still left the countdown visible on its native CDM icon. Apply the saved per-spell override during native icon decoration on every refresh, using the stored entry ID and destination container. Clearing the override restores the row setting without changing neighboring icons.

Validation: all 213 CDM test files pass under LuaJIT; luacheck and strict taint checks pass for the changed code. In-game validation is pending.

Depends on https://github.com/zol-wow/QUI-tests/pull/118. Merge the tests PR first, then this PR. The tests submodule is pinned to 53f876307ef14ac543e0b5e5534dfc86486a5154. If the tests PR is squash-merged or rebased, update the submodule pointer to the resulting commit before merging this PR.