### PR TITLE
fix(cdm): poll next-cast spell for rotation helper

### DIFF
--- a/modules/combat/rotationassist.lua
+++ b/modules/combat/rotationassist.lua
@@ -496,6 +496,27 @@ if AssistedCombatManager and AssistedCombatManager.UpdateAllAssistedHighlightFra
     end)
 end
 
+local POLL_KEY = "QUI_RotationAssistIcon"
+
+-- The EventRegistry/hooksecurefunc paths above only fire while Blizzard's
+-- own highlight poll is running (assistedCombatHighlight CVar on). The shared
+-- poller in keybinds.lua keeps the icon moving regardless.
+local function SyncNextCastPoll()
+    local poll = QUI.AssistedCombatNext
+    if not poll then return end
+    local db = GetDB()
+    if db and db.enabled then
+        poll.Subscribe(POLL_KEY, function(spellID)
+            local cur = GetDB()
+            if not cur or not cur.enabled then return end
+            -- nil means "no suggestion"; DoUpdate re-queries and clears
+            DoUpdate(spellID)
+        end)
+    else
+        poll.Unsubscribe(POLL_KEY)
+    end
+end
+
 local function InitOrCatchUp()
     C_Timer.After(0.5, function()
         if not isInitialized then
@@ -508,6 +529,7 @@ local function InitOrCatchUp()
             RefreshIconFrame()
             DoUpdate()
         end
+        SyncNextCastPoll()
     end)
 end
 
@@ -564,6 +586,7 @@ end
 
 local function RefreshRotationAssistIcon()
     RefreshIconFrame()
+    SyncNextCastPoll()
 end
 
 _G.QUI_RefreshRotationAssistIcon = RefreshRotationAssistIcon

--- a/modules/combat/rotationassist.lua
+++ b/modules/combat/rotationassist.lua
@@ -31,7 +31,8 @@ local COLOR_OUT_OF_RANGE = { 0.8, 0.2, 0.2 }
 
 local iconFrame = nil
 local isInitialized = false
-local lastSpellID = nil
+local lastSpellID = nil      -- last query result (reset to force a repaint)
+local displayedSpellID = nil -- what is actually painted on the icon
 local inCombat = false
 
 local GCD_SPELL_ID = 61304
@@ -210,11 +211,13 @@ UpdateIconDisplay = function(spellID)
     local db = GetDB()
     if not db or not db.enabled then
         iconFrame:Hide()
+        displayedSpellID = nil
         return
     end
 
     local isEmpty = (spellID == nil) or
         (not IsSecretValue(spellID) and spellID == 0)
+    displayedSpellID = (not isEmpty) and spellID or nil
     if isEmpty then
         -- No suggestion. Never leave the previous spell on screen: mirror
         -- Blizzard's single button, which falls back to the Assisted Combat
@@ -371,7 +374,11 @@ local function DoUpdate(overrideSpellID)
         end
     end
 
-    if spellID ~= lastSpellID then
+    -- Repaint when the query answer changed, or when what is painted no
+    -- longer matches it (e.g. target change reset the cache and the next
+    -- answer is "nothing": the old spell must not stay on screen).
+    local displayedChanged = IsSecretValue(displayedSpellID) or spellID ~= displayedSpellID
+    if spellID ~= lastSpellID or displayedChanged then
         lastSpellID = spellID
         UpdateIconDisplay(spellID)
     end
@@ -380,8 +387,8 @@ end
 -- Explicit "no suggestion" from the poller: do not re-query (the API may
 -- still answer with a stale spell after Assisted Combat went away).
 local function ClearIconDisplay()
-    if lastSpellID == nil then return end
     lastSpellID = nil
+    if displayedSpellID == nil then return end
     UpdateIconDisplay(nil)
 end
 

--- a/modules/combat/rotationassist.lua
+++ b/modules/combat/rotationassist.lua
@@ -216,8 +216,23 @@ UpdateIconDisplay = function(spellID)
     local isEmpty = (spellID == nil) or
         (not IsSecretValue(spellID) and spellID == 0)
     if isEmpty then
