### PR TITLE
fix(cdm): avoid native serializer writes and add taint tracing

### DIFF
--- a/QUI_CDM/cdm/cdm_catalog.lua
+++ b/QUI_CDM/cdm/cdm_catalog.lua
@@ -190,11 +190,7 @@ function CDMCatalog.GetTrackedCategorySet(category, allowUnlearned)
             return nil, false
         end
 
-        local okManager, manager
-        if provider.GetLayoutManager then
-            okManager, manager = pcall(provider.GetLayoutManager, provider)
-        end
-        if not okManager or not manager then
+        if not provider.layoutManager then
             return nil, false
         end
 

--- a/QUI_CDM/cdm/cdm_containers.lua
+++ b/QUI_CDM/cdm/cdm_containers.lua
@@ -2733,6 +2733,7 @@ local function RunPostLayoutRefresh()
 end
 
 RefreshAll = function(forceSync)
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("RefreshAll entry") end
     if not initialized then
         return
     end
@@ -2771,12 +2772,15 @@ RefreshAll = function(forceSync)
         end
     end
 
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("RefreshAll positions restored") end
     SyncSettingsFeatureLookups()
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("RefreshAll settings synced") end
 
     refreshAllReanchorBatchActive = true
     refreshAllReanchorBatchCounts = nil
     if ns._cdmBoot and ns._cdmBoot.RefreshBuiltins then
         InitBuffContainer()
+        if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("RefreshAll buff initialized") end
         RefreshReanchoredBuiltin(ns._cdmBoot, "essential", false)
     end
 
@@ -3637,6 +3641,7 @@ function ownedEngine:Initialize()
     RegisterClassTalentSwitchCallbacks()
 
     eventFrame:SetScript("OnEvent", function(self, event, arg1, arg2)
+        if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("containers event entry: " .. event) end
         if not IsCDMRuntimeEnabled() then
             self:UnregisterAllEvents()
             return
@@ -3701,10 +3706,12 @@ function ownedEngine:Initialize()
             end
         elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
             local newSpecID = ConsumePendingClassTalentSpecSwitchID() or GetCurrentSpecID()
+            if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("spec ID resolved") end
             if not newSpecID or newSpecID ~= _previousSpecID then
                 if _previousSpecID and _previousSpecID ~= 0 then
                     SaveCurrentSpecProfile()
                 end
+                if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("previous spec saved") end
                 if ns.InvalidateCDMFrameCache then ns.InvalidateCDMFrameCache() end
                 if ns.CDMSpellData and ns.CDMSpellData.InvalidateLearnedCache then
                     ns.CDMSpellData:InvalidateLearnedCache()
@@ -3712,7 +3719,9 @@ function ownedEngine:Initialize()
                 specTrackingReady = false
                 specTrackingPendingRefresh = true
                 specTrackingRetryToken = specTrackingRetryToken + 1
+                if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("before spec profile restore") end
                 local readyNow = LoadOrSnapshotSpecProfile(newSpecID, 1, specTrackingRetryToken)
+                if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("after spec profile restore") end
                 _previousSpecID = newSpecID
                 _previousLoadoutID = GetEffectiveLoadoutIDForSpec(newSpecID)
                 local specDB = GetSpecStateDB(true)
@@ -3738,6 +3747,7 @@ function ownedEngine:Initialize()
             local myToken = loadoutTrackingToken
 
             loadoutDebounceTimer = C_Timer.NewTimer(0.5, function()
+                if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("loadout timer entry") end
                 loadoutDebounceTimer = nil
                 if myToken ~= loadoutTrackingToken then return end
                 if not specTrackingReady then
@@ -3783,12 +3793,15 @@ function ownedEngine:Initialize()
         elseif event == "PLAYER_TALENT_UPDATE" then
             if not specTrackingReady then
                 local readyNow = InitSpecTracking()
+                if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("talent tracking initialized") end
                 specTrackingReady = readyNow
                 if readyNow and specTrackingPendingRefresh then
                     FinalizeSpecTracking()
+                    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("talent tracking finalized") end
                 end
             end
             ResolveInitialLoadoutSlot()
+            if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("containers talent event exit") end
         elseif event == "SPECIALIZATION_CHANGE_CAST_FAILED" then
             ClearPendingClassTalentSwitchIntent()
         elseif event == "TRAIT_CONFIG_LIST_UPDATED" then

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -5,6 +5,15 @@ ns.CDMReanchorBoot = CDMReanchorBoot
 
 local _issecretvalue = issecretvalue or function() return false end
 
+local function CallNativeWidget(frame, widget, method, fn, ...)
+    local trace = ns.CDMNativeCallTrace
+    local token = trace and trace:Before(frame, method)
+    fn(widget, ...)
+    if token then trace:After(frame, method, token) end
+end
+
+CDMReanchorBoot._CallNativeWidget = CallNativeWidget
+
 local function MakePositionOwned(env)
     return function(icon, container, point, relPoint, x, y, rowConfig)
         if icon.GetScale and icon:GetScale() ~= 1 then
@@ -109,17 +118,17 @@ function CDMReanchorBoot.BuildRuntime(env)
     local function reassertColor(frame, cd, containerKey)
         if not (cd and cd.SetSwipeColor) then return end
         if effectsHidden(containerKey) then
-            cd:SetSwipeColor(0, 0, 0, 0)
-            if cd.SetDrawSwipe then cd:SetDrawSwipe(false) end
-            if cd.SetDrawEdge then cd:SetDrawEdge(false) end
+            CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, 0, 0, 0, 0)
+            if cd.SetDrawSwipe then CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, false) end
+            if cd.SetDrawEdge then CallNativeWidget(frame, cd, "SetDrawEdge", cd.SetDrawEdge, false) end
             return
         end
         if isBuffIconFrameKey(containerKey) then
             if swipeSettings().showBuffIconSwipe == false then
