### PR TITLE
fix: backport mainline review fixes to beta

### DIFF
--- a/QUI_ActionBars/actionbars/actionbars.lua
+++ b/QUI_ActionBars/actionbars/actionbars.lua
@@ -396,6 +396,10 @@ env.__declared.LayoutNativeButtons = true
 
 function ReclaimBarButtons(barKey)
     local btns = ActionBarsOwned.nativeButtons[barKey]
+    if barKey == "microbar" and ActionBarsOwned.pendingMicroBuild and not btns then
+        BuildBar(barKey)
+        return
+    end
     local cont = ActionBarsOwned.containers[barKey]
     if not btns or not cont then return end
     for _, btn in ipairs(btns) do

--- a/QUI_ActionBars/actionbars/actionbars_builder.lua
+++ b/QUI_ActionBars/actionbars/actionbars_builder.lua
@@ -443,6 +443,9 @@ function BuildBar(barKey)
 
         local microMenuParent = MicroMenu and MicroMenu:GetParent()
         if microMenuParent and microMenuParent ~= UIParent and microMenuParent ~= MicroMenuContainer then
+            if not ActionBarsOwned.nativeButtons.microbar then
+                ActionBarsOwned.pendingMicroBuild = true
+            end
             return
         end
         if microMenuParent == MicroMenuContainer then
@@ -745,6 +748,9 @@ function BuildBar(barKey)
     end
 
     ActionBarsOwned.nativeButtons[barKey] = buttons
+    if barKey == "microbar" then
+        ActionBarsOwned.pendingMicroBuild = nil
+    end
     if barKey ~= "pet" and barKey ~= "stance" and barKey ~= "microbar" and barKey ~= "bags" then
         FinalizeStandardOwnedActionButtons(container, barKey, buttons)
         if EnsureOwnedFlyoutFrame then

--- a/QUI_CDM/cdm/cdm_editmode_policy.lua
+++ b/QUI_CDM/cdm/cdm_editmode_policy.lua
@@ -28,11 +28,7 @@ function CDMEditModePolicy.NeedsManualSetup(systems, enums)
     return false
 end
 
