### PR TITLE
fix(unitframes): display raid markers for secret indices

### DIFF
--- a/QUI_UnitFrames/unitframes/unitframes.lua
+++ b/QUI_UnitFrames/unitframes/unitframes.lua
@@ -1196,9 +1196,12 @@ local function UpdateTargetMarker(frame)
     end
 
     local index = GetRaidTargetIndex(QUI_UF.GetFrameUnit(frame))
-    if not IsSecretValue(index) and index then
-        SetRaidTargetIconTexture(frame.targetMarker, index)
-        frame.targetMarker:Show()
+    if IsSecretValue(index) or index then
+        if pcall(SetRaidTargetIconTexture, frame.targetMarker, index) then
+            frame.targetMarker:Show()
+        else
+            frame.targetMarker:Hide()
+        end
     else
         frame.targetMarker:Hide()
     end


### PR DESCRIPTION
Raid markers disappeared on focus and other unit frames when GetRaidTargetIndex returned a secret value. Forward those indices to the texture sink and hide the marker if the sink fails.

Includes regression coverage through QUI-tests PR #134 for six unit types, indices 1–8, secret passthrough, sink failure, nil, and disabled settings. All nine local gates pass, including 924 unit files; independent review found no blockers. Real WoW secret-value enforcement still needs live verification.