### PR TITLE
fix(infobar): lower bar frame strata

### DIFF
--- a/modules/infobar/infobar.lua
+++ b/modules/infobar/infobar.lua
@@ -92,7 +92,7 @@ end
 local function CreateBar()
     if bar then return end
     bar = CreateFrame("Frame", "QUI_InfoBar", UIParent)
-    bar:SetFrameStrata("HIGH")
+    bar:SetFrameStrata("LOW")
 
     bar:SetScript("OnSizeChanged", QueueReflow)
 


### PR DESCRIPTION
The Info Bar used HIGH frame strata, allowing it to overlap lower-strata UI windows. Set it to LOW so those windows render above the bar.

Validation: all nine local gates passed via `bash tools/test.sh`; independent review found no actionable regressions. Visual layering still needs an in-game check.
