### PR TITLE
ci: use Astra at medium reasoning for PR reviews

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -123,7 +123,7 @@ jobs:
           printf '%s\n' "$CODEX_SCHEMA" > "$RUNNER_TEMP/codex-schema.json"
           printf '%s\n' "$CODEX_PROMPT" | codex exec \
             --ephemeral --ignore-user-config --ignore-rules \
-            -C "$GITHUB_WORKSPACE" -m gpt-5.6-sol \
+            -C "$GITHUB_WORKSPACE" -m gpt-6-astra \
             -c 'model_reasoning_effort="medium"' \
             --sandbox read-only \
             --output-schema "$RUNNER_TEMP/codex-schema.json" \


### PR DESCRIPTION
Switch the automatic GitHub PR reviewer to `gpt-6-astra` while retaining medium reasoning effort. The on-demand Codex and issue-triage workflows keep their current models.

Validation: local Codex model metadata confirms medium reasoning support; `JOBS=4 bash tools/test.sh` passed all nine gates.
