### PR TITLE
release: v5.5.0-ptr-alpha4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.5.0-ptr-alpha4 - 2026-09-12
+
+> ⚠️ **WoW 12.1.5 PTR ONLY.** This alpha targets interface 120105 and will
+> not load on the live 12.1 client.
+
+Includes the beta updates through v5.3.1-beta8 while retaining PTR features.
+
+### Added
+
+- **Reminders is a new optional module, off by default**, with defensive
+  callouts driven by BigWigs, DBM, or Blizzard's encounter timeline. Configure
+  per-spec priorities, movable callouts, sound or text-to-speech, and CDM glows.
+- **Bonus Roll filters** can hide prompts by raid difficulty, boss, dungeon,
+  Delve, or Mythic+ key level. Recover an unexpired hidden offer with
+  `/qui bonusroll show`.
+- **Group Frames can hide raid groups 7 and 8 in Mythic raids and hide unit
+  tooltips during combat.**
+
+### Changed
+
+- **Options load on demand and raid frames reuse secure unit buttons**,
+  reducing startup work and repeated styling during roster updates.
+- **Cooldown Manager custom auras use native tracking and rendering**, with
+  improved buff-row spacing, alignment, group boundaries, and aura glows.
+
+### Fixed
+
+- **Cooldown Manager aura sounds no longer modify Blizzard's native alert
+  layouts**, preventing taint in native cooldown and aura tracking. Configure
+  native sounds and text-to-speech in Blizzard's Cooldown Manager settings.
+- **Chat preserves whisper recipients, replies, and Battle.net routing**,
+  follows the active window, and safely handles restricted achievement messages
+  and channel names.
+- **Castbar anchor chains no longer restrict resizing during combat**, arena target health bars
+  retain class colors, and minimap datatexts keep their saved positions.
+- **Settings searches skip restricted preview text**, unchanged pinned values
+  avoid full refreshes, and Rotation Helper clears stale suggestions.
+
 ## v5.5.0-ptr-alpha3 - 2026-09-08
 
 > ⚠️ **WoW 12.1.5 PTR ONLY.** This alpha targets interface 120105 and will

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_Reminders/QUI_Reminders.toc
+++ b/QUI_Reminders/QUI_Reminders.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Reminders
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.5.0-ptr-alpha3
+## Version: 5.5.0-ptr-alpha4
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Prepare v5.5.0-ptr-alpha4 for the WoW 12.1.5 PTR after the beta8 catch-up. Bump all 12 shipped TOCs, add release notes, and pin the alpha documentation release from zol-wow/QUI-docs#59. Interface 120105 and runtime behavior are preserved.

Validation: all nine tools/test.sh gates passed in the working tree and isolated committed tree, including 957 unit test files; generated search/i18n files are current. Verified packaging TOC scope, exact workflow notes extraction, and independent metadata review.
