### PR TITLE
release: v5.3.1-beta5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.3.1-beta5 - 2026-09-10
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+### Fixed
+
+- **Combat whispers keep their native recipient and reply routing** while
+  displaying the input inside QUI, including Reply, character links, and
+  Battle.net whisper initiation. Restricted identities use a shared Whispers tab.
+- **Chat input follows the active QUI window**, including when switching or
+  deleting windows.
+- **Whisper preferences are preserved**, and duplicate Blizzard whisper sounds
+  are suppressed while QUI chat is active.
+
 ## v5.3.1-beta4 - 2026-09-10
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_Reminders/QUI_Reminders.toc
+++ b/QUI_Reminders/QUI_Reminders.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Reminders
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta4
+## Version: 5.3.1-beta5
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Prepare v5.3.1-beta5 with the combat whisper fixes landed in #945. Bump all 12 shipped addon TOCs, add the beta5 release notes, and pin the merged beta documentation from zol-wow/QUI-docs#54.

Validation: all nine local quality gates pass, including 942 unit test files and lint. Generators are current, the workflow's release-note extractor selects only beta5 notes, and independent release review found no issues. The exact committed tree is also checked in an isolated checkout with both pinned sidecars before push.
