### PR TITLE
fix(chat): format restricted achievement messages

### DIFF
--- a/QUI_Chat/chat/message_format.lua
+++ b/QUI_Chat/chat/message_format.lua
@@ -894,7 +894,8 @@ local function FormatSpecialLine(event, typeKey, kind, p)
     local channelFull, channelNumber, targetUser = p.channelFull, p.chNum, p.target
 
     if kind == "ach" then
-        if type(sender) ~= "string" or sender == "" then return nil end
+        if IsSecret(p.rawSender) then sender = p.rawSender end
+        if not IsSecret(sender) and (type(sender) ~= "string" or sender == "") then return nil end
         local shown = p.decorated or sender
         local link = BracketedPlayerLink(sender, shown)
         return FormatString(text, link)
@@ -1014,6 +1015,9 @@ function Format.WrapSecretEventLine(event, p)
     local typeKey = Format.EventToTypeKey(event)
     if not typeKey then return text end
 
+    if SPECIAL_KIND[typeKey] == "ach" then
+        return FormatSpecialLine(event, typeKey, "ach", p)
+    end
     if BOSS_NOTICE_EVENTS[event] or SPECIAL_KIND[typeKey] then
         return text
     end


### PR DESCRIPTION
Achievement messages with restricted bodies previously skipped player substitution, while restricted senders could drop the event. Route both achievement event types through the shared formatter and pass restricted senders opaquely into player links.

Updates the tests submodule with eight regression cases covering both event types and every body/sender secrecy combination, including complete achievement hyperlink preservation.

Validation: all nine `bash tools/test.sh` gates passed, including 953 unit test files and lint; both restricted-body and restricted-sender cases fail against the previous source. Independent diff review found no blockers. Graphify updated. The reported live link-only disappearance has not been reproduced offline.
