### PR TITLE
fix(unitframes): preserve arena target class colors

### DIFF
--- a/QUI_UnitFrames/unitframes/unitframes.lua
+++ b/QUI_UnitFrames/unitframes/unitframes.lua
@@ -599,10 +599,8 @@ local function GetHealthBarColor(unit, settings)
 
     if useClassColor and UnitIsPlayer(unit) then
         local _, class = UnitClass(unit)
-        -- @secret-policy: collapse-only — fall through to hostility/default color
-        if issecretvalue and issecretvalue(class) then class = nil end
         if type(class) == "string" then
-            local color = RAID_CLASS_COLORS[class]
+            local color = C_ClassColor.GetClassColor(class)
             if color then
                 return color.r, color.g, color.b, 1
             end


### PR DESCRIPTION
Arena targets can fall back to red hostility coloring when their player class token is restricted. Resolve player class colors through `C_ClassColor.GetClassColor` and forward its RGB values to the health bar, preserving existing settings and fallback priorities.

Pins behavioral regression coverage from https://github.com/zol-wow/QUI-tests/pull/159. The test passes this fix and fails the original resolver at the restricted-player color assertion.

Validation: `bash tools/test.sh` — all nine gates passed, including lint. Independent local review found no actionable issues. Live arena behavior still needs in-game verification.
