### PR TITLE
fix(infobar): restore the Shop button

### DIFF
--- a/modules/infobar/micromenu.lua
+++ b/modules/infobar/micromenu.lua
@@ -14,6 +14,25 @@ local C_Texture = _G.C_Texture
 
 local ATLAS_PREFIX = "UI-HUD-MicroMenu-"
 
+local function ToggleStore()
+    local kiosk = _G.Kiosk
+    if _G.DISALLOW_FRAME_TOGGLING or (kiosk and kiosk.IsEnabled()) then return end
+
+    local useCatalogShop = _G.C_CatalogShop and _G.C_CatalogShop.IsShop2Enabled()
+    local frame = useCatalogShop and _G.CatalogShopFrame or _G.StoreFrame
+    if not frame then return end
+
+    local shown = frame:GetAttribute("isshown")
+    if not shown then
+        local glue = _G.C_Glue
+        if not (glue and glue.IsOnGlueScreen()) then
+            _G.securecall("CloseAllWindows")
+        end
+        frame:SetAttribute("contextkey", "StoreMicroButton")
+    end
+    frame:SetAttribute("action", shown and "Hide" or "Show")
+end
+
 local BUTTONS = {
     {
         key = "character", label = ns.L["Character"], portrait = true,
@@ -58,6 +77,10 @@ local BUTTONS = {
             local u = _G.HousingFramesUtil
             if u and u.ToggleHousingDashboard then u.ToggleHousingDashboard() end
         end,
+    },
+    {
+        key = "shop", label = ns.L["Shop"], atlas = "Shop",
+        onClick = ToggleStore,
     },
     {
         key = "help", label = ns.L["Support"], atlas = "GameMenu",


### PR DESCRIPTION
Restore the custom Info Bar Shop button removed during mainline integration. The button uses its original guarded attribute-based toggle to open and close both catalog and legacy shops, retaining the StoreMicroButton context and kiosk/frame-toggle guards.

Regression coverage now requires the Shop entry and exercises both shop variants. The supporting tests change landed in https://github.com/zol-wow/QUI-tests/pull/144.

Validation: all nine gates passed on the working tree and an isolated committed checkout; removing the Shop entry makes the regression fail. Graphify updated.
