### PR TITLE
fix(qol): dismiss accepted summon popups

### DIFF
--- a/modules/qol/qol.lua
+++ b/modules/qol/qol.lua
@@ -766,6 +766,13 @@ local function SummonIsActive()
         and C_SummonInfo.GetSummonConfirmTimeLeft() > 0
 end
 
+local function AcceptSummon()
+    if C_SummonInfo and C_SummonInfo.ConfirmSummon then
+        C_SummonInfo.ConfirmSummon()
+        C_Timer.After(0, _G.HideSummonConfirmationDialogs)
+    end
+end
+
 local function TryAcceptPendingSummon()
     if not summonAcceptPending then return end
     local mode = GetAutoAcceptSummonMode()
@@ -782,7 +789,7 @@ local function TryAcceptPendingSummon()
         return
     end
     summonAcceptPending = false
-    if C_SummonInfo and C_SummonInfo.ConfirmSummon then C_SummonInfo.ConfirmSummon() end
+    AcceptSummon()
 end
 
 local function OnConfirmSummon()
@@ -798,7 +805,7 @@ local function OnConfirmSummon()
         C_Timer.After(0.2, TryAcceptPendingSummon)
         return
     end
-    if C_SummonInfo and C_SummonInfo.ConfirmSummon then C_SummonInfo.ConfirmSummon() end
+    AcceptSummon()
 end
 
 local function OnDuelRequested(challengerName)


### PR DESCRIPTION
Automatically accepted summons now close all Blizzard summon confirmation dialogs. Cleanup runs after the current event dispatch so it also catches dialogs Blizzard opens after QUI handles the event; immediate acceptance and combat/teleport retries share the same cleanup.

Validation: all nine local gates passed, including 908 unit test files and strict taint, Lua 5.1 compile, lint, profiles, and generated-file checks. The regression fails on the original code and passes with this change. Independent review found no issues. Live-client behavior has not been verified.

The tests pointer preserves QUI's existing test baseline and adds the popup regression. The companion tests PR carries the identical test change onto the tests repository's beta without importing its different baseline into QUI.
