### PR TITLE
fix(chat): preserve native combat whisper routing

### DIFF
--- a/QUI_Chat/chat/blizzard_suppress.lua
+++ b/QUI_Chat/chat/blizzard_suppress.lua
@@ -25,6 +25,12 @@ local NEUTER_ALLOWED = {
     UPDATE_CHAT_COLOR = true,
 }
 
+local PRIMARY_ALLOWED = {
+    CHAT_MSG_WHISPER = true,
+    CHAT_MSG_BN_WHISPER = true,
+    CAUTIONARY_CHAT_MESSAGE = true,
+}
+
 local neutered = {}
 local registerHooked = {}
 local inOwnRegister = false
@@ -41,7 +47,7 @@ end
 
 local function IsNeuterAllowed(frame, event)
     if NEUTER_ALLOWED[event] then return true end
-    return event == "CAUTIONARY_CHAT_MESSAGE" and frame == _G.ChatFrame1
+    return frame == _G.ChatFrame1 and PRIMARY_ALLOWED[event] == true
 end
 
 local function HookRegisterEvent(frame)
@@ -77,9 +83,12 @@ local function NeuterOne(frame)
         ns.SafeCallMethod("best-effort-style", frame, "RegisterEvent", event)
     end
     local valid = _G.C_EventUtils and _G.C_EventUtils.IsEventValid
-    if frame == _G.ChatFrame1
-        and (not valid or valid("CAUTIONARY_CHAT_MESSAGE")) then
-        ns.SafeCallMethod("best-effort-style", frame, "RegisterEvent", "CAUTIONARY_CHAT_MESSAGE")
+    if frame == _G.ChatFrame1 then
+        for event in pairs(PRIMARY_ALLOWED) do
+            if not valid or valid(event) then
+                ns.SafeCallMethod("best-effort-style", frame, "RegisterEvent", event)
+            end
+        end
     end
     inOwnRegister = false
     HookRegisterEvent(frame)
@@ -150,6 +159,74 @@ function Suppress.IsActive()
     return lastActive == true
 end
 
+local savedWhisperMode
+local changingWhisperMode = false
+local pendingWhisperMode
+local whisperModeWatcher
+
+function Suppress.GetWhisperMode()
+    return savedWhisperMode or (_G.GetCVar and _G.GetCVar("whisperMode"))
+end
+
+local function SetNativeWhisperMode(mode)
+    local setCVar = _G.C_CVar and _G.C_CVar.SetCVar or _G.SetCVar
+    if not setCVar then return end
+    pendingWhisperMode = mode
+    changingWhisperMode = true
+    setCVar("whisperMode", mode)
+    changingWhisperMode = false
+end
+
+local function RestoreWhisperMode()
+    if not savedWhisperMode then return end
+    local mode = savedWhisperMode
+    savedWhisperMode = nil
+    SetNativeWhisperMode(mode)
+end
+
+local function SyncWhisperMode()
+    if not _G.GetCVar then return end
+    local mode = _G.GetCVar("whisperMode")
+    if mode == "popout" then
+        savedWhisperMode = mode
+        SetNativeWhisperMode("popout_and_inline")
+    elseif mode ~= "popout_and_inline" then
+        savedWhisperMode = nil
+    end
+    if not whisperModeWatcher then
+        whisperModeWatcher = CreateFrame("Frame")
+        whisperModeWatcher:RegisterEvent("CVAR_UPDATE")
+        whisperModeWatcher:RegisterEvent("PLAYER_LOGOUT")
+        whisperModeWatcher:SetScript("OnEvent", function(_, event, name, value)
+            if event == "CVAR_UPDATE" and name == "whisperMode"
+                and pendingWhisperMode == (value or _G.GetCVar("whisperMode")) then
+                pendingWhisperMode = nil
+                return
+            end
+            if changingWhisperMode then return end
+            if event == "PLAYER_LOGOUT" then
+                RestoreWhisperMode()
+            elseif lastActive == true and name == "whisperMode" then
+                if value and value ~= _G.GetCVar("whisperMode") then return end
+                savedWhisperMode = nil
+                SyncWhisperMode()
+            end
+        end)
+        local function OnSetCVar(name, value)
+            if changingWhisperMode or lastActive ~= true or name ~= "whisperMode" then return end
+            savedWhisperMode = value == "popout" and value or nil
+            SyncWhisperMode()
+        end
+        if _G.hooksecurefunc then
+            if _G.C_CVar and _G.C_CVar.SetCVar then
+                _G.hooksecurefunc(_G.C_CVar, "SetCVar", OnSetCVar)
+            elseif _G.SetCVar then
+                _G.hooksecurefunc("SetCVar", OnSetCVar)
+            end
+        end
+    end
+end
+
 local pendingParents = setmetatable({}, { __mode = "k" })
 local regenFlushFrame
 local graceApply = false
