### PR TITLE
fix(infobar): restore the Shop button on alpha

### DIFF
--- a/modules/infobar/micromenu.lua
+++ b/modules/infobar/micromenu.lua
@@ -14,6 +14,25 @@ local C_Texture = _G.C_Texture
 
 local ATLAS_PREFIX = "UI-HUD-MicroMenu-"
 
+local function ToggleStore()
+    local kiosk = _G.Kiosk
+    if _G.DISALLOW_FRAME_TOGGLING or (kiosk and kiosk.IsEnabled()) then return end
+
+    local useCatalogShop = _G.C_CatalogShop and _G.C_CatalogShop.IsShop2Enabled()
+    local frame = useCatalogShop and _G.CatalogShopFrame or _G.StoreFrame
+    if not frame then return end
+
+    local shown = frame:GetAttribute("isshown")
+    if not shown then
+        local glue = _G.C_Glue
+        if not (glue and glue.IsOnGlueScreen()) then
+            _G.securecall("CloseAllWindows")
+        end
+        frame:SetAttribute("contextkey", "StoreMicroButton")
+    end
+    frame:SetAttribute("action", shown and "Hide" or "Show")
+end
+
 local BUTTONS = {
     {
         key = "character", label = ns.L["Character"], portrait = true,
@@ -58,6 +77,10 @@ local BUTTONS = {
             local u = _G.HousingFramesUtil
             if u and u.ToggleHousingDashboard then u.ToggleHousingDashboard() end
         end,
+    },
+    {
+        key = "shop", label = ns.L["Shop"], atlas = "Shop",
+        onClick = ToggleStore,
     },
     {
         key = "help", label = ns.L["Support"], atlas = "GameMenu",


### PR DESCRIPTION
Restore the custom Info Bar Shop button on alpha using the beta13 attribute-based toggle. Clicking it opens or hides the catalog or legacy store, retaining the combat guard, kiosk restriction, frame-toggle restriction, and StoreMicroButton context.

Pin QUI-tests alpha PR #145, which restores behavioral coverage and requires the Shop button to exist. No version, release, documentation, or PTR compatibility changes.

Validation: all nine `bash tools/test.sh` gates passed on the working tree and isolated committed tree; removing only the Shop entry fails the mandatory-button regression assertion. The runtime file matches beta13 commit `e609cd4a` byte for byte. Graphify updated.
