### PR TITLE
fix(minimap): recalculate hidden cluster bounds

### DIFF
--- a/modules/minimap/minimap.lua
+++ b/modules/minimap/minimap.lua
@@ -1515,6 +1515,9 @@ local function UpdateButtonVisibility()
     end
 
     UpdateGreatVaultButton()
+    if MinimapCluster then
+        MinimapCluster:Layout()
+    end
 end
 
 local function BuildMiddleClickMenu()
@@ -3601,6 +3604,9 @@ function Minimap_Module:Refresh()
         end
     end
 
+    if MinimapCluster then
+        MinimapCluster:Layout()
+    end
     EndQUIControlledMinimapUpdate(0.75)
     FlushMinimapDebugStats(false)
 end


### PR DESCRIPTION
Hidden MinimapCluster bounds can remain stale even when the native layout reports clean, leaving negative available space for Blizzard’s right action bars. Recalculate the native cluster layout after button visibility updates and after the final saved minimap position is applied, using the existing combat and initialization guards.

The regression loads the real QUI update paths and native ResizeLayout with the reported geometry. It verifies stale-bound correction, combat exclusion, and final-position ordering. Tests are included through the merged companion PR https://github.com/zol-wow/QUI-tests/pull/123.

Validation: all nine `bash tools/test.sh` gates passed, including 909 unit test files. Independent review found no actionable defects; removing the fix and removing only the final refresh call each make the relevant regression assertion fail. `graphify update .` completed. Live reload recurrence remains unverified.