@@ -175,8 +252,12 @@ SafeSetParent = function(region, parent)
     if not (region and region.SetParent and parent) then return end
     if not graceApply
         and type(_G.InCombatLockdown) == "function" and _G.InCombatLockdown() then
-        QueueParentForRegen(region, parent)
-        return
+        local protected = region.IsProtected and region:IsProtected()
+        local restricted = region.IsAnchoringRestricted and region:IsAnchoringRestricted()
+        if IsSecret(protected) or IsSecret(restricted) or protected or restricted then
+            QueueParentForRegen(region, parent)
+            return
+        end
     end
     inOwnSetParent = true
     ns.SafeCallMethod("best-effort-style", region, "SetParent", parent)
@@ -294,6 +375,9 @@ local function SuppressOne(name)
     end
     SuppressRegion(_G[name .. "Tab"], function() return hiddenAnchor end)
     SuppressRegion(_G[name .. "ButtonFrame"], function() return hiddenAnchor end)
+    SuppressRegion(_G[name .. "EditBox"], function() return _G.UIParent end)
+    local EB = ns.QUI.Chat.EditBoxBasics
+    if EB and EB.StyleEditBox and f then EB.StyleEditBox(f) end
 end
 
 local function NeuterChatFrameManager()
@@ -403,6 +487,7 @@ local function SuppressAll()
         hiddenAnchor:Hide()
     end
 
+    SyncWhisperMode()
     EachChatFrameName(SuppressOne)
     StripCombatLogChatMessages()
     EnsureChannelRefreshWatcher()
@@ -411,8 +496,6 @@ local function SuppressAll()
 
     SuppressRegion(_G.GeneralDockManager, function() return hiddenAnchor end)
     NeutralizeDockUpdateScripts()
-
-    SuppressRegion(_G.ChatFrame1EditBox, function() return _G.UIParent end)
 
     NeuterChatFrameManager()
     SwapTempWindowFn()
@@ -433,12 +516,17 @@ local function SuppressAll()
 end
 
 local function RestoreAll()
+    RestoreWhisperMode()
     RestoreChatFrameManager()
     RestoreTempWindowFn()
     local CL = ns.QUI.Chat.CombatLogTab
     if CL and CL.Deactivate then CL.Deactivate(1) end
     for region, parent in pairs(savedParents) do
         SafeSetParent(region, parent)
+    end
+    local EB = ns.QUI.Chat.EditBoxBasics
+    if EB and EB.RemoveEditBoxStyle then
+        EachChatFrameName(function(name) EB.RemoveEditBoxStyle(_G[name]) end)
     end
     savedParents = {}
     local toRestore = {}
@@ -458,6 +546,7 @@ local function ApplyNow()
     else
         RestoreAll()
     end
+    if ns.RefreshSoundMute then ns.RefreshSoundMute() end
 end
 
 function Suppress.Apply()

--- a/QUI_Chat/chat/conversation_manager.lua
+++ b/QUI_Chat/chat/conversation_manager.lua
@@ -46,6 +46,8 @@ local function WhisperSettings()
 end
 
 local function GetWhisperMode()
+    local Suppress = ns.QUI.Chat.BlizzardSuppress
+    if Suppress and Suppress.GetWhisperMode then return Suppress.GetWhisperMode() end
     if type(_G.GetCVar) ~= "function" then return nil end
     local ok, value = pcall(_G.GetCVar, "whisperMode")
     if ok then return value end
@@ -88,7 +90,8 @@ local function RefreshAfterChange()
 end
 
 function Conv.Open(chatType, target, windowID, activate)
