### PR TITLE
fix: defer options startup work and guard chat channel names

### DIFF
--- a/QUI_Chat/chat/message_format.lua
+++ b/QUI_Chat/chat/message_format.lua
@@ -570,6 +570,7 @@ local function FormatDiscordMessage(discordInfo, message)
 end
 
 local function ResolvePrefixedChannelName(channelFull)
+    if not channelFull:match("(%d+. )(.*)") then return channelFull end
     local util = _G.ChatFrameUtil
     if util and util.ResolvePrefixedChannelName then
         local ok, resolved = ns.SafeCall("chain-next", util.ResolvePrefixedChannelName, channelFull)

--- a/QUI_Options/framework.lua
+++ b/QUI_Options/framework.lua
@@ -5355,7 +5355,6 @@ function GUI:CreateMainFrame()
         accentSwatch._bg:SetVertexColor(r, g, b, 1)
         title:SetTextColor(C.accentLight[1], C.accentLight[2], C.accentLight[3], 1)
         version:SetTextColor(C.accentLight[1], C.accentLight[2], C.accentLight[3], 1)
-        RefreshAllSkinning()
     end
 
     local themeLabel = titleBar:CreateFontString(nil, "OVERLAY", "GameFontNormal")
@@ -7941,6 +7940,10 @@ end
 function GUI:OnFontChanged()
     if not self.MainFrame or not self.MainFrame:IsShown() then return end
     self:RefreshAccentColor()
+    if ns.Registry then
+        ns.Registry:RefreshAll("skinning")
+    end
+    if _G.QUI_RefreshStatusTrackingBarSkin then _G.QUI_RefreshStatusTrackingBarSkin() end
 end
 
 QUI.GUI = GUI

--- a/init.lua
+++ b/init.lua
@@ -634,12 +634,6 @@ function QUI:OnEnable()
     self:RegisterEvent("ADDON_LOADED")
     self:RegisterOptionalPullAlias()
 
-    ns.RunAfterFirstFrame(function()
-        if QUI:EnsureOptionsLoaded() then
-            QUI.GUI:InitializeOptions()
-        end
-    end, 0)
-
     if self.QUICore then
         local sw = self.db and self.db.global and self.db.global.setupWizard
         if sw and not sw.completedAt then


### PR DESCRIPTION
Prevents the options window from loading and constructing automatically after login, and removes the constructor-triggered refresh of gameplay skins. Opening options and the fresh-install setup wizard still load on demand; explicit theme and font changes retain their skin updates.

Guards chat channel names without Blizzard’s expected numbered prefix before calling its resolver, preserving their display without reporting a Lua error. Includes the tests submodule update with three regression tests.

Validation: `bash tools/test.sh` — all nine gates passed, including 951 unit tests; independent local review found no blockers. Live client verification remains pending.