-        if not iconFrame:IsShown() then
-            UpdateVisibility()
+        -- No suggestion. Never leave the previous spell on screen: mirror
+        -- Blizzard's single button, which falls back to the Assisted Combat
+        -- action icon, dimmed, with no keybind.
+        UpdateVisibility()
+        local fallback = nil
+        if C_AssistedCombat and C_AssistedCombat.GetActionSpell then
+            local okAct, actionSpellID = ns.SafeCall("best-effort-style", C_AssistedCombat.GetActionSpell)
+            if okAct and actionSpellID and not IsSecretValue(actionSpellID) and actionSpellID ~= 0 then
+                local okTex, tex = ns.SafeCall("best-effort-style", C_Spell.GetSpellTexture, actionSpellID)
+                if okTex then fallback = tex end
+            end
+        end
+        iconFrame.icon:SetTexture(fallback)
+        iconFrame.icon:SetVertexColor(COLOR_UNUSABLE[1], COLOR_UNUSABLE[2], COLOR_UNUSABLE[3], 1)
+        iconFrame.keybindText:SetText("")
+        if iconFrame.cooldown then
+            iconFrame.cooldown:Clear()
         end
         return
     end
@@ -360,6 +375,14 @@ local function DoUpdate(overrideSpellID)
         lastSpellID = spellID
         UpdateIconDisplay(spellID)
     end
+end
+
+-- Explicit "no suggestion" from the poller: do not re-query (the API may
+-- still answer with a stale spell after Assisted Combat went away).
+local function ClearIconDisplay()
+    if lastSpellID == nil then return end
+    lastSpellID = nil
+    UpdateIconDisplay(nil)
 end
 
 RefreshIconFrame = function()
@@ -509,7 +532,10 @@ local function SyncNextCastPoll()
         poll.Subscribe(POLL_KEY, function(spellID)
             local cur = GetDB()
             if not cur or not cur.enabled then return end
-            -- nil means "no suggestion"; DoUpdate re-queries and clears
+            if spellID == nil then
+                ClearIconDisplay()
+                return
+            end
             DoUpdate(spellID)
         end)
     else

--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -2027,7 +2027,15 @@ do
         if not key or type(fn) ~= "function" then return end
         if not subscribers[key] then subscriberCount = subscriberCount + 1 end
         subscribers[key] = fn
+        local clearedBefore = lastDispatchWasClear
         Start()
+        -- Consumers typically query the API themselves right before
+        -- subscribing and may have painted a stale suggestion. If Assisted
+        -- Combat is unavailable, tell this consumer directly: the shared
+        -- latch only covers subscribers that were present at the last clear.
+        if not available and clearedBefore then
+            QUI.SafeCall("bulkhead", fn, nil)
+        end
     end
 
     function AssistedCombatNext.Unsubscribe(key)

--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -1852,6 +1852,16 @@ local function UpdateAllRotationHelpers(overrideSpellID, baseSpellID)
     UpdateViewerRotationHelper("utility", nextSpellID, nextBaseSpellID)
 end
 
+-- Explicit "no suggestion": drop the cached spell and hide every overlay
+-- without asking GetNextCastSpell again (it may still answer with a stale
+-- spell after Assisted Combat went away).
+local function ClearAllRotationHelpers()
+    currentRotationSpellID = nil
+    currentRotationBaseSpellID = nil
+    UpdateViewerRotationHelper("essential", nil)
+    UpdateViewerRotationHelper("utility", nil)
+end
+
 local function ShouldRunRotationHelper()
     local core = GetCore()
     if not core or not core.db or not core.db.profile then return false end
@@ -2068,8 +2078,12 @@ local ROTATION_HELPER_POLL_KEY = "QUI_CDMRotationHelper"
 
 SyncRotationHelperPoll = function()
     if rotationHelperEnabled then
