### PR TITLE
fix: restore Info Bar Shop button

### DIFF
--- a/modules/infobar/micromenu.lua
+++ b/modules/infobar/micromenu.lua
@@ -14,6 +14,25 @@ local C_Texture = _G.C_Texture
 
 local ATLAS_PREFIX = "UI-HUD-MicroMenu-"
 
+local function ToggleStore()
+    local kiosk = _G.Kiosk
+    if _G.DISALLOW_FRAME_TOGGLING or (kiosk and kiosk.IsEnabled()) then return end
+
+    local useCatalogShop = _G.C_CatalogShop and _G.C_CatalogShop.IsShop2Enabled()
+    local frame = useCatalogShop and _G.CatalogShopFrame or _G.StoreFrame
+    if not frame then return end
+
+    local shown = frame:GetAttribute("isshown")
+    if not shown then
+        local glue = _G.C_Glue
+        if not (glue and glue.IsOnGlueScreen()) then
+            _G.securecall("CloseAllWindows")
+        end
+        frame:SetAttribute("contextkey", "StoreMicroButton")
+    end
+    frame:SetAttribute("action", shown and "Hide" or "Show")
+end
+
 local BUTTONS = {
     {
         key = "character", label = ns.L["Character"], portrait = true,
@@ -58,6 +77,10 @@ local BUTTONS = {
             local u = _G.HousingFramesUtil
             if u and u.ToggleHousingDashboard then u.ToggleHousingDashboard() end
         end,
+    },
+    {
+        key = "shop", label = ns.L["Shop"], atlas = "Shop",
+        onClick = ToggleStore,
     },
     {
         key = "help", label = ns.L["Support"], atlas = "GameMenu",


### PR DESCRIPTION
Restore the custom Info Bar Shop button and its beta13 attribute-based toggle. Existing Shop preferences and combat, kiosk, and frame-toggling guards apply again. The prior removal was carried from main without reproducing a failure of this behavior.

The restored regression requires the button and exercises catalog open/close, legacy open, secure panel closing, and toggle guards (QUI-tests #143). Removing Shop fails the regression. All nine gates pass on both the working tree and isolated committed tree; graphify updated.