### PR TITLE
fix(libs): update vendored libraries for API compatibility

### DIFF
--- a/libs/AceComm-3.0/ChatThrottleLib.lua
+++ b/libs/AceComm-3.0/ChatThrottleLib.lua
@@ -23,7 +23,7 @@
 -- LICENSE: ChatThrottleLib is released into the Public Domain
 --
 
-local CTL_VERSION = 31
+local CTL_VERSION = 32
 
 local _G = _G
 
@@ -279,6 +279,7 @@ end
 local bMyTraffic = false
 
 function ChatThrottleLib.Hook_SendChatMessage(text, chattype, language, destination, ...)
+	if issecretvalue and (issecretvalue(text) or issecretvalue(destination)) then return end
 	if bMyTraffic then
 		return
 	end
@@ -288,6 +289,7 @@ function ChatThrottleLib.Hook_SendChatMessage(text, chattype, language, destinat
 	self.nBypass = self.nBypass + size	-- just a statistic
 end
 function ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destination, ...)
+	if issecretvalue and (issecretvalue(text) or issecretvalue(destination)) then return end
 	if bMyTraffic then
 		return
 	end

--- a/libs/LibDualSpec-1.0/LibDualSpec-1.0.lua
+++ b/libs/LibDualSpec-1.0/LibDualSpec-1.0.lua
@@ -31,10 +31,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --]]
 
--- Only load in Classic Era on Season of Discovery and Anniversary realms
-if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC and C_Seasons.GetActiveSeason() ~= 2 and C_Seasons.GetActiveSeason() ~= 11 and C_Seasons.GetActiveSeason() ~= 12 then return end
-
-local MAJOR, MINOR = "LibDualSpec-1.0", 29
+local MAJOR, MINOR = "LibDualSpec-1.0", 32
 assert(LibStub, MAJOR.." requires LibStub")
 local lib, minor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end
@@ -291,7 +288,6 @@ end
 options.new = {
 	name = "New",
 	type = "input",
-	order = 30,
 	get = false,
 	set = function(info, value)
 		local db = info.handler.db
@@ -301,19 +297,20 @@ options.new = {
 			db:SetProfile(value)
 		end
 	end,
+	order = 30,
 }
 
 options.choose = {
 	name = "Existing Profiles",
 	type = "select",
-	order = 40,
 	get = "GetCurrentProfile",
 	set = "SetProfile",
 	values = "ListProfiles",
 	arg = "common",
 	disabled = function(info)
 		return info.handler.db:IsDualSpecEnabled()
-	end
+	end,
+	order = 40,
 }
 
 options.enabled = {
@@ -331,11 +328,11 @@ options.enabled = {
 		return desc
 	end,
 	descStyle = "inline",
-	order = 41,
-	width = "full",
 	get = function(info) return info.handler.db:IsDualSpecEnabled() end,
 	set = function(info, value) info.handler.db:SetDualSpecEnabled(value) end,
 	disabled = function() return lib.currentSpec == 0 end,
+	order = 41,
+	width = "full",
 }
 
 local points = {}
@@ -379,7 +376,6 @@ for i = 1, numSpecs do
 				end
 			end
 		end or nil,
-		order = 42 + i,
 		get = function(info)
 			local specIndex = tonumber(info[#info]:sub(-1))
 			return info.handler.db:GetDualSpecProfile(specIndex)
@@ -391,6 +387,8 @@ for i = 1, numSpecs do
 		values = "ListProfiles",
 		arg = "common",
 		disabled = function(info) return not info.handler.db:IsDualSpecEnabled() end,
+		order = 42 + i,
+		width = 1.5,
 	}
 end
 
@@ -418,6 +416,12 @@ function lib:EnhanceOptions(optionTable, target)
 	options.new.desc = optionTable.args.new.desc
 	options.choose.name = optionTable.args.choose.name
 	options.choose.desc = optionTable.args.choose.desc
+
+	-- copy properties
+	options.new.validate = optionTable.args.new.validate
+	options.new.usage = optionTable.args.new.usage
+	options.new.width = optionTable.args.new.width
+	options.choose.width = optionTable.args.choose.width
 
 	-- add our new options
 	if not optionTable.plugins then

--- a/libs/LibDualSpec-1.0/LibDualSpec-1.0.toc
+++ b/libs/LibDualSpec-1.0/LibDualSpec-1.0.toc
@@ -1,8 +1,8 @@
-## Interface: 11508, 20505, 30405, 38000, 40402, 50503, 120001
+## Interface: 11508, 11509, 20505, 20506, 30405, 38001, 40402, 50503, 50504, 120100, 120005, 120007
 ## LoadOnDemand: 1
 ## Title: Lib: DualSpec-1.0
-## Version: v1.29.0
-## X-Date: 2026-02-14T00:00:00Z
+## Version: v1.32.0
+## X-Date: 2026-09-05T03:53:48Z
 ## Notes: Adds spec switching support to individual AceDB-3.0 databases.
 ## Author: Adirelle, Nebula
 ## OptionalDeps: Ace3

--- a/libs/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/libs/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 35
+local MINOR_VERSION = 36
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
@@ -114,7 +114,13 @@ local UnitClass = UnitClass
 local UnitRace = UnitRace
 local GetInventoryItemLink = GetInventoryItemLink
 local GetTime = GetTime
-local HandSlotId = GetInventorySlotInfo("HANDSSLOT")
+
+local HandSlotId
+if C_PaperDollInfo and C_PaperDollInfo.GetInventorySlotInfo then
+  HandSlotId = C_PaperDollInfo.GetInventorySlotInfo("HANDSSLOT")
+else
+  HandSlotId = GetInventorySlotInfo("HANDSSLOT")
+end
 local math_floor = math.floor
 local UnitIsVisible = UnitIsVisible
 


### PR DESCRIPTION
Updates ChatThrottleLib to 32, LibRangeCheck to 36, and LibDualSpec to 1.32.0. Secret chat text and destinations now bypass bandwidth accounting safely, and range checks load when only the namespaced inventory-slot API is available. QUI's existing secret-value protections remain intact.

Includes the regression tests from zol-wow/QUI-tests#131 through the tests submodule. All nine `bash tools/test.sh` gates passed, including 923 unit files and ten vendor regression cases. Independent review found no issues. Live WoW smoke testing remains outstanding.
