### PR TITLE
fix: restore chat routing and CDM runtime behavior

### DIFF
--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -312,6 +312,7 @@ function Runs.StyleNativeEffects(frame, profile, key)
     end
     for _, effect in ipairs(effects) do
         effect.group:Stop()
+        effect.playing = false
         effect.texture:SetAlpha(0)
         effect.enabled = false
     end
@@ -410,6 +411,7 @@ function Runs.StyleNativeEffects(frame, profile, key)
             path:CreateControlPoint(nil, nil, #corners + 1):SetOffset(0, 0)
         end
         group:Play()
+        effect.playing = true
     end
     return effects
 end
@@ -420,7 +422,12 @@ function Runs.SetNativeProcGlow(icon, active)
     if not icon._quiNativeProcGlows then return end
     for effects in pairs(icon._quiNativeProcGlows) do
         for _, effect in ipairs(effects) do
-            effect.texture:SetAlpha(active and effect.enabled and 1 or 0)
+            local playing = active == true and effect.enabled == true
+            if effect.playing ~= playing then
+                if playing then effect.group:Play() else effect.group:Stop() end
+                effect.playing = playing
+            end
+            effect.texture:SetAlpha(playing and 1 or 0)
         end
     end
 end

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -274,6 +274,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         catalogScopeOptionsScratch = { includeItems = false },
         spellScopeRefreshOptionsScratch = { refreshRuntime = true },
         itemScopeRefreshOptionsScratch = { refreshRuntime = true },
+        barQueue = { scheduled = false },
         spellQueue = {
             ids = {},
             frame = nil,
@@ -311,11 +312,6 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         return InCombatLockdown and InCombatLockdown() or false
     end
 
-    local function refreshBars()
-        if callbacks.setBarsDirty then callbacks.setBarsDirty(true) end
-        if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end
-    end
-
     local function armQueue(state, onUpdate)
         state.scheduled = true
         state.elapsed = 0
@@ -333,6 +329,24 @@ function CDMIconRuntimeRefresh.Create(callbacks)
         if state.frame then
             state.frame:SetScript("OnUpdate", nil)
             if state.frame.Hide then state.frame:Hide() end
+        end
+    end
+
+    local function drainBarQueue()
+        disarmQueue(controller.barQueue)
+        if not isRuntimeEnabled(callbacks) then
+            if callbacks.setBarsDirty then callbacks.setBarsDirty(false) end
+            return
+        end
+        if callbacks.runDirtyBarUpdate then callbacks.runDirtyBarUpdate() end
+    end
+
+    local function refreshBars(immediate)
+        if callbacks.setBarsDirty then callbacks.setBarsDirty(true) end
+        if immediate or not inCombat() then
+            drainBarQueue()
+        elseif not controller.barQueue.scheduled then
+            armQueue(controller.barQueue, drainBarQueue)
         end
     end
 
@@ -1013,11 +1027,11 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             return
         end
         if event == "PLAYER_REGEN_DISABLED" then
-            refreshBars()
+            refreshBars(true)
             return
         end
         if event == "PLAYER_REGEN_ENABLED" then
-            refreshBars()
+            refreshBars(true)
             controller:DrainDeferredFullRefresh()
             if callbacks.refreshPendingSecureAttributes then
                 callbacks.refreshPendingSecureAttributes()

--- a/QUI_CDM/cdm/cdm_reanchor_runtime.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_runtime.lua
@@ -524,7 +524,7 @@ function CDMReanchorRuntime:PositionEntries(container, plan, containerKey)
                 local placement = segment.placement
                 local padding = placement.rowConfig and placement.rowConfig.padding or 0
                 local w, h = PlacementRect(placement)
-                if not dynamic then
+                if not dynamic and not segment.wrapper.reanchored then
                     container._quiBuffFlowProxies = container._quiBuffFlowProxies or {}
                     local proxyRows = container._quiBuffFlowProxies
                     proxyRows[row] = proxyRows[row] or {}
@@ -533,27 +533,25 @@ function CDMReanchorRuntime:PositionEntries(container, plan, containerKey)
                         "DisableUntrustedLayoutScriptsTemplate")
                     frame = proxies[index]
                     frame:SetSize(w, h)
-                    if segment.wrapper.reanchored then
-                        bridge:OverlayRect(segment.frame, frame, "TOPLEFT", 0, 0, "BOTTOMRIGHT", 0, 0)
-                    else
-                        segment.frame:ClearAllPoints()
-                        segment.frame:SetPoint("CENTER", frame, "CENTER", 0, 0)
-                    end
+                    segment.frame:ClearAllPoints()
+                    segment.frame:SetPoint("CENTER", frame, "CENTER", 0, 0)
                 end
-                frame:ClearAllPoints()
-                if segments.count == 1 then
-                    local offset = (padding + 1) / 2 * (forward and 1 or -1)
-                    local rc = placement.rowConfig
-                    frame:SetPoint("CENTER", container, "CENTER",
-                        vertical and placement.x or ((rc and rc.xOffset or 0) + offset),
-                        vertical and ((rc and rc.yOffset or 0) + offset) or placement.y)
-                elseif previous then
-                    local offset = (previousDynamic and -1 or padding) * (forward and 1 or -1)
-                    frame:SetPoint(anchor, previous, opposite, vertical and 0 or offset, vertical and offset or 0)
-                else
-                    local offset = (vertical and h or w) / 2 * (forward and -1 or 1)
-                    frame:SetPoint(anchor, container, "CENTER", placement.x + (vertical and 0 or offset),
-                        placement.y + (vertical and offset or 0))
+                if not segment.wrapper.reanchored then
+                    frame:ClearAllPoints()
+                    if segments.count == 1 then
+                        local offset = (padding + 1) / 2 * (forward and 1 or -1)
+                        local rc = placement.rowConfig
+                        frame:SetPoint("CENTER", container, "CENTER",
+                            vertical and placement.x or ((rc and rc.xOffset or 0) + offset),
+                            vertical and ((rc and rc.yOffset or 0) + offset) or placement.y)
+                    elseif previous then
+                        local offset = (previousDynamic and -1 or padding) * (forward and 1 or -1)
+                        frame:SetPoint(anchor, previous, opposite, vertical and 0 or offset, vertical and offset or 0)
+                    else
+                        local offset = (vertical and h or w) / 2 * (forward and -1 or 1)
+                        frame:SetPoint(anchor, container, "CENTER", placement.x + (vertical and 0 or offset),
+                            placement.y + (vertical and offset or 0))
+                    end
                 end
                 previous, previousDynamic = frame, dynamic
             end

--- a/QUI_Chat/chat/display_layer.lua
+++ b/QUI_Chat/chat/display_layer.lua
@@ -418,7 +418,7 @@ local function CreateWindow(id)
 
     local cd = GetCustomDisplaySettings()
     local linkHandler = CreateFrame(
-        "ScrollingMessageFrame", smfName .. "LinkHandler", container, "ChatFrameTemplate")
+        "ScrollingMessageFrame", smfName .. "LinkHandler", container, "ChatFrameTemplate,InlineHyperlinkFrameTemplate")
     win.linkHandler = linkHandler
     linkHandler:SetAllPoints(container)
     linkHandler:UnregisterAllEvents()
