### PR TITLE
release: v5.5.0-ptr-alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.5.0-ptr-alpha2 - 2026-09-08
+
+> ⚠️ **WoW 12.1.5 PTR ONLY.** This alpha targets interface 120105 and will
+> not load on the live 12.1 client.
+
+Includes the beta catch-ups and PTR improvements since alpha1.
+
+### Added
+
+- **Aura Displays offer templates, guided creation, nested groups, share strings,
+  and compact layouts**, with improved encounter-based preparation and imports.
+- **Aura icons support optional caster labels and pandemic pulse/flash styles.**
+  Settings and bag searches use native Unicode case folding on the PTR client.
+- **Cooldown Manager buff icons have growth-direction and anchor controls**,
+  with clearer setup guidance when Blizzard's native viewers are disabled.
+- **Alt equipment supports filtering, sorting, scrolling, and item tooltips**;
+  weekly progress includes inline lockouts and compact Great Vault summaries.
+- **Quality-of-life controls include summon automation, teleport cooldowns,
+  a dedicated Notifications tab, and the native Rotate Minimap setting.**
+
+### Fixed
+
+- **Possession abilities stay visible with their usual action keys**, including
+  after fade timers expire; deferred microbar construction recovers correctly.
+- **Raid markers display when WoW restricts their indices**, and boss castbar
+  retries are consolidated and cleaned up when no longer needed.
+- **Cooldown Manager preserves unusable tint and native frame ownership**,
+  defers settings updates, and avoids writes to Blizzard's layout serializer.
+- **Aura Displays retain sound configuration and validate imported settings**;
+  weapon-oil timers recover after zoning, and grouped displays handle previews
+  and encounter load conditions more reliably.
+- **Damage Meter retains the selected death recap**, dimmed group frames keep
+  their tooltips, and the info bar no longer overlaps foreground UI. The unsafe
+  info-bar Shop shortcut has been removed; bundled libraries include API fixes.
+
 ## v5.5.0-ptr-alpha1 - 2026-09-03
 
 > ⚠️ **WoW 12.1.5 PTR ONLY.** This alpha targets PTR build 12.1.5.69594

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha1
+## Version: 5.5.0-ptr-alpha2
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Release the accumulated alpha changes as v5.5.0-ptr-alpha2 for WoW 12.1.5 PTR. Bump all 11 packaging-discovered shipped TOCs, add release notes covering changes since alpha1, and pin the updated alpha documentation. Interface remains 120105; excluded Debug/Logger addon versions are unchanged.

Validation: all nine local gates passed on the working tree and exact committed tree, release-note extraction and runtime generators passed, and independent release review found no issues. No live WoW test was performed.