-    local key = Conv.DeriveKey(chatType, target)
+    local shared = IsSecret(target)
+    local key = shared and "WHISPERS" or Conv.DeriveKey(chatType, target)
     if not key then return nil end
     local existing = conversations[key]
     if existing then
@@ -101,14 +104,15 @@ function Conv.Open(chatType, target, windowID, activate)
         return key
     end
     windowID = ClampWindowID(windowID)
-    local name = target
-    if chatType == "WHISPER" and _G.Ambiguate then
+    local name = shared and (_G.WHISPERS or "Whispers") or target
+    if not shared and chatType == "WHISPER" and _G.Ambiguate then
         name = _G.Ambiguate(target, "short")
     end
     conversations[key] = {
         key      = key,
         chatType = chatType,
-        target   = target,
+        target   = not shared and target or nil,
+        shared   = shared or nil,
         name     = name,
         windowID = windowID,
     }
@@ -127,12 +131,12 @@ end
 
 function Conv.Close(key)
     if not conversations[key] then return end
+    if key == Conv.GetPreTargetedKey() then
+        Conv.ClearPreTarget()
+    end
     conversations[key] = nil
     for i = #order, 1, -1 do
         if order[i] == key then table.remove(order, i) end
-    end
-    if key == Conv.GetPreTargetedKey() then
-        Conv.ClearPreTarget()
     end
     RefreshAfterChange()
 end
@@ -151,7 +155,12 @@ local preTargetedKey
 
 function Conv.PreTargetEditBox(key)
     local c = conversations[key]
-    local eb = _G.ChatFrame1EditBox
+    if c and c.shared then
+        Conv.ClearPreTarget()
+        return
+    end
+    local util = _G.ChatFrameUtil
+    local eb = util and util.ChooseBoxForSend and util.ChooseBoxForSend() or _G.ChatFrame1EditBox
     if not (c and eb) then return end
     if eb.HasFocus and eb:HasFocus() then
         if eb.HasText then
@@ -174,9 +183,18 @@ end
 
 function Conv.ClearPreTarget()
     if not preTargetedKey then return end
+    local c = conversations[preTargetedKey]
     preTargetedKey = nil
-    local eb = _G.ChatFrame1EditBox
+    local util = _G.ChatFrameUtil
+    local eb = util and util.ChooseBoxForSend and util.ChooseBoxForSend() or _G.ChatFrame1EditBox
     if not eb then return end
+    local chatType, target
+    if eb.GetChatType then chatType = eb:GetChatType()
+    else chatType = eb:GetAttribute("chatType") end
+    if eb.GetTellTarget then target = eb:GetTellTarget()
+    else target = eb:GetAttribute("tellTarget") end
+    if IsSecret(chatType) or IsSecret(target) or not c
+        or chatType ~= c.chatType or target ~= c.target then return end
     if eb.HasFocus and eb:HasFocus() then
         if eb.HasText then
             if eb:HasText() then return end
@@ -193,14 +211,14 @@ function Conv.OnBlizzardPopout(chatType, chatTarget)
     local wt = WhisperSettings()
     if not (wt and wt.translatePopout) then return end
     if chatType ~= "WHISPER" and chatType ~= "BN_WHISPER" then return end
-    if IsSecret(chatTarget) or type(chatTarget) ~= "string" or chatTarget == "" then return end
+    if not IsSecret(chatTarget) and (type(chatTarget) ~= "string" or chatTarget == "") then return end
     local Display = ns.QUI.Chat.DisplayLayer
     local windowID = (Display and Display.GetActiveWindow and Display.GetActiveWindow()) or 1