-                cd:SetSwipeColor(0, 0, 0, 0)
+                CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, 0, 0, 0, 0)
             else
                 local r, g, b, a = modeColor("aura")
-                cd:SetSwipeColor(r, g, b, a)
+                CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, r, g, b, a)
             end
             return
         end
@@ -127,54 +136,54 @@ function CDMReanchorBoot.BuildRuntime(env)
             if not frame.GetCooldownID then return end
             local s = swipeSettings()
             if not isAuraPhaseEnabled() or s.showBuffSwipe == false then
-                cd:SetSwipeColor(0, 0, 0, 0)
+                CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, 0, 0, 0, 0)
             else
                 local r, g, b, a = modeColor("aura")
-                cd:SetSwipeColor(r, g, b, a)
+                CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, r, g, b, a)
             end
         elseif cooldownShown(frame) then
             local r, g, b, a = modeColor("cooldown")
-            cd:SetSwipeColor(r, g, b, a)
+            CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, r, g, b, a)
         else
-            cd:SetSwipeColor(0, 0, 0, 0)
+            CallNativeWidget(frame, cd, "SetSwipeColor", cd.SetSwipeColor, 0, 0, 0, 0)
         end
     end
-    local function reassertEdge(_frame, cd, containerKey)
+    local function reassertEdge(frame, cd, containerKey)
         if not (cd and cd.SetDrawEdge) then return end
         if effectsHidden(containerKey) then
-            cd:SetDrawEdge(false)
+            CallNativeWidget(frame, cd, "SetDrawEdge", cd.SetDrawEdge, false)
             return
         end
         local s = swipeSettings()
         if isBuffIconFrameKey(containerKey) then
             if s.showBuffIconSwipe == false or s.showBuffEdge == false then
-                cd:SetDrawEdge(false)
+                CallNativeWidget(frame, cd, "SetDrawEdge", cd.SetDrawEdge, false)
             end
             return
         end
         if s.showRechargeEdge then return end
-        cd:SetDrawEdge(false)
+        CallNativeWidget(frame, cd, "SetDrawEdge", cd.SetDrawEdge, false)
     end
     local function reassertSwipe(frame, cd, containerKey, show)
         if not (cd and cd.SetDrawSwipe) then return end
         local s = swipeSettings()
         if effectsHidden(containerKey) then
-            if show then cd:SetDrawSwipe(false) end
+            if show then CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, false) end
             return
         end
         if isBuffIconFrameKey(containerKey) then
             if s.showBuffIconSwipe == false and show then
-                cd:SetDrawSwipe(false)
+                CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, false)
             elseif s.showBuffIconSwipe ~= false and show == false then