-        AssistedCombatNext.Subscribe(ROTATION_HELPER_POLL_KEY, function()
+        AssistedCombatNext.Subscribe(ROTATION_HELPER_POLL_KEY, function(spellID)
             if not rotationHelperEnabled then return end
+            if spellID == nil then
+                ClearAllRotationHelpers()
+                return
+            end
             UpdateAllRotationHelpers()
         end)
     else

--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -1920,6 +1920,10 @@ do
     local tickerRate = nil
     local lastRaw = nil
     local lastWasSecret = false
+    -- nil is a valid "no suggestion" answer, so "nothing delivered yet" needs
+    -- its own flag; otherwise the first tick after Reset() could be swallowed.
+    local delivered = false
+    local lastDispatchWasClear = false
     local available = nil
 
     local function PollRate()
@@ -1956,17 +1960,33 @@ do
         if not ok then return end
         if Helpers.IsSecretValue(sid) then
             -- can't compare secrets; notify once on the transition into secrecy
-            if not lastWasSecret then
+            if not lastWasSecret or not delivered then
                 lastWasSecret = true
                 lastRaw = nil
+                delivered = true
+                lastDispatchWasClear = false
                 Dispatch(sid)
             end
             return
         end
         lastWasSecret = false
-        if sid == lastRaw then return end
+        if delivered and sid == lastRaw then return end
         lastRaw = sid
+        delivered = true
+        lastDispatchWasClear = false
         Dispatch(sid)
+    end
+
+    -- Assisted Combat went away (spec without it, API missing): tell consumers
+    -- to drop whatever they last showed, once.
+    local function ClearConsumers()
+        if subscriberCount == 0 then return end
+        if lastDispatchWasClear then return end
+        lastRaw = nil
+        lastWasSecret = false
+        delivered = true
+        lastDispatchWasClear = true
+        Dispatch(nil)
     end
 
     local function Stop()
@@ -1980,7 +2000,11 @@ do
     local function Start()
         if subscriberCount == 0 then Stop() return end
         if available == nil then RefreshAvailability() end
-        if not available then Stop() return end
+        if not available then
+            Stop()
+            ClearConsumers()
+            return
+        end
         if not (C_Timer and C_Timer.NewTicker) then return end
         local rate = PollRate()
         if ticker and tickerRate == rate then return end
@@ -2007,6 +2031,7 @@ do
     function AssistedCombatNext.Reset()
         lastRaw = nil
         lastWasSecret = false
+        delivered = false
         RefreshAvailability()
         Start()
     end

--- a/modules/utility/keybinds.lua
+++ b/modules/utility/keybinds.lua
@@ -1865,6 +1865,8 @@ local function ShouldRunRotationHelper()
     return (essential and essential.showRotationHelper) or (utility and utility.showRotationHelper)
 end
 
+local SyncRotationHelperPoll
+
 local function RefreshRotationHelper()
     rotationHelperEnabled = ShouldRunRotationHelper()
 
@@ -1874,6 +1876,7 @@ local function RefreshRotationHelper()
     else
         UpdateAllRotationHelpers()
     end
+    if SyncRotationHelperPoll then SyncRotationHelperPoll() end
 end
 
 local rotationHelperInitFrame = CreateFrame("Frame")
@@ -1899,6 +1902,153 @@ QUI._onIconAssigned = function(icon)
     local settings = core.db.profile.viewers[VIEWER_DB_KEY[vType] or vType]
     if settings then
         ApplyRotationHelperToIcon(icon, settings, currentRotationSpellID, currentRotationBaseSpellID)
+    end
+end
+
+-- Shared next-cast poller.
+-- Blizzard only calls UpdateAllAssistedHighlightFramesForSpell from its own
+-- OnUpdate poll, and that poll only runs while the "assistedCombatHighlight"
+-- CVar is on. OnSetActionSpell fires on spec/loadout changes, not per
+-- suggestion. So consumers that hang off those hooks freeze when the CVar is
+-- off. This ticker gives them a heartbeat of their own, at Blizzard's own
+-- update rate, and only notifies when the suggested spell changes.
+local AssistedCombatNext = {}
+do
+    local subscribers = {}
+    local subscriberCount = 0
+    local ticker = nil
+    local tickerRate = nil
+    local lastRaw = nil
+    local lastWasSecret = false
+    local available = nil
+
+    local function PollRate()
+        local manager = _G.AssistedCombatManager
+        local rate = manager and manager.GetUpdateRate and manager:GetUpdateRate()
+        if type(rate) ~= "number" or rate <= 0 then rate = 0.2 end
+        if rate < 0.1 then rate = 0.1 end
+        return rate
+    end
+
+    local function RefreshAvailability()
+        if not (C_AssistedCombat and C_AssistedCombat.GetNextCastSpell) then
+            available = false
+            return
+        end
+        if not C_AssistedCombat.IsAvailable then
+            available = true
+            return
+        end
+        local ok, isAvailable = QUI.SafeCall("best-effort-style", C_AssistedCombat.IsAvailable)
+        available = ok and (isAvailable == true)
+    end
+
+    local function Dispatch(spellID)
+        for _, fn in pairs(subscribers) do
+            -- keep polling even if one consumer misbehaves
+            QUI.SafeCall("bulkhead", fn, spellID)
+        end
+    end
+
+    local function Tick()
+        if subscriberCount == 0 then return end
+        local ok, sid = QUI.SafeCall("best-effort-style", C_AssistedCombat.GetNextCastSpell, false)
+        if not ok then return end
+        if Helpers.IsSecretValue(sid) then
+            -- can't compare secrets; notify once on the transition into secrecy
+            if not lastWasSecret then
+                lastWasSecret = true
+                lastRaw = nil
+                Dispatch(sid)
+            end
+            return
+        end
+        lastWasSecret = false
+        if sid == lastRaw then return end
+        lastRaw = sid
+        Dispatch(sid)
+    end
+
+    local function Stop()
+        if ticker then
+            ticker:Cancel()
+            ticker = nil
+            tickerRate = nil
+        end
+    end
+
+    local function Start()
+        if subscriberCount == 0 then Stop() return end
+        if available == nil then RefreshAvailability() end
+        if not available then Stop() return end
+        if not (C_Timer and C_Timer.NewTicker) then return end
+        local rate = PollRate()
+        if ticker and tickerRate == rate then return end
+        Stop()
+        tickerRate = rate
+        ticker = C_Timer.NewTicker(rate, Tick)
+    end
+
+    function AssistedCombatNext.Subscribe(key, fn)
+        if not key or type(fn) ~= "function" then return end
+        if not subscribers[key] then subscriberCount = subscriberCount + 1 end
+        subscribers[key] = fn
+        Start()
+    end
+
+    function AssistedCombatNext.Unsubscribe(key)
+        if not key or not subscribers[key] then return end
+        subscribers[key] = nil
+        subscriberCount = subscriberCount - 1
+        if subscriberCount == 0 then Stop() end
+    end
+
+    -- Re-evaluate availability/rate and force the next tick to notify.
+    function AssistedCombatNext.Reset()
+        lastRaw = nil
+        lastWasSecret = false
+        RefreshAvailability()
+        Start()
+    end
+
+    function AssistedCombatNext.IsPolling()
+        return ticker ~= nil
+    end
+
+    function AssistedCombatNext.GetLast()
+        return lastRaw
+    end
+
+    -- Test seam: drive a tick without a timer.
+    AssistedCombatNext._Tick = Tick
+
+    local resetFrame = CreateFrame("Frame")
+    resetFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+    resetFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+    resetFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
+    resetFrame:RegisterEvent("CVAR_UPDATE")
+    resetFrame:SetScript("OnEvent", function(_, event, cvarName)
+        if event == "CVAR_UPDATE" then
+            if cvarName ~= "assistedCombatIconUpdateRate" then return end
+            Stop()
+            Start()
+            return
+        end
+        AssistedCombatNext.Reset()
+    end)
+end
+QUI.AssistedCombatNext = AssistedCombatNext
+
+local ROTATION_HELPER_POLL_KEY = "QUI_CDMRotationHelper"
+
+SyncRotationHelperPoll = function()
+    if rotationHelperEnabled then
+        AssistedCombatNext.Subscribe(ROTATION_HELPER_POLL_KEY, function()
+            if not rotationHelperEnabled then return end
+            UpdateAllRotationHelpers()
+        end)
+    else
+        AssistedCombatNext.Unsubscribe(ROTATION_HELPER_POLL_KEY)
     end
 end
 


### PR DESCRIPTION
## Summary
- The CDM rotation helper overlay and the standalone Rotation Assist icon only learned about next-cast changes via hooks on Blizzard's `AssistedCombatManager`. Those fire from Blizzard's own OnUpdate poll, which runs only while the `assistedCombatHighlight` CVar is on. With the CVar off, both froze on the login-time suggestion while the single-button assistant icon (which polls independently) kept cycling.
- The only live callers also lived in `QUI_ActionBars/actionbars_public.lua`, so the overlay had no trigger of its own.
- New shared poller `QUI.AssistedCombatNext` in `modules/utility/keybinds.lua`: tickers at `AssistedCombatManager:GetUpdateRate()`, re-queries `C_AssistedCombat.GetNextCastSpell`, notifies only on change, never compares secret values, stops with no subscribers or when Assisted Combat is unavailable, resets on zone-in/spec/trait events.
- CDM overlay subscribes while `showRotationHelper` is on; `rotationassist.lua` subscribes the standalone icon while enabled. Existing hook paths stay in place.

## Test plan
- [x] New `tests/unit/assisted_combat_next_poller_test.lua` (companion QUI-tests PR, same branch)
- [x] keybind tests, rotationassist-loading tests, pcall ratchet, luacheck, taint analyzer on both modules: clean
- [x] Full `tests/unit` under LuaJIT: only the seven known baseline failures
- [x] In-game on training dummies with the Blizzard highlight option off