### PR TITLE
fix(cdm): avoid native aura animation script warnings

### DIFF
--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -318,7 +318,7 @@ function Runs.StyleNativeEffects(frame, profile, key)
     if not glow or not frame.CreateTexture then return effects end
     local host = frame._quiCDMNativeEffectHost
     if not host then
-        host = CreateFrame("Frame", nil, frame, "AnimateWhileShownTemplate")
+        host = CreateFrame("Frame", nil, frame)
         host:SetAllPoints(frame)
         frame._quiCDMNativeEffectHost = host
     end


### PR DESCRIPTION
Native aura effects produced repeated blocked `OnShow` and `OnHide` assignment warnings from Blizzard’s `AnimationTemplates.xml`. Create the effect host without `AnimateWhileShownTemplate`, preserving the explicitly started repeating glow groups, configured effects, and native aura parent visibility.

Pins the regression update from https://github.com/zol-wow/QUI-tests/pull/168, which models the template’s actual XML handlers and rejects their assignment.

Validation: all nine `bash tools/test.sh` gates pass, including 945 unit files. The regression fails with the reported blocked `OnShow` assignment when the old template is restored. Independent review found no introduced defects. Live WoW aura expiration/reapplication animation behavior remains unverified.
