### PR TITLE
fix(auras): restore weapon-oil timers after zoning

### DIFF
--- a/QUI_ActionBars/actionbars/buffborders.lua
+++ b/QUI_ActionBars/actionbars/buffborders.lua
@@ -693,8 +693,17 @@ end
 
 local paRegenFrame = CreateFrame("Frame")
 paRegenFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
-paRegenFrame:SetScript("OnEvent", function()
-    FlushPendingContainerWork()
+paRegenFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+paRegenFrame:SetScript("OnEvent", function(_, event)
+    if event == "PLAYER_ENTERING_WORLD" then
+        C_Timer.After(0, function()
+            if previewActive then return end
+            local container = buffContainer and buffContainer._quiLiveContainer
+            if container then container:UpdateAllAuras() end
+        end)
+    else
+        FlushPendingContainerWork()
+    end
 end)
 
 local function SetupDebugInstrumentation()


### PR DESCRIPTION
Weapon-oil durations can disappear after entering an instance; reloading, reapplying oil, or manually calling the native container refresh restores them. Request that native refresh on the frame after PLAYER_ENTERING_WORLD, using the current live buff container and skipping preview mode.

Includes the regression-test submodule update. The test loads the actual module and checks deferred dispatch, combat entry, missing or replaced containers, and no debuff refresh. All nine local quality gates pass. Automatic in-game recovery remains unverified.