-                cd:SetDrawSwipe(true)
+                CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, true)
             end
             return
         end
         if frameCanUseAuraForDisplay(frame) then
             if not isAuraPhaseEnabled() or s.showBuffSwipe == false then
-                if show then cd:SetDrawSwipe(false) end
+                if show then CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, false) end
             elseif show == false then
-                cd:SetDrawSwipe(true)
+                CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, true)
             end
             return
         end
@@ -182,20 +191,20 @@ function CDMReanchorBoot.BuildRuntime(env)
         if _issecretvalue(gcd) then return end
         if gcd == true then
             if s.showGCDSwipe == true and not show then
-                cd:SetDrawSwipe(true)
+                CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, true)
             elseif s.showGCDSwipe ~= true and show then
-                cd:SetDrawSwipe(false)
+                CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, false)
             end
             return
         end
         if s.showCooldownSwipe == false and show then
-            cd:SetDrawSwipe(false)
+            CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, false)
             return
         end
         if not show then
             local hasCharges = type(frame and frame.HasVisualDataSource_Charges) == "function"
                 and frame:HasVisualDataSource_Charges()
-            if not hasCharges then cd:SetDrawSwipe(true) end
+            if not hasCharges then CallNativeWidget(frame, cd, "SetDrawSwipe", cd.SetDrawSwipe, true) end
         end
     end
     local function cleanSpellID(spellID)
@@ -250,11 +259,12 @@ function CDMReanchorBoot.BuildRuntime(env)
             duration = Sources.QuerySpellCooldownDuration(spellID, true)
         end
         if not duration then return end
-        if cd.SetUseAuraDisplayTime then cd:SetUseAuraDisplayTime(false) end
+        if cd.SetUseAuraDisplayTime then CallNativeWidget(frame, cd, "SetUseAuraDisplayTime", cd.SetUseAuraDisplayTime, false) end
         if ns.CDMRenderers and ns.CDMRenderers.ApplyDurationObjectCooldown then
-            ns.CDMRenderers.ApplyDurationObjectCooldown(cd, duration, true, false)
+            CallNativeWidget(frame, cd, "ApplyDurationObjectCooldown",
+                ns.CDMRenderers.ApplyDurationObjectCooldown, duration, true, false)
         elseif cd.SetCooldownFromDurationObject then
