### PR TITLE
release: v5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.3 - 2026-09-08
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+QUI 5.3 brings the 5.3 beta improvements to the stable release: expanded Aura
+Displays, a richer Damage Meter workspace, combat alerts, and UI refinements.
+
+### Added
+
+- **Aura Displays support guided setup, templates, nested groups, share strings,
+  draggable previews, gap collapsing, and Blizzard-native sound alerts.**
+- **Damage Meter rows open a resizable five-pane detail workspace**, with richer
+  historical-session controls and target-to-spell drilldowns.
+- **Combat alerts include killing-blow details for Group Death Alert and
+  per-entry sound and text-to-speech alerts for Cooldown Manager.**
+- **Auto Accept Summons has Always and Out of Combat modes**, while dungeon
+  teleports show cooldowns in the Mythic+ window, world map, and Info Bar.
+- **Cooldown Manager buff icons have growth and anchor controls**, and minimap
+  settings include Blizzard's native Rotate Minimap toggle.
+
+### Improved
+
+- **Settings and Blizzard-window skins have more consistent styling**, including
+  the Character window, Social, talents, and Crafting Orders.
+- **Alt equipment supports filtering, sorting, dedicated tooltips, and a guild
+  column**, while weekly progress shows lockouts and compact Great Vault summaries.
+- **Incoming Casts can collapse readable hidden icons**, and Battle Res Counter
+  can hide when charge information is unavailable.
+
+### Fixed
+
+- **Cooldown Manager preserves native layouts, buff anchors, visibility, and
+  unusable-spell tint** across loading, combat, and cooldown transitions.
+- **Action bars preserve secure button state and possession key bindings**,
+  recover cooldown animations after fades, and refresh layouts after minimap changes.
+- **Unit-frame castbars defer restricted layout changes**, raid markers handle
+  restricted indices, and dimmed group frames retain tooltips.
+- **Damage Meter retains spell names and healing rows during combat.**
+- **Bank money dialogs and guild-bank transfers work reliably**, including the
+  combined All view and reopening the bank.
+- **QUI Chat preserves literal messages, other addons retain their `/pull`
+  commands, and weapon-oil timers refresh after zone changes.**
+- **The Info Bar Shop button is restored.**
+
 ## v5.3-beta13 - 2026-09-08
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3-beta13
+## Version: 5.3
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Publish the existing mainline as stable v5.3 for WoW 12.1. All 11 dynamically discovered shipped TOCs now declare 5.3, CHANGELOG contains the cumulative stable release notes, and the docs pin references the merged and deployed stable documentation update.

Validation: all nine tools/test.sh gates passed on the working tree and an isolated checkout of this commit. Release caches match regeneration, the production extractor returns only the v5.3 notes, and independent metadata review found no issues. Debug/Logger and library versions remain independent.