-    Conv.Open(chatType, chatTarget, windowID, true)
+    return Conv.Open(chatType, chatTarget, windowID, true)
 end
 
 Store.OnAppend(function(entry)
-    if not entry.w or conversations[entry.w] then return end
+    if entry.w and conversations[entry.w] then return end
     local info = WHISPER_EVENTS[entry.e]
     if not info then return end
     local wt = WhisperSettings()
@@ -209,6 +227,7 @@ Store.OnAppend(function(entry)
         if info.incoming then want = wt.autoIncoming else want = wt.autoOutgoing end
     end
     if not want then return end
-    if IsSecret(entry.wn) or type(entry.wn) ~= "string" or entry.wn == "" then return end
-    Conv.Open(info.chatType, entry.wn, wt and wt.targetWindow or 1, false)
+    local target = entry.wn
+    if not IsSecret(target) and (type(target) ~= "string" or target == "") then return end
+    Conv.Open(info.chatType, target, wt and wt.targetWindow or 1, false)
 end)

--- a/QUI_Chat/chat/display_layer.lua
+++ b/QUI_Chat/chat/display_layer.lua
@@ -27,6 +27,9 @@ local function ReanchorEditBoxToActiveWindow()
     local EditBox = ns.QUI.Chat.EditBoxBasics
     if EditBox and EditBox.StyleEditBox and _G.ChatFrame1 then
         EditBox.StyleEditBox(_G.ChatFrame1)
+        for frame in pairs(I.editBoxBackdrops or {}) do
+            if frame ~= _G.ChatFrame1 then EditBox.StyleEditBox(frame) end
+        end
     end
 end
 

--- a/QUI_Chat/chat/editbox_basics.lua
+++ b/QUI_Chat/chat/editbox_basics.lua
@@ -7,20 +7,18 @@ local I = assert(ns.QUI.Chat and ns.QUI.Chat._internals,
 ns.QUI.Chat.EditBoxBasics = ns.QUI.Chat.EditBoxBasics or {}
 local EditBoxBasics = ns.QUI.Chat.EditBoxBasics
 
-local function GetAnchorFrame(chatFrame, frameID)
-    if frameID == 1 then
-        local settings = I.GetSettings and I.GetSettings()
-        if I.IsChatEnabled and I.IsChatEnabled(settings) then
-            local Display = ns.QUI.Chat.DisplayLayer
-            if Display and Display.GetContainer then
-                local active = Display.GetActiveWindow and Display.GetActiveWindow() or 1
-                local c = Display.GetContainer(active)
-                if not (c and c.IsShown and c:IsShown()) then
-                    c = Display.GetContainer(1)
-                end
-                if c and c.IsShown and c:IsShown() then
-                    return c
-                end
+local function GetAnchorFrame(chatFrame)
+    local settings = I.GetSettings and I.GetSettings()
+    if I.IsChatEnabled and I.IsChatEnabled(settings) then
+        local Display = ns.QUI.Chat.DisplayLayer
+        if Display and Display.GetContainer then
+            local active = Display.GetActiveWindow and Display.GetActiveWindow() or 1
+            local c = Display.GetContainer(active)
+            if not (c and c.IsShown and c:IsShown()) then
+                c = Display.GetContainer(1)
+            end
+            if c and c.IsShown and c:IsShown() then
+                return c
             end
         end
     end
@@ -88,6 +86,9 @@ local function EnsureGeometryHooks(chatFrame, editBox, state)
         editBox:HookScript("OnShow", function()
             QueueStyleEditBox(chatFrame)
         end)
+        editBox:HookScript("OnHide", function()
+            QueueStyleEditBox(chatFrame)
+        end)
     end
 end
 
@@ -151,8 +152,6 @@ local function StyleEditBox(chatFrame)
     local frameName = chatFrame:GetName()
     if not frameName then return end
 
-    local frameID = tonumber(frameName:match("ChatFrame(%d+)"))
-
     local editBox = chatFrame.editBox or _G[frameName .. "EditBox"]
     if not editBox then return end
 
@@ -201,7 +200,7 @@ local function StyleEditBox(chatFrame)
     local backdrop = I.editBoxBackdrops[chatFrame]
     local positionTop = settings.editBox.positionTop
 
-    local anchor = GetAnchorFrame(chatFrame, frameID)
+    local anchor = GetAnchorFrame(chatFrame)
 
     if backdrop:GetParent() ~= anchor then
         backdrop:SetParent(anchor)
@@ -275,7 +274,16 @@ local function StyleEditBox(chatFrame)
 
         ebState.backdropRef = backdrop
 
-        backdrop:Show()
+        local util = _G.ChatFrameUtil
+        local active = util and util.GetActiveWindow and util.GetActiveWindow()
+        for frame, bg in pairs(I.editBoxBackdrops) do
+            local input = frame.editBox or _G[frame:GetName() .. "EditBox"]
+            if active == input or (not active and frame:GetName() == "ChatFrame1") then
+                bg:Show()
+            else
+                bg:Hide()
+            end
+        end
         editBox:EnableMouse(true)
         SetEditBoxVisualShown(editBox, true)
     end

--- a/QUI_Chat/chat/message_capture.lua
+++ b/QUI_Chat/chat/message_capture.lua
@@ -336,6 +336,8 @@ end
 local WHISPER_POPOUT_KEYS = I.WHISPER_TYPE_KEYS
 
 local function GetWhisperMode()
+    local Suppress = ns.QUI.Chat.BlizzardSuppress
+    if Suppress and Suppress.GetWhisperMode then return Suppress.GetWhisperMode() end
     if type(_G.GetCVar) ~= "function" then return nil end
     local ok, value = ns.SafeCall("chain-next", _G.GetCVar, "whisperMode")
     if ok then return value end
@@ -383,13 +385,6 @@ local function OnCaptureEvent(_, event, ...)
 
     MaybeAutoAddChannel(event, p)
 
-    if (event == "CHAT_MSG_WHISPER" or event == "CHAT_MSG_BN_WHISPER") and p.sender then
-        local CFU = _G.ChatFrameUtil
-        if CFU and CFU.SetLastTellTarget then
-            ns.SafeCall("sink-forward", CFU.SetLastTellTarget, p.sender, typeKey)
-        end
-    end
-
     local colorKey = typeKey
     if (typeKey == "CHANNEL" or typeKey == "CHANNEL_NOTICE") and p.chNum and p.chNum > 0 then
         colorKey = "CHANNEL" .. p.chNum
@@ -400,9 +395,14 @@ local function OnCaptureEvent(_, event, ...)
     do
         local Conv = ns.QUI.Chat.ConversationManager
         local info = Conv and Conv.WHISPER_EVENTS and Conv.WHISPER_EVENTS[event]
-        if info and p.sender then
-            convKey = Conv.DeriveKey(info.chatType, p.sender)
+        if info then
             convName = p.sender
+            if IsSecret(p.rawSender) then convName = p.rawSender end
+            if IsSecret(convName) then
+                convKey = "WHISPERS"
+            elseif convName then
+                convKey = Conv.DeriveKey(info.chatType, convName)
+            end
         end
     end
     local whisperPopoutOnly = IsWhisperPopoutOnly(typeKey, convKey)

--- a/QUI_Chat/chat/tab_manager.lua
+++ b/QUI_Chat/chat/tab_manager.lua
@@ -147,6 +147,9 @@ end
 
 function TabManager.BuildConversationFilter(key)
     return function(entry)
+        if key == "WHISPERS" then
+            return _I.WHISPER_TYPE_KEYS and _I.WHISPER_TYPE_KEYS[entry.k] == true
+        end
         return entry.w == key
     end
 end

--- a/modules/qol/sound_mute.lua
+++ b/modules/qol/sound_mute.lua
@@ -43,6 +43,11 @@ local function Apply()
             if sm[key] then want[key] = true end
         end
     end
+    local chat = ns.QUI and ns.QUI.Chat
+    local suppress = chat and chat.BlizzardSuppress
+    if suppress and suppress.IsActive and suppress.IsActive() then
+        want.iface_whisper = true
+    end
 
     local toUnmute, toMute = ComputeMuteDelta(applied, want)
     for _, key in ipairs(toUnmute) do


### PR DESCRIPTION
Combat whisper initiation can silently focus an input beneath a hidden Blizzard chat frame. Keep native reply history and recipient selection intact while presenting every native input inside QUI; restricted senders use a shared QUI Whispers tab. Preserve the requested whisper mode across normalization and restore it when QUI chat is disabled or the player logs out.

Use the existing sound-mute service to suppress duplicate native whisper audio. Ensure the selected input and its single backdrop follow the active QUI window.

Validation: all nine local gates pass, including Lua 5.1 compilation, strict taint checks, lint and the complete unit suite. Regression checks execute vendored native whisper routing and fail against the original implementation. Live in-game combat verification remains pending.

Includes the merged regression tests from https://github.com/zol-wow/QUI-tests/pull/160.
