### PR TITLE
fix(cdm): stabilize buff layouts and reduce native aura refresh work

### DIFF
--- a/QUI_CDM/cdm/cdm_bar_renderer.lua
+++ b/QUI_CDM/cdm/cdm_bar_renderer.lua
@@ -1,4 +1,7 @@
 local _, ns = ...
+
+local SetGroupCandidateFilters = ns.AuraSkin and ns.AuraSkin.SetGroupCandidateFilters
+    or function(container, key, filters) container:SetAuraGroupCandidateFilters(key, filters) end
 local Helpers = ns.Helpers
 local QUICore = ns.Addon
 local LSM = ns.LSM
@@ -1052,7 +1055,7 @@ local function ConfigureNativeRuns(state, settings)
                     })
                 else
                     run.container:SetAuraGroupFilterString("bar1", config.filter)
-                    run.container:SetAuraGroupCandidateFilters("bar1", filters)
+                    SetGroupCandidateFilters(run.container, "bar1", filters)
                     for _, button in ipairs(run.frames.bar1) do StyleNativeBar(button, run.entry, settings) end
                 end
                 run.container:SetFlowLayoutAxis(vertical
@@ -1113,7 +1116,7 @@ local function ConfigureItemAuraOverlays(state, settings)
                 overlay.entry = entry
                 overlay.container:SetUnit(config.unit)
                 overlay.container:SetAuraGroupFilterString("aura", config.filter)
-                overlay.container:SetAuraGroupCandidateFilters("aura", { includeSpellIDs = config.includeSpellIDs })
+                SetGroupCandidateFilters(overlay.container, "aura", { includeSpellIDs = config.includeSpellIDs })
                 for _, button in ipairs(overlay.frames) do StyleNativeBar(button, entry, settings) end
             end
             local vertical = settings.orientation == "vertical"

--- a/QUI_CDM/cdm/cdm_buff_layout.lua
+++ b/QUI_CDM/cdm/cdm_buff_layout.lua
@@ -786,6 +786,11 @@ LayoutBuffIcons = function()
         end
     end
 
+    if ns._cdmBoot then
+        isIconLayoutRunning = false
+        return
+    end
+
     local iconSize = settings.iconSize or 42
     local padding = settings.padding or 0
     local aspectRatio = settings.aspectRatioCrop or 1.0
@@ -802,11 +807,9 @@ LayoutBuffIcons = function()
     local currentCount = #icons
 
     if currentCount == 0 then
-        if not ns._cdmBoot then
-            viewer:SetSize(iconWidth, iconHeight)
-            if _G.QUI_SetCDMViewerBounds then
-                _G.QUI_SetCDMViewerBounds(viewer, iconWidth, iconHeight)
-            end
+        viewer:SetSize(iconWidth, iconHeight)
+        if _G.QUI_SetCDMViewerBounds then
+            _G.QUI_SetCDMViewerBounds(viewer, iconWidth, iconHeight)
         end
         isIconLayoutRunning = false
         return

--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -235,7 +235,7 @@ local function Profile(rowConfig, settings, entry)
     return {
         cdmProcGlow = ns._OwnedGlows and ns._OwnedGlows.ResolveGlowForEntry
             and ns._OwnedGlows.ResolveGlowForEntry(entry) or nil,
-        cdmActiveGlow = settings and settings.activeGlowEnabled ~= false
+        cdmActiveGlow = settings and settings.containerType == "customBar" and settings.activeGlowEnabled ~= false
             and not (override and override.glowEnabled == false) and {
             color = override and override.glowColor or settings.activeGlowColor or { 1, 0.85, 0.3, 1 },
             thickness = settings.activeGlowThickness or 2,
@@ -458,8 +458,8 @@ function Runs.SetNativeProcGlow(icon, active)
             if effect.playing ~= playing then
                 if playing then effect.group:Play() else effect.group:Stop() end
                 effect.playing = playing
+                effect.texture:SetAlpha(playing and 1 or 0)
             end
-            effect.texture:SetAlpha(playing and 1 or 0)
         end
     end
 end

--- a/QUI_CDM/cdm/cdm_layout.lua
+++ b/QUI_CDM/cdm/cdm_layout.lua
@@ -281,6 +281,31 @@ function CDMLayout.ApplyCustomBarGrowthOrder(icons, settings)
     return reversed
 end
 
+local function PackNativeAuraTail(icons, first, count)
+    local fixedCount = 0
+    for i = first, first + count - 1 do
+        local options = icons[i].auraMirrorOptions
+        if not (options and options.dynamic) then fixedCount = fixedCount + 1 end
+    end
+    if fixedCount == 0 or fixedCount == count then return icons, count end
+
+    local ordered = {}
+    for i, icon in ipairs(icons) do ordered[i] = icon end
+    local fixedIndex, tailIndex = first, first + fixedCount
+    for i = first, first + count - 1 do
+        local icon = icons[i]
+        local options = icon.auraMirrorOptions
+        if options and options.dynamic then
+            ordered[tailIndex] = icon
+            tailIndex = tailIndex + 1
+        else
+            ordered[fixedIndex] = icon
+            fixedIndex = fixedIndex + 1
+        end
+    end
+    return ordered, fixedCount
+end
+
 function CDMLayout.BuildIconLayout(settings, icons, opts)
     opts = opts or {}
     local rows = CDMLayout.BuildRows(settings)
@@ -316,16 +341,18 @@ function CDMLayout.BuildIconLayout(settings, icons, opts)
         local rowCount = rowConfig._actualCount or rowConfig.count
         local iconsInRow = math.min(rowCount, #icons - tempIndex + 1)
         if iconsInRow > 0 then
+            local sizeCount
+            icons, sizeCount = PackNativeAuraTail(icons, tempIndex, iconsInRow)
             local iconWidth = rowConfig.size
             local aspectRatio = rowConfig.aspectRatioCrop or 1.0
             local iconHeight = rowConfig.size / aspectRatio
 
             if isVertical then
-                local colHeight = (iconsInRow * iconHeight) + ((iconsInRow - 1) * rowConfig.padding)
+                local colHeight = (sizeCount * iconHeight) + ((sizeCount - 1) * rowConfig.padding)
                 rowWidths[rowNum] = iconWidth
                 if colHeight > maxColHeight then maxColHeight = colHeight end
             else
-                local rowWidth = (iconsInRow * iconWidth) + ((iconsInRow - 1) * rowConfig.padding)
+                local rowWidth = (sizeCount * iconWidth) + ((sizeCount - 1) * rowConfig.padding)
                 rowWidths[rowNum] = rowWidth
                 if rowWidth > maxRowWidth then maxRowWidth = rowWidth end
             end
@@ -342,6 +369,10 @@ function CDMLayout.BuildIconLayout(settings, icons, opts)
         local rowCount = rowConfig._actualCount or rowConfig.count
         local iconsInRow = math.min(rowCount, #icons - tempIdx + 1)
         if iconsInRow > 0 then
+            rowConfig.flowDirection = isVertical and "DOWN" or "RIGHT"
+            rowConfig.flowAlignment = isVertical and "START"
+                or (rowConfig.growDirection == "RIGHT" and "START"
+                    or rowConfig.growDirection == "LEFT" and "END" or "CENTER")
             local aspectRatio = rowConfig.aspectRatioCrop or 1.0
             local iconHeight = rowConfig.size / aspectRatio
             local iconWidth = rowConfig.size
@@ -540,7 +571,9 @@ function CDMLayout.BuildBuffGridLayout(settings, icons, _opts)
     local rowConfig = {
         rowNum = 1,
         count = #icons,
-        size = iconSize,
+        size = iconWidth,
+        flowDirection = growthDirection == "CENTERED_HORIZONTAL" and "RIGHT" or growthDirection,
+        flowAlignment = "CENTER",
         borderSize = settings.borderSize or 2,
         borderColorSource = settings.borderColorSource,
         borderColor = settings.borderColor or settings.borderColorTable or {0, 0, 0, 1},
@@ -566,7 +599,8 @@ function CDMLayout.BuildBuffGridLayout(settings, icons, _opts)
         opacity = settings.opacity or 1.0,
     }
 
-    local n = #icons
+    local n
+    icons, n = PackNativeAuraTail(icons, 1, #icons)
     local placements = {}
     local totalWidth, totalHeight
 
@@ -579,7 +613,7 @@ function CDMLayout.BuildBuffGridLayout(settings, icons, _opts)
         else
             startY = (totalHeight / 2) - iconHeight / 2
         end
-        for i = 1, n do
+        for i = 1, #icons do
             local y = (growthDirection == "UP")
                 and (startY + (i - 1) * (iconHeight + padding))
                 or (startY - (i - 1) * (iconHeight + padding))
@@ -592,7 +626,7 @@ function CDMLayout.BuildBuffGridLayout(settings, icons, _opts)
         local startX = growLeft
             and (totalWidth / 2 - iconWidth / 2)
             or (-totalWidth / 2 + iconWidth / 2)
-        for i = 1, n do
+        for i = 1, #icons do
             local x = growLeft
                 and (startX - (i - 1) * (iconWidth + padding))
                 or (startX + (i - 1) * (iconWidth + padding))

--- a/QUI_CDM/cdm/cdm_managed_aura_mirrors.lua
+++ b/QUI_CDM/cdm/cdm_managed_aura_mirrors.lua
@@ -72,6 +72,12 @@ local function CandidateFilter(spellID)
     return { includeSpellIDs = { [spellID] = true } }
 end
 
+local function SetSlotCandidate(auraContainer, slot, spellID)
+    if slot.spellID == spellID then return end
+    auraContainer:SetAuraSlotCandidateFilters(slot.key, spellID and CandidateFilter(spellID) or PARK_FILTER)
+    slot.spellID = spellID
+end
+
 function CDMManagedAuraMirrors.New(deps)
     deps = deps or {}
     local self = {
@@ -145,7 +151,7 @@ local function ParkRecord(pool, record)
     if record.parked then return end
     local auraContainer = pool.auraContainer
     for i = 1, #record.slots do
-        auraContainer:SetAuraSlotCandidateFilters(record.slots[i].key, PARK_FILTER)
+        SetSlotCandidate(auraContainer, record.slots[i], nil)
     end
     record.parked = true
 end
@@ -235,8 +241,7 @@ function CDMManagedAuraMirrors:Acquire(ownerContainer, placementKey, entry, prof
         local slot = record.slots[i]
         if slot then
             auraContainer:SetAuraSlotFilterString(slot.key, filter)
-            auraContainer:SetAuraSlotCandidateFilters(slot.key, CandidateFilter(spellID))
-            slot.spellID = spellID
+            SetSlotCandidate(auraContainer, slot, spellID)
         else
             pool.slotSeq = pool.slotSeq + 1
             local key = "quiAuraMirror:" .. tostring(pool.slotSeq)
@@ -270,7 +275,7 @@ function CDMManagedAuraMirrors:Acquire(ownerContainer, placementKey, entry, prof
         end
     end
     for i = #ids + 1, #record.slots do
-        auraContainer:SetAuraSlotCandidateFilters(record.slots[i].key, PARK_FILTER)
+        SetSlotCandidate(auraContainer, record.slots[i], nil)
     end
 
     record.entry = entry

--- a/QUI_CDM/cdm/cdm_reanchor_realenv.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_realenv.lua
@@ -1,5 +1,8 @@
 local _, ns = ...
 
+local SetGroupCandidateFilters = ns.AuraSkin and ns.AuraSkin.SetGroupCandidateFilters
+    or function(container, key, filters) container:SetAuraGroupCandidateFilters(key, filters) end
+
 local CDMReanchorRealEnv = {}
 ns.CDMReanchorRealEnv = CDMReanchorRealEnv
 
@@ -887,7 +890,7 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
                 })
             else
                 run.host:SetAuraGroupFilterString(record.key, config.filter)
-                run.host:SetAuraGroupCandidateFilters(record.key, { includeSpellIDs = config.includeSpellIDs })
+                SetGroupCandidateFilters(run.host, record.key, { includeSpellIDs = config.includeSpellIDs })
                 run.host:SetAuraGroupMaxFrameCount(record.key, 1)
             end
             run.host:SetEnabled(true)
@@ -991,7 +994,8 @@ function CDMReanchorRealEnv.BuildEnv(ctx)
                     or auraProfileFromRow(rowConfig)
                 record.profile.iconWidth, record.profile.iconHeight = w, h
                 if record.baseIcon then record.baseIcon._quiNativeProcGlows = nil end
-                local direction = settings.growthDirection or "CENTERED_HORIZONTAL"
+                local direction = rowConfig and rowConfig.flowDirection
+                    or settings.growthDirection or "CENTERED_HORIZONTAL"
                 local vertical = direction == "UP" or direction == "DOWN"
                 local forward = direction ~= "LEFT" and direction ~= "DOWN"
                 local anchor = vertical and (forward and "BOTTOM" or "TOP")

--- a/QUI_CDM/cdm/cdm_reanchor_runtime.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_runtime.lua
@@ -432,7 +432,7 @@ function CDMReanchorRuntime:PositionEntries(container, plan, containerKey)
         if frame then
             local options = wrapper.auraMirrorOptions
             if options then
-                options.order = index
+                options.order = options.order or index
                 options.rowConfig = placement.rowConfig
                 wrapper.auraMirror = deps.acquireAuraMirror(wrapper.src, containerKey,
                     wrapper.placementKey or (containerKey .. ":layout:" .. index), options)
@@ -493,6 +493,7 @@ function CDMReanchorRuntime:PositionEntries(container, plan, containerKey)
         local row = placement.rowConfig and placement.rowConfig.rowNum or 1
         local segments = rows[row]
         if not segments then segments = { count = 0 }; rows[row] = segments end
+        segments.lastPlacement = placement
         if not segments.active then
             segments.active = true
             rowOrder[#rowOrder + 1] = row
@@ -538,12 +539,19 @@ function CDMReanchorRuntime:PositionEntries(container, plan, containerKey)
                 end
                 if not segment.wrapper.reanchored then
                     frame:ClearAllPoints()
-                    if segments.count == 1 then
+                    local alignment = placement.rowConfig and placement.rowConfig.flowAlignment or "CENTER"
+                    if segments.count == 1 and alignment == "CENTER" then
                         local offset = (padding + 1) / 2 * (forward and 1 or -1)
                         local rc = placement.rowConfig
                         frame:SetPoint("CENTER", container, "CENTER",
                             vertical and placement.x or ((rc and rc.xOffset or 0) + offset),
                             vertical and ((rc and rc.yOffset or 0) + offset) or placement.y)
+                    elseif segments.count == 1 and alignment == "END" then
+                        local last = segments.lastPlacement
+                        local lastW, lastH = PlacementRect(last)
+                        local offset = ((vertical and lastH or lastW) / 2 + padding + 1) * (forward and 1 or -1)
+                        frame:SetPoint(opposite, container, "CENTER", last.x + (vertical and 0 or offset),
+                            last.y + (vertical and offset or 0))
                     elseif previous then
                         local offset = (previousDynamic and -1 or padding) * (forward and 1 or -1)
                         frame:SetPoint(anchor, previous, opposite, vertical and 0 or offset, vertical and offset or 0)
@@ -561,6 +569,7 @@ function CDMReanchorRuntime:PositionEntries(container, plan, containerKey)
             segment.frame, segment.record, segment.placement, segment.wrapper = nil, nil, nil, nil
         end
         segments.count, segments.active, segments.direction, segments.hasDynamic = 0, nil, nil, nil
+        segments.lastPlacement = nil
         rowOrder[rowIndex] = nil
     end
     for frame in pairs(positionedFrames) do positionedFrames[frame] = nil end

--- a/core/aura_skin.lua
+++ b/core/aura_skin.lua
@@ -594,6 +594,57 @@ local function EachTrackedButton(container, fn)
     end
 end
 
+local EMPTY_CANDIDATE_FILTERS = {}
+
+local function CandidateFiltersMatch(previous, filters)
+    if not previous then return false end
+    filters = filters or EMPTY_CANDIDATE_FILTERS
+    for field, value in pairs(filters) do
+        local old = previous[field]
+        if type(value) == "table" then
+            if type(old) ~= "table" then return false end
+            for key, entry in pairs(value) do
+                if old[key] ~= entry then return false end
+            end
+            for key in pairs(old) do
+                if value[key] == nil then return false end
+            end
+        elseif old ~= value then
+            return false
+        end
+    end
+    for field in pairs(previous) do
+        if filters[field] == nil then return false end
+    end
+    return true
+end
+
+local function CacheGroupCandidateFilters(container, key, filters)
+    local cache = container._quiGroupCandidateFilters
+    if not cache then
+        cache = {}
+        container._quiGroupCandidateFilters = cache
+    end
+    local snapshot = {}
+    for field, value in pairs(filters or EMPTY_CANDIDATE_FILTERS) do
+        if type(value) == "table" then
+            local copy = {}
+            for entry, enabled in pairs(value) do copy[entry] = enabled end
+            snapshot[field] = copy
+        else
+            snapshot[field] = value
+        end
+    end
+    cache[key] = snapshot
+end
+
+function AuraSkin.SetGroupCandidateFilters(container, key, filters)
+    local cache = container._quiGroupCandidateFilters
+    if CandidateFiltersMatch(cache and cache[key], filters) then return end
+    container:SetAuraGroupCandidateFilters(key, filters)
+    CacheGroupCandidateFilters(container, key, filters)
+end
+
 function AuraSkin.Configure(container, profile, groups)
     local L = ResolveLayout(profile)
     container._quiProfile = profile
@@ -635,7 +686,7 @@ function AuraSkin.Configure(container, profile, groups)
             end
             container:SetAuraGroupMaxFrameCount(key, maxCount)
             container:SetAuraGroupSortMethod(key, sortMethod, sortDir)
-            container:SetAuraGroupCandidateFilters(key, g.candidateFilters)
+            AuraSkin.SetGroupCandidateFilters(container, key, g.candidateFilters)
             container:SetAuraGroupLayout(key, GroupLayout(L, g))
             registered[key] = filter
         else
@@ -647,6 +698,7 @@ function AuraSkin.Configure(container, profile, groups)
                 initializeFrame  = MakeInitializer(container, g, key),
                 layout           = GroupLayout(L, g),
             })
+            CacheGroupCandidateFilters(container, key, g.candidateFilters)
             registered[key] = filter
         end
     end


### PR DESCRIPTION
Mixed Blizzard/custom buff rows could retain empty gaps, use incorrect flow geometry, or have their bounds overwritten by the legacy layout. Pack Blizzard icons together with custom auras following each row, preserve native group boundaries, and apply the planned direction, alignment, and dimensions.

Avoid redundant native candidate-filter rebuild requests and repeated proc texture writes during unchanged refreshes. Keep active-aura glow scoped to custom bars.

Validation: all nine local `bash tools/test.sh` gates, including 948 unit files; regression coverage in the pinned tests sidecar. Mixed-row spacing was confirmed in game; live FPS improvement remains unmeasured.
