### PR TITLE
fix(actionbars): keep possession actions visible and bound

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars_editmode.lua
+++ b/QUI_ActionBars/actionbars/actionbars_editmode.lua
@@ -94,9 +94,7 @@ function OnEditModeExit()
 end
 
 function IsVehicleBarActive()
-    return (HasVehicleActionBar and HasVehicleActionBar())
-        or (HasOverrideActionBar and HasOverrideActionBar())
-        or (UnitInVehicle and UnitInVehicle("player"))
+    return SecureCmdOptionParse("[overridebar][vehicleui] hide; show") == "hide"
 end
 
 function IsPetBattleActive()

--- a/QUI_ActionBars/actionbars/actionbars_events.lua
+++ b/QUI_ActionBars/actionbars/actionbars_events.lua
@@ -281,6 +281,7 @@ function OnOwnedEvent(self, event, ...)
             ActionBarsOwned.pendingStanceUpdate = true
         end
         ApplyBar1OverrideBindings()
+        SetupOwnedBarMouseover("bar1")
 
     elseif event == "UPDATE_SHAPESHIFT_COOLDOWN" or event == "UPDATE_SHAPESHIFT_USABLE" then
         ActionBarsOwned.UpdateAllStanceButtons()

--- a/QUI_ActionBars/actionbars/actionbars_helpers.lua
+++ b/QUI_ActionBars/actionbars/actionbars_helpers.lua
@@ -784,7 +784,9 @@ function CreateBarContainer(barKey)
         end
     ]])
     local driver = "[overridebar][vehicleui][possessbar][petbattle] hide; show"
-    if barKey == "pet" then
+    if barKey == "bar1" then
+        driver = "[overridebar][vehicleui][petbattle] hide; show"
+    elseif barKey == "pet" then
         driver = "[overridebar][vehicleui][possessbar][petbattle][nopet] hide; show"
         local function notifyAnchor()
             if _G.QUI_UpdateFramesAnchoredTo then

--- a/QUI_ActionBars/actionbars/actionbars_layout.lua
+++ b/QUI_ActionBars/actionbars/actionbars_layout.lua
@@ -474,6 +474,11 @@ function SetOwnedBarAlpha(barKey, alpha)
     local container = ActionBarsOwned.containers[barKey]
     if not container then return end
 
+    GetOwnedBarFadeState(barKey).requestedAlpha = alpha
+    if barKey == "bar1" and SecureCmdOptionParse("[possessbar] show") == "show" then
+        alpha = 1
+    end
+
     local buttons = ActionBarsOwned.nativeButtons[barKey]
 
     container:SetAlpha(alpha)

--- a/QUI_CDM/cdm/hud_visibility.lua
+++ b/QUI_CDM/cdm/hud_visibility.lua
@@ -858,6 +858,9 @@ local function ApplyActionBarListAlpha(frames, alpha)
 end
 
 local function GetActionBarEntryAlpha(entry)
+    local states = ns.ActionBarsOwned and ns.ActionBarsOwned.fadeState
+    local state = states and states[entry.barKey]
+    if state and state.requestedAlpha ~= nil then return state.requestedAlpha end
     return entry.container:GetAlpha()
 end
 
@@ -867,6 +870,7 @@ local ActionBarsVisibility = CreateVisibilityController({
     applyAlpha = ApplyActionBarListAlpha,
     getAlpha = GetActionBarEntryAlpha,
     includeVehicle = true,
+    instantApply = true,
     leaveDelay = 0.3,
     update = function() UpdateActionBarsVisibility() end,
 })
@@ -1047,6 +1051,8 @@ visibilityEventFrame:RegisterEvent("PLAYER_IMPULSE_APPLIED")
 visibilityEventFrame:RegisterEvent("UNIT_ENTERED_VEHICLE")
 visibilityEventFrame:RegisterEvent("UNIT_EXITED_VEHICLE")
 visibilityEventFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR")
+visibilityEventFrame:RegisterEvent("UPDATE_POSSESS_BAR")
+visibilityEventFrame:RegisterEvent("UPDATE_VEHICLE_ACTIONBAR")
 visibilityEventFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
 visibilityEventFrame:RegisterEvent("PLAYER_FLAGS_CHANGED")
 visibilityEventFrame:RegisterEvent("PLAYER_IS_GLIDING_CHANGED")


### PR DESCRIPTION
Skinless vehicle possession could select the suppressed native main bar while QUI hid Action Bar 1 or faded it to zero, leaving vehicle abilities invisible and releasing their usual keys.

Keep owned Action Bar 1 visible and bound during possession while retaining native override, vehicle UI, and pet-battle suppression. Force its opacity during possession, preserve requested fade state so sibling bars do not flash, and refresh fades on possession changes so normal visibility returns afterward.

Validation: all nine local gates passed, including 926 unit test files and clean luacheck. Independent review found no issues. Regression tests cover secure visibility/paging and bindings, ongoing and completed fades, sibling opacity, repeated refresh, and possession exit. Actual WoW combat enforcement still needs in-game verification.

Includes the tests pointer from https://github.com/zol-wow/QUI-tests/pull/135. This PR contains one commit and is intended for squash merge into beta.