-            cd:SetCooldownFromDurationObject(duration, true)
+            CallNativeWidget(frame, cd, "SetCooldownFromDurationObject", cd.SetCooldownFromDurationObject, duration, true)
         end
     end
     local auraPhase = ns.CDMReanchorAuraPhase and ns.CDMReanchorAuraPhase.New({

--- a/QUI_CDM/cdm/cdm_reanchor_runtime.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_runtime.lua
@@ -558,6 +558,7 @@ function CDMReanchorRuntime:_PrepareContainerState(containerKey)
 end
 
 function CDMReanchorRuntime:RefreshContainers(containerKeys)
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("reanchor batch entry") end
     local keys, seen = {}, {}
     containerKeys = containerKeys or DEFAULT_BATCH_KEYS
     for i = 1, #containerKeys do
@@ -629,6 +630,7 @@ function CDMReanchorRuntime:RefreshContainers(containerKeys)
 end
 
 function CDMReanchorRuntime:RefreshContainer(containerKey, prepared, placementPlan, batchCommit)
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("reanchor container entry") end
     if not batchCommit and self:_ShouldDeferOwnedReleaseInCombat(containerKey) then
         self._pendingCombatRefresh = self._pendingCombatRefresh or {}
         self._pendingCombatRefresh[containerKey] = true
@@ -675,6 +677,7 @@ function CDMReanchorRuntime:RefreshContainer(containerKey, prepared, placementPl
             containerKey, frameMap, settings, prepared, placementPlan)
     end
 
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("reanchor entries assembled") end
     if not batchCommit then self:ClearContainerRegistry(containerKey) end
     local reanchored = {}
     for i = 1, #entries do
@@ -696,6 +699,7 @@ function CDMReanchorRuntime:RefreshContainer(containerKey, prepared, placementPl
             end
             if deps.auraPhase then
                 deps.auraPhase:Hook(w.liveFrame, containerKey, w.src)
+                if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("reanchor aura hooks installed") end
                 if deps.auraPhase.Reassert then
                     deps.auraPhase:Reassert(w.liveFrame, w.src)
                 end

--- a/QUI_CDM/cdm/cdm_spelldata.lua
+++ b/QUI_CDM/cdm/cdm_spelldata.lua
@@ -2369,9 +2369,12 @@ local function LearnedCatalogSignature()
 end
 
 local function RunReconcileSequence(guardUnchanged)
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("reconcile entry") end
     local restored = CDMSpellData:CheckAllDormantSpells()
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("dormant spells checked") end
     local before = guardUnchanged and LearnedCatalogSignature() or nil
     CDMSpellData:ReconcileAllContainers()
+    if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("catalog reconciled") end
     if guardUnchanged and not restored and before == LearnedCatalogSignature() then
         return
     end
@@ -3496,6 +3499,7 @@ function CDMSpellData:Initialize()
     eventFrame:RegisterEvent("COOLDOWN_VIEWER_TABLE_HOTFIXED")
     eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
     eventFrame:SetScript("OnEvent", function(self, event, arg)
+        if ns.CDMNativeCallTrace then ns.CDMNativeCallTrace:Checkpoint("spelldata event entry: " .. event) end
         if not IsCDMRuntimeEnabled() then
             self:UnregisterAllEvents()
             return

--- a/QUI_Debug/QUI_Debug.toc
+++ b/QUI_Debug/QUI_Debug.toc
@@ -18,6 +18,7 @@ editmode_diagnose.lua
 combat_end_profiler.lua
 ui_smoke.lua
 aura_probe.lua
+cdm_taint_trace.lua
 cdm_debug.lua
 # activate.lua must stay LAST: drains the main addon's debug-instrumentation gate
 activate.lua

--- a/QUI_Debug/cdm_debug.lua
+++ b/QUI_Debug/cdm_debug.lua
@@ -3938,6 +3938,7 @@ local function PrintCDMDebugHelp()
     print("  /cdmdebug profile [status|clean]          -> CDM profile tools")
     print("  /cdmdebug probe                           -> resolver parity sweep")
     print("  /cdmdebug mint                            -> native mint/provider taint verdict")
+    print("  /cdmdebug taintcalls [report|off]          -> trace native cooldown setter ownership changes")
     print("  /cdmdebug borrow <spell> [container]      -> borrow a spare native item frame; off|report")
     print("  /cdmdebug native <spell> [seconds]         -> native frame/aura/charge lifecycle trace")
     print("  /cdmdebug buff                            -> reanchor BuffIcon pipeline dump")
@@ -3969,6 +3970,15 @@ local function RunCDMDebugCommand(msg)
         RunCDMDebugProbe()
     elseif lower == "mint" then
         RunCDMDebugMint()
+    elseif lower == "taintcalls" then
+        if rest == "off" then
+            ns.CDMTaintTrace:Stop()
+            ns.CDMTaintTrace:Report()
+        elseif rest == "report" then
+            ns.CDMTaintTrace:Report()
+        else
+            ns.CDMTaintTrace:Start()
+        end
     elseif lower == "borrow" then
         RunCDMDebugBorrow(rest)
     elseif lower == "native" then

--- a/QUI_Debug/cdm_taint_trace.lua
+++ b/QUI_Debug/cdm_taint_trace.lua
@@ -1,0 +1,134 @@
+local _, ns = ...
+
+local Trace = {}
+ns.CDMTaintTrace = Trace
+
+local providerFields = { "displayData", "displayDataDirty", "layoutManager" }
+local displayFields = {
+    "orderedCooldownIDs", "cooldownInfoByID", "cooldownDefaultsByID", "defaultOrderedCooldownIDs",
+}
+local itemFields = {
+    "cooldownID", "cooldownInfo", "auraInstanceID", "auraSpellID", "auraDataCached",
+    "auraDataUnit", "alertsByEvent", "viewerFrame", "layoutIndex", "isActive", "isActiveSpell",
+}
+
+local function Snapshot(frame)
+    local result = {}
+    local function add(object, fields, prefix)
+        if not object or (issecretvalue and issecretvalue(object)) then return end
+        for _, field in ipairs(fields) do
+            local secure, owner = issecurevariable(object, field)
+            result[#result + 1] = { key = prefix .. field, secure = secure, owner = owner }
+        end
+    end
+    local settings = _G.CooldownViewerSettings
+    local provider = settings and settings.dataProvider
+    add(provider, providerFields, "provider.")
+    local display = provider and provider.displayData
+    add(display, displayFields, "displayData.")
+    add(frame, itemFields, "item.")
+    return result
+end
+
+local function Changes(before, after)
+    local previous, changes = {}, {}
+    for _, entry in ipairs(before) do previous[entry.key] = entry.secure end
+    for _, entry in ipairs(after) do
+        if previous[entry.key] == true and entry.secure == false then
+            changes[#changes + 1] = entry.key .. " -> " .. tostring(entry.owner)
+        end
+    end
+    return changes
+end
+
+function Trace:Stop()
+    ns.CDMNativeCallTrace = nil
+    if self.ticker then self.ticker:Cancel(); self.ticker = nil end
+end
+
+function Trace:Record(label, changes)
+    self:Stop()
+    self.report = {
+        "[CDMTrace] " .. label .. "; calls=" .. tostring(self.calls),
+        table.concat(changes, "; "),
+        "[CDMTrace] last clean checkpoint: " .. tostring(self.lastClean),
+        debugstack(3, 18, 0),
+    }
+    self:Report()
+end
+
+function Trace:Report()
+    if self.report then
+        for _, line in ipairs(self.report) do print(line) end
+    else
+        print("[CDMTrace] no transition recorded; calls=" .. tostring(self.calls or 0))
+    end
+end
+
+function Trace:Checkpoint(label)
+    local current = Snapshot(nil)
+    local changes = Changes(self.previous, current)
+    if #changes > 0 then
+        self:Record("ownership changed before checkpoint: " .. label, changes)
+    else
+        self.previous = current
+        self.lastClean = label
+    end
+end
+
+function Trace:Before(frame, method)
+    local snapshot = Snapshot(frame)
+    local changes = Changes(self.previous, snapshot)
+    if #changes > 0 then
+        self:Record("taint already present on entry to " .. method, changes)
+        return nil
+    end
+    self.calls = self.calls + 1
+    return snapshot
+end
+
+function Trace:After(frame, method, before)
+    if ns.CDMNativeCallTrace ~= self then return end
+    local after = Snapshot(frame)
+    local changes = Changes(before, after)
+    if #changes > 0 then
+        self:Record("ownership changed during " .. method, changes)
+    else
+        self.previous = Snapshot(nil)
+        self.lastClean = "after " .. method
+    end
+end
+
+function Trace:Start()
+    self:Stop()
+    self.report = nil
+    self.calls = 0
+    self.lastClean = "trace start"
+    self.previous = Snapshot(nil)
+    if #self.previous == 0 then
+        print("[CDMTrace] native provider unavailable")
+        return
+    end
+    for _, entry in ipairs(self.previous) do
+        if entry.secure == false then
+            print("[CDMTrace] already tainted: " .. entry.key .. "; /reload before starting")
+            return
+        end
+    end
+    ns.CDMNativeCallTrace = self
+    local ticks = 0
+    self.ticker = C_Timer.NewTicker(0.2, function()
+        ticks = ticks + 1
+        local current = Snapshot(nil)
+        local changes = Changes(self.previous, current)
+        if #changes > 0 then
+            self:Record("ownership change detected by periodic sample", changes)
+        elseif ticks >= 300 then
+            self:Stop()
+            print("[CDMTrace] finished 60 seconds; calls=" .. tostring(self.calls) .. "; no transition captured")
+        else
+            self.previous = current
+        end
+    end)
+    print("[CDMTrace] started: clean provider; tracing spec refresh and native cooldown setters for 60 seconds")
+end


### PR DESCRIPTION
CDM category reads now use the existing native layout manager without calling its getter, which can populate Blizzard's serializer cache from QUI's execution context.

Adds `/cdmdebug taintcalls [report|off]` to capture provider ownership transitions at refresh checkpoints and provider/item transitions across native cooldown setters. Tracing is opt-in and stops after the first transition or 60 seconds. This is diagnostic instrumentation; a fix for the reported live aura-map failure has not been established.

Validation: all nine gates passed with `JOBS=8 bash tools/test.sh`; the provider regression fails against the previous implementation at the native serializer-cache assertion. Independent local review found no concrete blockers. Supporting tests landed in zol-wow/QUI-tests#130.

All local changes are included in this single commit for squash merge into beta.
