### PR TITLE
chore(libs): remove verified redundant secret patches

### DIFF
--- a/libs/LibOpenRaid/GetPlayerInformation.lua
+++ b/libs/LibOpenRaid/GetPlayerInformation.lua
@@ -1051,14 +1051,6 @@ do
         end
 
         function openRaidLib.AuraTracker.ScanUnitAuras(unitId)
-            --QUI patch (12.1): see getAuraDuration — the aura walk is
-            --RequiresUnitAuraAccess-guarded (hard error) under encounter/M+/
-            --PvP restrictions. Bail BEFORE touching scan state so the next
-            --unrestricted scan still diffs removals correctly.
-            if (C_Secrets and C_Secrets.ShouldAurasBeSecret and C_Secrets.ShouldAurasBeSecret()) then
-                return
-            end
-
             local maxCount = nil
             local bUsePackedAura = true
             openRaidLib.AuraTracker.CurrentUnitId = unitId
@@ -1066,7 +1058,7 @@ do
             openRaidLib.AuraTracker.AurasFoundOnScan = {}
 
             --code of 'ForEachAura' has been updated to use the latest API available
-            pcall(AuraUtil.ForEachAura, unitId, "HELPFUL", maxCount, openRaidLib.AuraTracker.ScanCallback, bUsePackedAura)
+            AuraUtil.ForEachAura(unitId, "HELPFUL", maxCount, openRaidLib.AuraTracker.ScanCallback, bUsePackedAura)
 
             local thisUnitAuras = openRaidLib.AuraTracker.CurrentAuras[unitId]
             for spellId in pairs(thisUnitAuras) do

--- a/libs/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/libs/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -58,15 +58,7 @@ local isCata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
 local isMists = WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC
 local isMidnight = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE and interfaceVersion >= 120000
 
---QUI patch (12.1): UnitCanAttack is secret-capable under restriction — probe
---before the `not` truth-test. A secret verdict counts as restricted (picks
---the conservative in-combat checker list; action policy, not a state claim).
-local InCombatLockdownRestriction = function(unit)
-  if not InCombatLockdown() then return false end
-  local canAttack = UnitCanAttack("player", unit)
-  if isMidnight and issecretvalue(canAttack) then return true end
-  return not canAttack
-end
+local InCombatLockdownRestriction = function(unit) return InCombatLockdown() and not UnitCanAttack("player", unit) end
 
 local _G = _G
 local next = next
@@ -4038,17 +4030,8 @@ local function getRangeWithCheckerList(unit, checkerList)
 end
 
 local function getRange(unit, noItems)
-  --QUI patch (12.1): UnitCanAssist/UnitIsDeadOrGhost/UnitCanAttack/UnitIsUnit
-  --are secret-capable under restriction (SecretWhen*Restricted) and their raw
-  --returns were truth-tested below, throwing out of the whole range query.
-  --Probe each verdict at its decision point (same isMidnight-gated
-  --issecretvalue idiom the cache key uses); a secret verdict is
-  --indeterminate, so return nil ("no result") and let callers fall back.
   local canAssist = UnitCanAssist("player", unit)
-  if isMidnight and issecretvalue(canAssist) then return nil end
-  local deadOrGhost = UnitIsDeadOrGhost(unit)
-  if isMidnight and issecretvalue(deadOrGhost) then return nil end
-  if deadOrGhost then
+  if UnitIsDeadOrGhost(unit) then
     if canAssist then
       return getRangeWithCheckerList(unit, InCombatLockdownRestriction(unit) and lib.resRCInCombat or lib.resRC)
     else
@@ -4057,7 +4040,6 @@ local function getRange(unit, noItems)
   end
 
   local canAttack = UnitCanAttack("player", unit)
-  if isMidnight and issecretvalue(canAttack) then return nil end
   local isPet
   if not canAttack then
     isPet = UnitIsUnit("pet", unit)


### PR DESCRIPTION
Remove redundant LibRangeCheck guards for UnitCanAssist, UnitCanAttack, and UnitIsDeadOrGhost based on the local 12.1.0.69587 API documentation. Retain the UnitIsUnit secret guard. Restore the upstream aura call only inside the disabled LibOpenRaid block; live aura protections remain intact.

Updates the tests pointer to zol-wow/QUI-tests#132, removing obsolete assertions while retaining the required probe check.

Validation: all nine local gates passed, all ten vendor runtime checks passed, and independent review found no blockers. Live client smoke testing remains outstanding.