### PR TITLE
fix: defer CDM settings updates and preserve dimmed group tooltips

### DIFF
--- a/QUI_CDM/cdm/cdm_index.lua
+++ b/QUI_CDM/cdm/cdm_index.lua
@@ -246,28 +246,17 @@ _eventFrame:SetScript("OnEvent", function(_, event, arg1, arg2)
     end
 end)
 
-local _securecall = securecallfunction or function(fn, ...) return fn(...) end
-local function _OnSettingsRefreshLayout() Notify("refresh_layout") end
-
-local _refreshLayoutHooked = false
-local function InstallRefreshLayoutHook()
-    if _refreshLayoutHooked then return end
-    if not (CooldownViewerSettings and CooldownViewerSettings.RefreshLayout) then return end
-    local ok = pcall(hooksecurefunc, CooldownViewerSettings, "RefreshLayout", function(...)
-        _securecall(_OnSettingsRefreshLayout, ...)
-    end)
-    if ok then _refreshLayoutHooked = true end
+local _settingsRefreshPending = false
+if EventRegistry and EventRegistry.RegisterCallback then
+    EventRegistry:RegisterCallback("CooldownViewerSettings.OnDataChanged", function()
+        if _settingsRefreshPending then return end
+        _settingsRefreshPending = true
+        C_Timer.After(0, function()
+            _settingsRefreshPending = false
+            Notify("refresh_layout")
+        end)
+    end, CDMIndex)
 end
-
-InstallRefreshLayoutHook()
-local _hookFrame = CreateFrame("Frame")
-_hookFrame:RegisterEvent("PLAYER_LOGIN")
-_hookFrame:SetScript("OnEvent", function(self)
-    InstallRefreshLayoutHook()
-    if _refreshLayoutHooked then
-        self:UnregisterAllEvents()
-    end
-end)
 
 local function BuildOrderedMaps()
     if _orderedSpellMap and _orderedMapsVersion == _version then

--- a/modules/qol/tooltip_provider.lua
+++ b/modules/qol/tooltip_provider.lua
@@ -184,6 +184,9 @@ function TooltipProvider:IsOwnerFadedOut(owner)
     if Helpers.IsSecretValue(alpha) then
         return false -- @secret-policy: treat-unknown-alpha-as-visible
     end
+    if owner._quiDecorated then
+        return (tonumber(alpha) or 1) <= 0
+    end
     return (tonumber(alpha) or 1) < FADED_ALPHA_THRESHOLD
 end
 


### PR DESCRIPTION
Native CDM settings edits now notify the QUI index on the next timer tick, coalescing each change burst without hooking Blizzard RefreshLayout. Range-dimmed group frames retain player tooltips; fully transparent frames and unrelated faded owners still suppress them.

The tests submodule includes regression coverage from zol-wow/QUI-tests#129 and the updated protected-call inventory. Both regressions pass with these changes and fail against the previous implementation for the intended reason. All nine local gates pass, including Lua 5.1 compilation, strict taint analysis, 921 unit test files, lint, and generated-file checks. Independent review found no actionable issues.

These checks verify notification and tooltip behavior; elimination of the reported native CDM taint still requires live WoW reproduction.