-local _applied = false
-
-function CDMEditModePolicy.Enforce()
-    if _applied then return end
-    if _G.QUI_IsCDMMasterEnabled and not _G.QUI_IsCDMMasterEnabled() then return end
+local function LayoutNeedsManualSetup()
     local C_EditMode = _G.C_EditMode
     local Enum = _G.Enum
     if not (C_EditMode and C_EditMode.GetLayouts
@@ -51,13 +47,12 @@ function CDMEditModePolicy.Enforce()
     if type(presets) ~= "table" or #presets == 0 then return end
     if type(layoutInfo.activeLayout) ~= "number" then return end
     if layoutInfo.activeLayout <= #presets then
-        _applied = true
-        return
+        return false
     end
     local activeLayout = layoutInfo.layouts[layoutInfo.activeLayout - #presets]
     if not activeLayout or type(activeLayout.systems) ~= "table" then return end
 
-    local needsSetup = CDMEditModePolicy.NeedsManualSetup(activeLayout.systems, {
+    return CDMEditModePolicy.NeedsManualSetup(activeLayout.systems, {
         cooldownSystem = Enum.EditModeSystem.CooldownViewer,
         visSetting = Enum.EditModeCooldownViewerSetting.VisibleSetting,
         visAlways = Enum.CooldownViewerVisibleSetting.Always,
@@ -65,19 +60,34 @@ function CDMEditModePolicy.Enforce()
         buffIconIdx = Enum.EditModeCooldownViewerSystemIndices.BuffIcon,
         buffBarIdx = Enum.EditModeCooldownViewerSystemIndices.BuffBar,
     })
+end
+
+local _applied = false
+
+function CDMEditModePolicy.Enforce()
+    if _applied then return end
+    if _G.QUI_IsCDMMasterEnabled and not _G.QUI_IsCDMMasterEnabled() then return end
+    local C_CVar = _G.C_CVar
+    local viewerDisabled = C_CVar and C_CVar.GetCVarBool
+        and C_CVar.GetCVarBool("cooldownViewerEnabled") == false
+    local needsSetup = viewerDisabled or LayoutNeedsManualSetup()
+    if needsSetup == nil then return end
 
     _applied = true
     if not needsSetup or not (_G.StaticPopupDialogs and _G.StaticPopup_Show) then return end
     _G.StaticPopupDialogs["QUI_CDM_EDITMODE_MANUAL"] = {
-        text = "QUI detected a Blizzard Cooldown Manager layout mismatch."
+        text = (viewerDisabled and "QUI detected that Blizzard's Cooldown Manager is disabled."
+            or "QUI detected a Blizzard Cooldown Manager layout mismatch.")
             .. " QUI did not change Blizzard's Edit Mode layout.\n\n"
             .. "1. Open /qui > Module Addons, disable Cooldown Manager, and reload.\n"
-            .. "2. Open Edit Mode and set each Cooldown Manager viewer's"
+            .. "2. Open WoW Options, search for '" .. (_G.ENABLE_COOLDOWN_VIEWER or "Enable Cooldown Manager")
+            .. "', and enable it.\n"
+            .. "3. Open Edit Mode and set each Cooldown Manager viewer's"
             .. " Visibility to Always.\n"
-            .. "3. On Tracked Buffs and Tracked Bars, enable Hide When Inactive.\n"
-            .. "4. Save the layout, leave Edit Mode, re-enable Cooldown Manager,"
+            .. "4. On Tracked Buffs and Tracked Bars, enable Hide When Inactive.\n"
+            .. "5. Save the layout, leave Edit Mode, re-enable Cooldown Manager,"
             .. " and reload.\n\n"
-            .. "This notice repeats each login until the layout is correct.",
+            .. "This notice repeats each login until the native viewers are enabled and the layout is correct.",
         button1 = _G.OKAY or "Okay",
         timeout = 0,
         whileDead = 1,

--- a/QUI_DamageMeter/damage_meter/breakout.lua
+++ b/QUI_DamageMeter/damage_meter/breakout.lua
@@ -107,8 +107,14 @@ local function ReadableGUID(source)
     return guid
 end
 
-local function SameSource(left, right)
+local function SameSource(left, right, matchDeathRecap)
     if not (left and right) then return false end
+    if left == right then return true end
+    if matchDeathRecap then
+        local leftID, rightID = left.deathRecapID, right.deathRecapID
+        return not IsSecret(leftID) and not IsSecret(rightID)
+            and type(leftID) == "number" and leftID > 0 and leftID == rightID
+    end
     if left.isLocalPlayer == true and right.isLocalPlayer == true then return true end
     local leftGUID = ReadableGUID(left)
     local rightGUID = ReadableGUID(right)
@@ -125,13 +131,13 @@ local function SameTarget(left, right)
     return not IsSecret(leftID) and leftID ~= nil and leftID == rightID
 end
 
-local function FindMatchingSource(selected, sources, fallbackToFirst)
+local function FindMatchingSource(selected, sources, fallbackToFirst, matchDeathRecap)
     if not selected then return fallbackToFirst ~= false and sources and sources[1] or nil end
     for _, source in ipairs(sources or {}) do
-        if source == selected or SameSource(selected, source) then return source end
+        if SameSource(selected, source, matchDeathRecap) then return source end
     end
     local specIconID = selected.specIconID
-    if type(specIconID) ~= "number" or specIconID <= 0 then
+    if matchDeathRecap or type(specIconID) ~= "number" or specIconID <= 0 then
         return fallbackToFirst ~= false and sources and sources[1] or nil
     end
     local match
@@ -400,8 +406,9 @@ end
 
 function Breakout:_ResolveSelectedSource(view)
     local previousSource = self.source
-    self.source = FindMatchingSource(previousSource, view.sources)
-    if previousSource and not SameSource(previousSource, self.source) then
+    local matchDeathRecap = self.damageMeterType == (Enum and Enum.DamageMeterType and Enum.DamageMeterType.Deaths)
+    self.source = FindMatchingSource(previousSource, view.sources, true, matchDeathRecap)
+    if previousSource and not SameSource(previousSource, self.source, matchDeathRecap) then
         self.selectedTarget = nil
     end
     local inCombat = IsCombatDataRestricted()
@@ -416,6 +423,7 @@ function Breakout:_RefreshPlayers(view)
     local section = self.sections.players
     local rowHeight, rowGap = self:_RowMetrics()
     local count = math.min(#(view.sources or {}), #section.rows)
+    local matchDeathRecap = self.damageMeterType == (Enum and Enum.DamageMeterType and Enum.DamageMeterType.Deaths)
     if count == 0 then
         SetSectionEmpty(section)
         return
@@ -425,7 +433,7 @@ function Breakout:_RefreshPlayers(view)
         row.Icon:Show()
         self.sourceRenderer:_SetRowSource(row, view.sources[i], view.maxAmount)
         row._source = view.sources[i]
-        row.Bar:SetAlpha(SameSource(self.source, view.sources[i]) and 1 or 0.72)
+        row.Bar:SetAlpha(SameSource(self.source, view.sources[i], matchDeathRecap) and 1 or 0.72)
         row:Show()
     end
     ShowSectionRows(section, count, rowHeight, rowGap)

--- a/QUI_UnitFrames/unitframes/castbar.lua
+++ b/QUI_UnitFrames/unitframes/castbar.lua
@@ -3032,11 +3032,34 @@ function QUI_Castbar:CreateBossCastbar(unitFrame, unit, bossIndex)
     function anchorFrame:Cast(fromCastStart)
         local check = _G.C_RestrictedActions and _G.C_RestrictedActions.CheckAllowProtectedFunctions
         if check and not check(self, true) then
-            C_Timer.After(0, function()
-                if not self._quiDestroyed then self:Cast(fromCastStart) end
+            local active, readable = ReadCastActivity(self.unit)
+            if not fromCastStart and readable and not active then
+                CancelPendingCastRetry(self)
+                return
+            end
+            local pending = self._quiPendingCastRetry
+            if pending then
+                pending.fromCastStart = fromCastStart
+                return
+            end
+            pending = {fromCastStart = fromCastStart}
+            self._quiPendingCastRetry = pending
+            pending.ticker = C_Timer.NewTicker(0.05, function(ticker)
+                if self._quiPendingCastRetry ~= pending then
+                    ticker:Cancel()
+                    return
+                end
+                if self._quiDestroyed then
+                    CancelPendingCastRetry(self)
+                    return
+                end
+                if not check(self, true) then return end
+                CancelPendingCastRetry(self)
+                self:Cast(pending.fromCastStart)
             end)
             return
         end
+        CancelPendingCastRetry(self)
 
         local spellName, text, texture, startTimeMS, endTimeMS, notInterruptible, unitSpellID, isChanneled, _, durationObj, hasSecretTiming, castKnown = GetCastInfo(self, self.unit, fromCastStart)
 

--- a/core/aura_elements.lua
+++ b/core/aura_elements.lua
@@ -298,13 +298,9 @@ function E.NormalizeElement(e)
         if e.auraType == nil then e.auraType = "HELPFUL" end
         if e.dynamicLayout ~= true then e.dynamicLayout = false end
         if type(e.border) ~= "table" then e.border = { thickness = 2 } end
-        local trackedSpellIDs = {}
         if type(e.spells) == "table" then
             for i, spellID in ipairs(e.spells) do
                 e.spells[i] = E.ResolveTrackedSpellID(spellID)
-                if type(e.spells[i]) == "number" then
-                    trackedSpellIDs[e.spells[i]] = true
-                end
             end
         end
         if type(e.onlyMineSpells) == "table" then
@@ -313,16 +309,6 @@ function E.NormalizeElement(e)
                 normalizedOnlyMine[E.ResolveTrackedSpellID(spellID)] = value
             end
             e.onlyMineSpells = normalizedOnlyMine
-        end
-        if type(e.auraSounds) == "table" then
-            local normalizedAuraSounds = {}
-            for spellID, sounds in pairs(e.auraSounds) do
-                local resolvedID = E.ResolveTrackedSpellID(tonumber(spellID) or spellID)
-                if trackedSpellIDs[resolvedID] and type(sounds) == "table" then
-                    normalizedAuraSounds[resolvedID] = sounds
-                end
-            end
-            e.auraSounds = next(normalizedAuraSounds) and normalizedAuraSounds or nil
         end
     end
     if e.dispelBorderMode ~= "stealable" and e.dispelBorderMode ~= "all" then
@@ -338,6 +324,23 @@ function E.NormalizeElement(e)
     end
     if e.applyToRoles == nil then e.applyToRoles = "all" end
     return e
+end
+
+function E.NormalizeAuraSounds(e)
+    if type(e.auraSounds) ~= "table" then return nil end
+    local trackedSpellIDs = {}
+    for _, spellID in ipairs(e.spells or {}) do
+        if type(spellID) == "number" then trackedSpellIDs[spellID] = true end
+    end
+    local normalizedAuraSounds = {}
+    for spellID, sounds in pairs(e.auraSounds) do
+        local resolvedID = E.ResolveTrackedSpellID(tonumber(spellID) or spellID)
+        if trackedSpellIDs[resolvedID] and type(sounds) == "table" then
+            normalizedAuraSounds[resolvedID] = sounds
+        end
+    end
+    e.auraSounds = next(normalizedAuraSounds) and normalizedAuraSounds or nil
+    return e.auraSounds
 end
 
 local ROLE_GATE_TO_ASSIGNED = { tank = "TANK", healer = "HEALER", dps = "DAMAGER" }

--- a/modules/infobar/micromenu.lua
+++ b/modules/infobar/micromenu.lua
@@ -14,25 +14,6 @@ local C_Texture = _G.C_Texture
 
 local ATLAS_PREFIX = "UI-HUD-MicroMenu-"
 
-local function ToggleStore()
-    local kiosk = _G.Kiosk
-    if _G.DISALLOW_FRAME_TOGGLING or (kiosk and kiosk.IsEnabled()) then return end
-
-    local useCatalogShop = _G.C_CatalogShop and _G.C_CatalogShop.IsShop2Enabled()
-    local frame = useCatalogShop and _G.CatalogShopFrame or _G.StoreFrame
-    if not frame then return end
-
-    local shown = frame:GetAttribute("isshown")
-    if not shown then
-        local glue = _G.C_Glue
-        if not (glue and glue.IsOnGlueScreen()) then
-            _G.securecall("CloseAllWindows")
-        end
-        frame:SetAttribute("contextkey", "StoreMicroButton")
-    end
-    frame:SetAttribute("action", shown and "Hide" or "Show")
-end
-
 local BUTTONS = {
     {
         key = "character", label = ns.L["Character"], portrait = true,
@@ -77,10 +58,6 @@ local BUTTONS = {
             local u = _G.HousingFramesUtil
             if u and u.ToggleHousingDashboard then u.ToggleHousingDashboard() end
         end,
-    },
-    {
-        key = "shop", label = ns.L["Shop"], atlas = "Shop",
-        onClick = ToggleStore,
     },
     {
         key = "help", label = ns.L["Support"], atlas = "GameMenu",

--- a/modules/trackers/aura_display_share.lua
+++ b/modules/trackers/aura_display_share.lua
@@ -396,7 +396,12 @@ local function ValidElement(element)
     local E = ns.AuraElements
     if E and type(E.NormalizeElement) == "function" and type(E.Validate) == "function" then
         local function Probe()
-            return E.Validate(E.NormalizeElement(CopyData(element)))
+            local normalized = E.NormalizeElement(CopyData(element))
+            return E.Validate(normalized)
+                and ValidRecord(normalized.duration, TEXT_FIELD_TYPES, TEXT_FIELD_ENUMS, TEXT_FIELD_RANGES)
+                and ValidColor(normalized.duration and normalized.duration.color)
+                and ValidRecord(normalized.pandemicGlow, PANDEMIC_FIELD_TYPES)
+                and ValidColor(normalized.pandemicGlow and normalized.pandemicGlow.color)
         end
         local ok, valid
         if type(ns.SafeCall) == "function" then

--- a/modules/trackers/aura_displays.lua
+++ b/modules/trackers/aura_displays.lua
@@ -788,7 +788,7 @@ local function PlayerSpecID()
     return nil
 end
 
-function AD.PassesLoad(display)
+function AD.PassesLoad(display, ignoreEncounter)
     local load = type(display) == "table" and display.load or nil
     if type(load) ~= "table" then return true end
 
@@ -804,7 +804,7 @@ function AD.PassesLoad(display)
         local role = PlayerRoleToken()
         if not role or load.roles[role] ~= true then return false end
     end
-    if AD.HasEncounterLoadConditions(display) then
+    if not ignoreEncounter and AD.HasEncounterLoadConditions(display) then
         if not activeEncounter or load.encounters[activeEncounter] ~= true then return false end
     end
     return true
@@ -815,11 +815,11 @@ function AD.HasEncounterLoadConditions(display)
     return type(load) == "table" and not SetIsEmpty(load.encounters)
 end
 
-function AD.DisplayActive(display)
+function AD.DisplayActive(display, ignoreEncounter)
     if type(display) ~= "table" then return false end
     if display.enabled == false then return false end
     if not AD.GroupEnabled(display.group) then return false end
-    if not AD.PassesLoad(display) then return false end
+    if not AD.PassesLoad(display, ignoreEncounter) then return false end
     return AD.ResolveUnit(display) ~= nil
 end
 
@@ -860,6 +860,7 @@ function AD.DefaultBucket()
 end
 
 local hosts = {}
+local visibilityFrames = {}
 local groupHosts = {}
 local registered = {}
 local auraSoundRegistrations = {}
@@ -914,8 +915,9 @@ local function ReconcileAuraSounds(store)
                 for _, element in ipairs(elements) do
                     if element.mode == "tracked" and type(element.spells) == "table"
                         and type(element.auraSounds) == "table" then
+                        local auraSounds = E.NormalizeAuraSounds(element)
                         for _, spellID in ipairs(element.spells) do
-                            local sounds = element.auraSounds[spellID]
+                            local sounds = auraSounds and auraSounds[spellID]
                             if type(spellID) == "number" and type(sounds) == "table"
                                 and not E.EffectiveOnlyMine(element, spellID) then
                                 for eventKey, trigger in pairs(AURA_SOUND_TRIGGERS) do
@@ -1014,7 +1016,8 @@ function AD.HostFor(id)
 end
 
 function AD.GetVisibilityFrames()
-    local frames = {}
+    wipe(visibilityFrames)
+    local frames = visibilityFrames
     for _, host in pairs(hosts) do
         if host._quiAuraDisplayActive then
             frames[#frames + 1] = host
@@ -1563,23 +1566,27 @@ ApplyDisplay = function(display, allowCreate)
         local specID = H and type(H.GetCurrentSpecID) == "function" and H.GetCurrentSpecID() or nil
         activeElements = E.ActiveElementsForSpec(display.auras, specID)
     end
-    local elements = unit and activeElements or EMPTY
+    local preparedUnit = unit
+    if not preparedUnit and AD.HasEncounterLoadConditions(display) and AD.DisplayActive(display, true) then
+        preparedUnit = AD.ResolveUnit(display)
+    end
+    local elements = preparedUnit and activeElements or EMPTY
 
     local layout = BuildDisplayLayout(display, activeElements)
     host._naturalW, host._naturalH = layout.width, layout.height
     host:SetSize(layout.width, layout.height)
 
     local skipElement
-    local Slots = unit and ns.AuraSlots
+    local Slots = preparedUnit and ns.AuraSlots
     if Slots and type(Slots.LivePolarityMismatch) == "function" then
         skipElement = function(element)
             if element.mode ~= "tracked" then return false end
-            return Slots.LivePolarityMismatch(unit, element.auraType or "HELPFUL")
+            return Slots.LivePolarityMismatch(preparedUnit, element.auraType or "HELPFUL")
         end
     end
 
     AuraSurface.ApplyElementPass(host, elements, {
-        unit = unit or "player",
+        unit = preparedUnit or "player",
         allowCreate = allowCreate == true and not InCombatLockdown(),
         cancelEligible = false,
         profileFor = DisplayElementProfile,
@@ -1654,7 +1661,7 @@ local PACK_FLOW = {
 }
 
 local function PackableElement(display, specID)
-    if not E or not AD.DisplayActive(display) then return nil end
+    if not E or not AD.DisplayActive(display) or AD.HasEncounterLoadConditions(display) then return nil end
     if type(display.auras) ~= "table" then return nil end
     local elements = E.ActiveElementsForSpec(display.auras, specID)
     local found
@@ -1880,7 +1887,7 @@ function AD.ReflowGroups(displays)
 
         local groupDisplays = buckets[groupName]
         local packAllowed = group.dynamicLayout == true and not previewActive
-            and not layoutActive and not GroupPreviewRelated(groupName)
+            and not layoutActive and not PreviewBoxMode(groupName)
         local pack = (packAllowed and groupDisplays) and BuildPack(groupHost, group, groupDisplays) or nil
         if not pack and groupHost._quiPackContainer then
             ParkPackContainer(groupHost._quiPackContainer)
@@ -1900,7 +1907,7 @@ function AD.ReflowGroups(displays)
                         host._quiGroupPacked = true
                         host:Hide()
                     end
-                elseif host and (forcePreview or AD.DisplayActive(display)) then
+                elseif host and (forcePreview or AD.DisplayActive(display, true)) then
                     memberSpecs[#memberSpecs + 1] = {
                         id = display.id,
                         display = display,


### PR DESCRIPTION
Backport the mainline fixes from #921 into beta so subsequent beta builds retain the reviewed behavior.

Preserve Shop safety, deferred MicroMenu initialization, and Aura Display visibility-list reuse. Reject malformed legacy aura imports; prepare encounter groups before combat; retain individual previews; identify repeated deaths by recap ID; guide disabled cooldown viewer setup; coalesce boss retries; and normalize aura sounds during registration instead of rendering.

Advance the tests pin to the matching beta regression suite. Runtime content matches main's reviewed f6d449e9 tree; version metadata and documentation remain unchanged.

Validation: all nine local gates, isolated verification of the exact committed tree, and GitHub checks/Codex review before merge. The original regression checks were mutation-proven in #921.
