### PR TITLE
release: v5.3-beta6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.3-beta6 - 2026-09-06
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+Aura Display creation and layout tools, buff-icon growth controls, and focused
+combat UI fixes for the 5.3 beta line.
+
+### Added
+
+- **Aura Displays have templates, guided setup, and custom creation.** Browse
+  spells with clearer same-name variants, choose a display style, and configure
+  its unit, position, and load conditions.
+- **Aura Displays support nested groups, draggable previews, and share strings**
+  for individual displays or whole groups, with configurable spacing,
+  alignment, and sizing.
+- **Aura Displays can collapse gaps left by inactive tracked icons.** Compatible
+  grouped displays watching the same unit can also pack together.
+- **Cooldown Manager buff icons have growth direction and anchor controls.**
+  Grow centered, left, right, up, or down; choose which edge stays fixed during
+  free placement. Existing anchors to other frames remain in control.
+
+### Changed
+
+- **Group Death Alert settings now live under QoL → Notifications.** Existing
+  pinned alert settings open the new tab.
+
+### Fixed
+
+- **Cooldown Manager respects per-spell duration-text visibility overrides**
+  on native icons, and settings tooltips remain above the override panel.
+- **Replaced Blizzard buff bars stay hidden through HUD fades**, and tracked
+  bars refresh after closing Blizzard's Cooldown Manager settings.
+- **Hidden unit-frame castbars can appear during combat** when Blizzard allows
+  the frame to be shown.
+- **Damage Meter preserves spell names and healing rows during combat.** When
+  restricted values prevent combining healing and absorbs, it retains the
+  native healing view.
+
 ## v5.3-beta5 - 2026-09-04
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta5
+## Version: 5.3-beta6
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Prepare v5.3-beta6 with Aura Display creation and grouping tools, buff-icon growth controls, Notifications settings, and recent combat UI fixes.

Bump all 11 shipped TOCs to 5.3-beta6, add release notes, and pin the merged beta documentation update (QUI-docs #31). Interface remains 120100.

Validation: all nine `bash tools/test.sh` gates pass on the working tree and the exact committed tree in an isolated checkout; release generators are current and the workflow changelog extractor selects only beta6 notes.