@@ -428,7 +428,8 @@ local function CreateWindow(id)
     linkHandler:EnableMouseWheel(false)
     if linkHandler.SetToplevel then linkHandler:SetToplevel(false) end
     if linkHandler.ScrollBar then linkHandler.ScrollBar:Hide() end
-    linkHandler.editBox = _G.ChatFrame1EditBox
+    linkHandler:SetScript("OnHyperlinkEnter", _G.ChatFrameMixin.OnHyperlinkEnter)
+    linkHandler:SetScript("OnHyperlinkLeave", _G.ChatFrameMixin.OnHyperlinkLeave)
     linkHandler:SetHyperlinksEnabled(true)
     linkHandler:Show()
 

--- a/QUI_Chat/chat/hyperlinks.lua
+++ b/QUI_Chat/chat/hyperlinks.lua
@@ -118,6 +118,51 @@ hooksecurefunc("SetItemRef", function(link, text, button, ...)
     end
 end)
 
+if _G.ChatFrameUtil and _G.ChatFrameUtil.ShowChatChannelContextMenu then
+    hooksecurefunc(_G.ChatFrameUtil, "ShowChatChannelContextMenu", function(source, chatType, chatTarget, chatName)
+        if IsSecret(source) or IsSecret(chatType) or IsSecret(chatTarget) or IsSecret(chatName) then return end
+        if source ~= nil or type(chatType) ~= "string" then return end
+        local settings = I.GetSettings and I.GetSettings()
+        if not (I.IsChatEnabled and I.IsChatEnabled(settings)) then return end
+        local Display = ns.QUI.Chat.DisplayLayer
+        local TM = ns.QUI.Chat.TabManager
+        local TabUI = ns.QUI.Chat.TabUI
+        if not (Display and TM and TabUI) then return end
+        local windowID = Display.GetActiveWindow()
+        for id = 1, Display.GetWindowCount() do
+            local container = Display.GetContainer(id)
+            if container and container:IsShown() and container:IsMouseOver() then windowID = id end
+        end
+        local container = Display.GetContainer(windowID)
+        if not (container and container:IsShown()) then return end
+
+        local name
+        if chatType == "CHANNEL" then
+            local Registry = ns.QUI.Chat.ChannelRegistry
+            name = Registry and Registry.ResolveName(tonumber(chatTarget))
+        elseif _G.ChatTypeInfo and _G.ChatTypeInfo[chatType] then
+            name = _G[chatType] or chatType
+        end
+        if IsSecret(name) then return end
+        local valid = type(name) == "string" and name ~= ""
+        _G.MenuUtil.CreateContextMenu(container, function(_, rootDescription)
+            if valid then rootDescription:CreateTitle(name) end
+            local button = rootDescription:CreateButton(ns.L["Add Tab"], function()
+                if not valid then return end
+                local tab = TM.NewDefaultTab(name)
+                if chatType == "CHANNEL" then tab.channels[name] = true
+                else tab.groups[chatType] = true end
+                local tabs = TM.GetWindowTabs(windowID)
+                tabs[#tabs + 1] = tab
+                TabUI.Rebuild()
+                TabUI.ActivateFrameID(windowID, -#tabs)
+                if I.NotifyChatSettingsChanged then I.NotifyChatSettingsChanged() end
+            end)
+            button:SetEnabled(valid)
+        end)
+    end)
+end
+
 local TOOLTIP_LINK_TYPES = {
     achievement = true,
     battlepet = true,

--- a/QUI_Chat/chat/message_format.lua
+++ b/QUI_Chat/chat/message_format.lua
@@ -357,6 +357,7 @@ function Format.BuildPayloadFromArgs(event, ...)
         guid = (not IsSecret(a12)) and type(a12) == "string" and a12 ~= "" and a12 or nil,
         rawGuid = a12,
         bnID = (not IsSecret(a13)) and type(a13) == "number" and a13 or nil,
+        rawBnID = a13,
         suppressIcons = (not IsSecret(a17)) and a17 and true or nil,
         isSubtitle = a15 and true or nil,
         hideSenderInLetterbox = a16 and true or nil,
@@ -682,16 +683,21 @@ end
 
 local function BuildPlayerLink(typeKey, chatGroup, p, linkDisplayText)
     local sender = p.sender
-    if type(sender) ~= "string" or sender == "" then return nil end
     if typeKey == "BN_WHISPER" or typeKey == "BN_WHISPER_INFORM" then
-        if type(p.bnID) == "number" then
+        if IsSecret(p.rawSender) then sender = p.rawSender end
+        if not IsSecret(sender) and (type(sender) ~= "string" or sender == "") then return nil end
+        local bnID = p.rawBnID
+        if not IsSecret(bnID) then bnID = p.bnID end
+        if IsSecret(bnID) or type(bnID) == "number" then
             local lid = type(p.lineID) == "number" and p.lineID or 0
-            local target = ChatTargetFor(chatGroup, sender, p.chNum)
-            return ("|HBNplayer:%s:%d:%d:%s:%s|h%s|h"):format(
-                sender, p.bnID, lid, chatGroup, target, linkDisplayText)
+            local target = sender
+            if not IsSecret(sender) then target = ChatTargetFor(chatGroup, sender, p.chNum) end
+            return string.format("|HBNplayer:%s:%s:%s:%s:%s|h%s|h",
+                sender, bnID, lid, chatGroup, target, linkDisplayText)
         end
         return linkDisplayText
     end
+    if type(sender) ~= "string" or sender == "" then return nil end
     if (typeKey == "GUILD_DISCORD" or typeKey == "GUILD") and p.isFromDiscord then
         local lid = type(p.lineID) == "number" and p.lineID or 0
         local target = ChatTargetFor(chatGroup, sender, p.chNum)
@@ -721,8 +727,11 @@ local function BuildPlayerLink(typeKey, chatGroup, p, linkDisplayText)
     return ("|Hplayer:%s:%d:%s:%s|h%s|h"):format(sender, lid, chatGroup, target, linkDisplayText)
 end
 
-local function BuildSecretSenderLink(p)
+local function BuildSecretSenderLink(typeKey, p)
     if not IsSecret(p.rawSender) then return nil end
+    if typeKey == "BN_WHISPER" or typeKey == "BN_WHISPER_INFORM" then
+        return BuildPlayerLink(typeKey, ChatCategory(typeKey), p, string.format("[%s]", p.rawSender))
+    end
     local guid = p.rawGuid
     local guidSecret = IsSecret(guid)
     if not guidSecret and not guid then guid = p.guid end
@@ -760,8 +769,14 @@ local function FormatNormalLine(event, typeKey, p)
     local usingDifferentLanguage = type(p.language) == "string" and p.language ~= ""
         and p.language ~= RelevantDefaultLanguage(typeKey)
 
-    if showLink and sender == "" and typeKey ~= "TEXT_EMOTE" then
-        local secretLink = BuildSecretSenderLink(p)
+    if showLink and typeKey ~= "TEXT_EMOTE"
+        and (sender == "" or (chatGroup == "BN_WHISPER" and IsSecret(p.rawBnID))) then
+        local secretLink
+        if sender ~= "" then
+            secretLink = BuildPlayerLink(typeKey, chatGroup, p, ("[%s]"):format(p.decorated or sender))
+        else
+            secretLink = BuildSecretSenderLink(typeKey, p)
+        end
         if IsSecret(secretLink) or secretLink then
             local linkWithFlag = string.format("%s%s", pflag, secretLink)
             local fmt = OutFormat(typeKey)
@@ -1023,7 +1038,7 @@ function Format.WrapSecretEventLine(event, p)
         if type(p.sender) == "string" and p.sender ~= "" then
             link = BuildPlayerLink(typeKey, chatGroup, p, ("[%s]"):format(p.decorated or p.sender))
         elseif IsSecret(p.rawSender) then
-            link = BuildSecretSenderLink(p)
+            link = BuildSecretSenderLink(typeKey, p)
         end
         local linkSecret = IsSecret(link)
         if linkSecret or link then


### PR DESCRIPTION
Fix combat Battle.net replies and sender clicks by using native inline hyperlink entry and preserving Battle.net recipient metadata. Channel context menus now create a filtered QUI tab without invoking the native nil-source tab-copy path.

Coalesce combat bar refreshes once per frame, stop inactive proc animations, and preserve valid anchors for mixed native/custom Buff Icon rows. The tests submodule includes regressions for these behaviors.

Validation: all nine `bash tools/test.sh` gates passed, including 947 standalone unit files, and focused CDM/chat review completed. The user confirmed Battle.net reply and sender-click recovery in game; CDM FPS/rendering still needs live verification.

All local source changes and the tests revision are consolidated into this one commit.
