### PR TITLE
fix(minimap): preserve saved datatext anchors

### DIFF
--- a/modules/minimap/minimap.lua
+++ b/modules/minimap/minimap.lua
@@ -573,8 +573,11 @@ local function UpdateDatatextPanel()
         datatextFrame:SetScale(1)
     end
 
-    datatextFrame:ClearAllPoints()
-    datatextFrame:SetPoint("TOP", Minimap, "BOTTOM", 0, -(minimapBorderSize + yOffset))
+    local hasAnchor = _G.QUI_HasFrameAnchor and _G.QUI_HasFrameAnchor("datatextPanel")
+    if not hasAnchor then
+        datatextFrame:ClearAllPoints()
+        datatextFrame:SetPoint("TOP", Minimap, "BOTTOM", 0, -(minimapBorderSize + yOffset))
+    end
 
     datatextFrame.borderLeft:ClearAllPoints()
     datatextFrame.borderLeft:SetPoint("TOPRIGHT", datatextFrame, "TOPLEFT", 0, dtBorderSize)
@@ -615,6 +618,11 @@ local function UpdateDatatextPanel()
     end
 
     datatextFrame:Show()
+
+    if hasAnchor and _G.QUI_ApplyFrameAnchor
+        and not (_G.QUI_IsLayoutModeActive and _G.QUI_IsLayoutModeActive()) then
+        _G.QUI_ApplyFrameAnchor("datatextPanel")
+    end
 
     RefreshDatatextSlots()
 end


### PR DESCRIPTION
Minimap refresh could overwrite a saved datatext screen position with an anchor back to the minimap, causing a circular-anchor error when the minimap already followed that panel.

Preserve saved anchor ownership and reapply saved positioning after showing the panel, before refreshing its slots. Layout Mode retains unsaved drag positions, while automatic sizing and parent visibility continue to apply.

Validation: all nine local gates pass. The regression reproduces the circular-anchor error on the previous runtime and passes with this fix. In-game verification remains pending.
