### PR TITLE
fix: refresh aura identities, pandemic glows, and chat realm names

### DIFF
--- a/QUI_CDM/cdm/cdm_custom_aura_runs.lua
+++ b/QUI_CDM/cdm/cdm_custom_aura_runs.lua
@@ -229,7 +229,8 @@ local function Profile(rowConfig, settings, entry)
         local suffix = auraConfig.filter:find("HARMFUL", 1, true)
             and "PandemicDebuffEnabled" or "PandemicBuffEnabled"
         if not glowSettings or glowSettings[viewerType .. suffix] ~= false then
-            pandemicGlow = { color = { 1, 0.85, 0.2, 1 } }
+            pandemicGlow = ns._OwnedGlows and ns._OwnedGlows.ResolvePandemicGlowForEntry
+                and ns._OwnedGlows.ResolvePandemicGlowForEntry(entry) or { color = { 1, 0.85, 0.2, 1 } }
         end
     end
     return {
@@ -310,9 +311,14 @@ function Runs.StyleNativeEffects(frame, profile, key)
         effects = {}
         frame[key] = effects
     end
-    local width = profile.iconWidth or profile.iconSize or 39
-    local height = profile.iconHeight or width
     local style = glow and glow.glowType or "Pixel Glow"
+    local useOffsets = style == "Pixel Glow" or style == "Autocast Shine" or style == "Proc Glow"
+    local xOffset = useOffsets and glow and glow.xOffset or 0
+    local yOffset = useOffsets and glow and glow.yOffset or 0
+    local baseWidth = profile.iconWidth or profile.iconSize or 39
+    local baseHeight = profile.iconHeight or baseWidth
+    local width = math.max(1, baseWidth + xOffset * 2)
+    local height = math.max(1, baseHeight + yOffset * 2)
     local lines = math.max(1, math.floor(glow and glow.lines or 8))
     local thickness = math.max(1, glow and glow.thickness or 2)
     local frequency = glow and glow.frequency or 0.25
@@ -325,6 +331,7 @@ function Runs.StyleNativeEffects(frame, profile, key)
     if glow and config and config.width == width and config.height == height
         and config.style == style and config.lines == lines and config.thickness == thickness
         and config.frequency == frequency and config.scale == scale
+        and config.xOffset == xOffset and config.yOffset == yOffset
         and config.r == r and config.g == g and config.b == b and config.a == a then
         return effects
     end
@@ -346,10 +353,11 @@ function Runs.StyleNativeEffects(frame, profile, key)
         frame._quiCDMNativeEffectHost = host
     end
     local flipbook = style == "Proc Glow" or style == "Button Glow"
+    local pulse = style == "Flash" or style == "Hammer"
     local length = math.max(thickness, math.min(width, height, math.floor((width + height) * (2 / lines - 0.1))))
     local segments = style == "Pixel Glow" and math.ceil(length / thickness) or 1
     local layers = style == "Autocast Shine" and 4 or 1
-    local count = flipbook and 1 or lines * segments * layers
+    local count = (flipbook or pulse) and 1 or lines * segments * layers
     local period = 1 / math.max(0.01, math.abs(frequency))
     local perimeter = (width + height) * 2
     for i = 1, count do
@@ -358,6 +366,10 @@ function Runs.StyleNativeEffects(frame, profile, key)
             local texture = host:CreateTexture(nil, "OVERLAY")
             effect = { texture = texture, group = host:CreateAnimationGroup() }
             effects[i] = effect
+            if key == "_quiCDMNativePandemicGlow" and frame.AddPandemicRegion then
+                texture:Hide()
+                frame:AddPandemicRegion(texture)
+            end
         end
         effect.enabled = true
         local texture, group = effect.texture, effect.group
@@ -366,25 +378,35 @@ function Runs.StyleNativeEffects(frame, profile, key)
         texture:SetAlpha(1)
         texture:SetTexCoord(0, 1, 0, 1)
         texture:SetBlendMode("BLEND")
-        local animationKind = flipbook and "FlipBook" or "Path"
+        local animationKind = flipbook and "FlipBook" or pulse and "Alpha" or "Path"
         if effect.animationKind ~= animationKind then
             group:RemoveAnimations()
             effect.animationKind = nil
             effect.animation = group:CreateAnimation(animationKind)
             effect.animation:SetTarget(texture)
             effect.points = nil
-            if not flipbook then
+            if animationKind == "Path" then
                 effect.points = {}
                 for order = 1, 5 do
                     effect.points[order] = effect.animation:CreateControlPoint(nil, nil, order)
                 end
             end
-            group:SetLooping("REPEAT")
+            group:SetLooping(pulse and "BOUNCE" or "REPEAT")
             effect.animationKind = animationKind
         end
-        if flipbook then
+        if pulse then
+            texture:SetPoint("TOPLEFT", frame, "TOPLEFT", -xOffset, yOffset)
+            texture:SetSize(width, height)
+            texture:SetTexture(((ns.Helpers and ns.Helpers.AssetPath) or "Interface\\AddOns\\QUI\\assets\\")
+                .. (style == "Flash" and "iconskin\\Flash" or "quazii_hammer"))
+            texture:SetBlendMode("ADD")
+            effect.animation:SetFromAlpha(0.3)
+            effect.animation:SetToAlpha(1)
+            effect.animation:SetDuration(0.4)
+        elseif flipbook then
             texture:SetPoint("CENTER", frame, "CENTER", 0, 0)
-            texture:SetSize(width * 1.4, height * 1.4)
+            texture:SetSize(math.max(1, baseWidth * 1.4 + xOffset * 2),
+                math.max(1, baseHeight * 1.4 + yOffset * 2))
             if style == "Proc Glow" then
                 texture:SetAtlas("UI-HUD-ActionBar-Proc-Loop-Flipbook")
             else
@@ -421,7 +443,7 @@ function Runs.StyleNativeEffects(frame, profile, key)
                 return 0, distance - perimeter
             end
             local x, y = Point(start)
-            texture:SetPoint("CENTER", frame, "TOPLEFT", x, y)
+            texture:SetPoint("CENTER", frame, "TOPLEFT", x - xOffset, y + yOffset)
             local corners = {}
             for _, distance in ipairs({ width, width + height, width * 2 + height, perimeter }) do
                 if distance <= start then distance = distance + perimeter end
@@ -444,6 +466,7 @@ function Runs.StyleNativeEffects(frame, profile, key)
     effects.config = {
         width = width, height = height, style = style, lines = lines, thickness = thickness,
         frequency = frequency, scale = scale, r = r, g = g, b = b, a = a,
+        xOffset = xOffset, yOffset = yOffset,
     }
     return effects
 end
@@ -466,6 +489,12 @@ end
 
 function Runs.ConfigureNativeEffects(frame, profile, owner)
     Runs.StyleNativeEffects(frame, profile)
+    Runs.StyleNativeEffects(frame, {
+        cdmActiveGlow = profile.pandemicGlow and profile.pandemicGlow.glowType and profile.pandemicGlow or nil,
+        iconWidth = profile.iconWidth,
+        iconHeight = profile.iconHeight,
+        iconSize = profile.iconSize,
+    }, "_quiCDMNativePandemicGlow")
     local effects = Runs.StyleNativeEffects(frame, {
         cdmActiveGlow = profile.cdmProcGlow,
         iconWidth = profile.iconWidth,
@@ -705,7 +734,10 @@ local function ApplyRoute(record)
     container:Show()
 end
 
-function Runs.RefreshTargets(identityChanged)
+function Runs.RefreshTargets(identityChanged, unit)
+    if identityChanged then
+        for _, manager in pairs(auraOverlayManagers) do manager:Refresh(unit) end
+    end
     for owner in pairs(activeOwners) do
         local records = owner._quiCDMAuraRunRecords
         if records then

--- a/QUI_CDM/cdm/cdm_effects.lua
+++ b/QUI_CDM/cdm/cdm_effects.lua
@@ -608,73 +608,101 @@ StopGlow = function(icon, glowKey)
     end
 end
 
-local PANDEMIC_TEXTURE = FLASH_TEXTURE
+local pandemicOwners = setmetatable({}, { __mode = "k" })
+local pandemicStyleRevision = 0
+local emptyPandemicProfile = {}
 
-local function EnsurePandemicGlowFrame(icon)
-    if not icon then return nil end
+local function ResolvePandemicGlowForEntry(entry)
+    local icon = { _spellEntry = entry }
+    local viewerType = GetViewerType(icon)
+    local settings = viewerType and GetViewerSettings(viewerType)
+    if settings then return ApplyGlowColorOverride(settings, GetSpellGlowOverride(icon)) end
+    return { color = { 1, 0.85, 0.2, 1 } }
+end
+
+local function StylePandemicGlow(icon, entry)
+    local runs = ns.CDMCustomAuraRuns
+    if not runs then return nil end
     local frame = icon.PandemicGlow
-    if frame then return frame end
-
-    local template = icon._quiLayoutRestricted and "DisableUntrustedLayoutScriptsTemplate" or nil
-    frame = CreateFrame("Frame", nil, icon, template)
-    frame:SetAllPoints(icon)
-    frame:SetAlpha(0)
-
-    local tex = frame:CreateTexture(nil, "OVERLAY")
-    tex:SetTexture(PANDEMIC_TEXTURE)
-    tex:SetTexCoord(0, 1, 0, 1)
-    tex:SetBlendMode("ADD")
-    tex:SetAllPoints(frame)
-    tex:SetVertexColor(1, 0.85, 0.2, 1)
-    frame.texture = tex
-
-    icon.PandemicGlow = frame
-    EnsureGlowBelowSwipe(icon, frame)
+    if not frame then
+        local template = icon._quiLayoutRestricted and "DisableUntrustedLayoutScriptsTemplate" or nil
+        frame = CreateFrame("Frame", nil, icon, template)
+        frame:SetAllPoints(icon)
+        frame:SetAlpha(0)
+        icon.PandemicGlow = frame
+        EnsureGlowBelowSwipe(icon, frame)
+    end
+    local width, height = icon:GetSize()
+    if _issecretvalue(width) then width = nil end
+    if _issecretvalue(height) then height = nil end
+    local profile = frame._quiPandemicProfile
+    if profile and profile.entry == entry and profile.viewerType == entry.viewerType
+        and profile.spellID == (entry.spellID or entry.id)
+        and profile.revision == pandemicStyleRevision
+        and profile.iconWidth == width and profile.iconHeight == height then
+        return frame
+    end
+    local glow = ResolvePandemicGlowForEntry(entry)
+    profile = profile or {}
+    profile.entry, profile.viewerType, profile.spellID = entry, entry.viewerType, entry.spellID or entry.id
+    profile.revision = pandemicStyleRevision
+    profile.cdmActiveGlow = glow.glowType and glow or nil
+    profile.iconWidth, profile.iconHeight = width, height
+    frame._quiPandemicProfile = profile
+    runs.StyleNativeEffects(frame, profile, "_quiPandemicEffects")
+    if not glow.glowType and not frame.texture then
+        local texture = frame:CreateTexture(nil, "OVERLAY")
+        texture:SetTexture(FLASH_TEXTURE)
+        texture:SetBlendMode("ADD")
+        texture:SetAllPoints(frame)
+        texture:SetVertexColor(1, 0.85, 0.2, 1)
+        frame.texture = texture
+    end
+    if frame.texture then frame.texture:SetShown(not glow.glowType) end
+    frame._quiPandemicAlphaTarget = glow.glowType and frame._quiCDMNativeEffectHost or frame.texture
+    pandemicOwners[icon] = entry
     return frame
+end
+
+ClearPandemicState = function(icon, preserveOwner)
+    local frame = icon and icon.PandemicGlow
+    if not frame then return end
+    frame:SetAlpha(0)
+    local runs = ns.CDMCustomAuraRuns
+    if runs and frame._quiPandemicProfile then
+        runs.StyleNativeEffects(frame, emptyPandemicProfile, "_quiPandemicEffects")
+    end
+    frame._quiPandemicProfile = nil
+    frame._quiPandemicSuppressed = preserveOwner or nil
+    if not preserveOwner then
+        pandemicOwners[icon] = nil
+        icon._quiNativePandemicActive = nil
+    end
 end
 
 UpdatePandemicGlow = function(icon)
     if not icon or not icon._spellEntry then return end
-
-    local frame = icon.PandemicGlow
-    local enabled = IsPandemicMirroringEnabled(icon)
-    if not enabled then
-        if frame then frame:SetAlpha(0) end
+    if not IsPandemicMirroringEnabled(icon) or not icon._auraActive or not icon._lastAuraDurObj then
+        ClearPandemicState(icon)
         return
     end
-
-    if not icon._auraActive or not icon._lastAuraDurObj then
-        if frame then frame:SetAlpha(0) end
-        return
-    end
-
     local curve = GetPandemicCurve()
     if not curve then
-        if frame then frame:SetAlpha(0) end
+        ClearPandemicState(icon)
         return
     end
-
-    frame = frame or EnsurePandemicGlowFrame(icon)
+    local frame = StylePandemicGlow(icon, icon._spellEntry)
     if not frame then return end
-
     local durObj = icon._lastAuraDurObj
-
-    if frame.texture
-       and durObj.IsZero
-       and C_CurveUtil and C_CurveUtil.EvaluateColorValueFromBoolean then
-        local isZero = durObj.IsZero(durObj)
-        local gate = C_CurveUtil.EvaluateColorValueFromBoolean(isZero, 0, 1)
-        frame.texture.SetAlpha(frame.texture, gate)
+    local host = frame._quiPandemicAlphaTarget
+    if host then
+        if durObj.IsZero and C_CurveUtil and C_CurveUtil.EvaluateColorValueFromBoolean then
+            host:SetAlpha(C_CurveUtil.EvaluateColorValueFromBoolean(durObj:IsZero(), 0, 1))
+        else
+            host:SetAlpha(1)
+        end
     end
-
     frame:SetAlpha(durObj:EvaluateRemainingPercent(curve))
-end
-
-ClearPandemicState = function(icon)
-    if not icon then return end
-    if icon.PandemicGlow then
-        icon.PandemicGlow:SetAlpha(0)
-    end
 end
 
 local _pandemicEntryProbe = {}
@@ -687,24 +715,17 @@ local function IsPandemicEnabledForEntry(entry)
     return enabled
 end
 
-local function ApplyPandemicToOverlay(overlay)
-    if not overlay then return end
-    local tex = overlay._quiPandemicTex
-    if not tex and overlay.CreateTexture then
-        tex = overlay:CreateTexture(nil, "OVERLAY")
-        tex:SetTexture(PANDEMIC_TEXTURE)
-        tex:SetTexCoord(0, 1, 0, 1)
-        tex:SetBlendMode("ADD")
-        tex:SetAllPoints(overlay)
-        tex:SetVertexColor(1, 0.85, 0.2, 1)
-        overlay._quiPandemicTex = tex
+local function ApplyPandemicToOverlay(overlay, entry)
+    if not overlay or not entry then return end
+    local frame = StylePandemicGlow(overlay, entry)
+    if frame then
+        overlay._quiNativePandemicActive = true
+        frame:SetAlpha(1)
     end
-    if tex then tex:Show() end
 end
 
 local function ClearPandemicFromOverlay(overlay)
-    local tex = overlay and overlay._quiPandemicTex
-    if tex then tex:Hide() end
+    ClearPandemicState(overlay)
 end
 
 local GROW_POP_PEAK     = 1.25
@@ -980,17 +1001,19 @@ local function StopAllTrackedGlows()
     end
     for _, icon in ipairs(toStop) do
         StopGlow(icon)
-        if icon.PandemicGlow then
-            icon.PandemicGlow:SetAlpha(0)
-        end
+        ClearPandemicState(icon)
     end
     wipe(toStop)
     wipe(activeGlowIcons)
     wipe(overlayGlowSpell)
     wipe(overlayGlowBase)
+    if not IsCDMRuntimeEnabled() then
+        for icon in pairs(pandemicOwners) do ClearPandemicState(icon) end
+    end
 end
 
 local function RefreshAllGlows()
+    pandemicStyleRevision = pandemicStyleRevision + 1
     StopAllTrackedGlows()
 
     if not IsCDMRuntimeEnabled() then
@@ -999,9 +1022,21 @@ local function RefreshAllGlows()
 
     RebuildGlowSpellMap()
     ScanAllGlows()
+    for icon, entry in pairs(pandemicOwners) do
+        if IsPandemicEnabledForEntry(entry) then
+            local frame = StylePandemicGlow(icon, entry)
+            if frame and frame._quiPandemicSuppressed and icon._quiNativePandemicActive then
+                frame:SetAlpha(1)
+                frame._quiPandemicSuppressed = nil
+            end
+        else
+            ClearPandemicState(icon, true)
+        end
+    end
 end
 
 local function ResyncAllGlows()
+    pandemicStyleRevision = pandemicStyleRevision + 1
     if not IsCDMRuntimeEnabled() then
         StopAllTrackedGlows()
         return
@@ -1082,6 +1117,7 @@ local function DisableRuntime()
     eventFrame:UnregisterAllEvents()
     eventFrame:SetScript("OnEvent", nil)
     StopAllTrackedGlows()
+    for icon in pairs(pandemicOwners) do ClearPandemicState(icon) end
 end
 
 local _pandemicVisited = {}
@@ -1119,6 +1155,7 @@ ns._OwnedGlows = {
     StartGlow = StartGlow,
     StopGlow = StopGlow,
     ResolveGlowForEntry = ResolveGlowForEntry,
+    ResolvePandemicGlowForEntry = ResolvePandemicGlowForEntry,
     RefreshAllGlows = RefreshAllGlows,
     ResyncAllGlows = ResyncAllGlows,
     RebuildGlowSpellMap = RebuildGlowSpellMap,

--- a/QUI_CDM/cdm/cdm_icon_renderer.lua
+++ b/QUI_CDM/cdm/cdm_icon_renderer.lua
@@ -4293,6 +4293,7 @@ cdEventFrame:RegisterEvent("BAG_UPDATE_DELAYED")
 cdEventFrame:RegisterEvent("ITEM_COUNT_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+cdEventFrame:RegisterEvent("PLAYER_FOCUS_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_SOFT_ENEMY_CHANGED")
 cdEventFrame:RegisterEvent("PLAYER_SOFT_FRIEND_CHANGED")
 cdEventFrame:RegisterUnitEvent("UNIT_FACTION", "target")
@@ -4645,9 +4646,9 @@ do
                 and icon._auraActive == true
                 and icon._auraUnit == "player"
         end,
-        refreshCustomAuraTargets = function(identityChanged)
+        refreshCustomAuraTargets = function(identityChanged, unit)
             if ns.CDMCustomAuraRuns and ns.CDMCustomAuraRuns.RefreshTargets then
-                ns.CDMCustomAuraRuns.RefreshTargets(identityChanged)
+                ns.CDMCustomAuraRuns.RefreshTargets(identityChanged, unit)
             end
         end,
         refreshPendingSecureAttributes = function()

--- a/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
+++ b/QUI_CDM/cdm/cdm_icon_runtime_refresh.lua
@@ -947,8 +947,10 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             callbacks.chargeDebug(nil, "EVENT", event, "target-scope-refresh")
         end
         if callbacks.refreshCustomAuraTargets then
-            callbacks.refreshCustomAuraTargets(event ~= "UNIT_FACTION")
+            callbacks.refreshCustomAuraTargets(event ~= "UNIT_FACTION",
+                event == "PLAYER_FOCUS_CHANGED" and "focus" or "target")
         end
+        if event == "PLAYER_FOCUS_CHANGED" then return end
         if callbacks.updateAllIconRanges then
             setResolveCallerTag("rangeTarget")
             callbacks.updateAllIconRanges()
@@ -1002,7 +1004,7 @@ function CDMIconRuntimeRefresh.Create(callbacks)
             end
             return
         end
-        if event == "PLAYER_TARGET_CHANGED" then
+        if event == "PLAYER_TARGET_CHANGED" or event == "PLAYER_FOCUS_CHANGED" then
             controller:ApplyTargetScope(event)
             return
         end

--- a/QUI_CDM/cdm/cdm_managed_aura_mirrors.lua
+++ b/QUI_CDM/cdm/cdm_managed_aura_mirrors.lua
@@ -330,7 +330,8 @@ function CDMManagedAuraMirrors:PositionOverlay(record, baseIcon, ownerContainer,
     return true
 end
 
-function CDMManagedAuraMirrors:Refresh()
+function CDMManagedAuraMirrors:Refresh(unit)
+    if unit and self._deps.unit ~= unit then return end
     for _, pool in pairs(self._pools) do
         local auraContainer = pool.auraContainer
         if auraContainer and auraContainer.UpdateAllAuras then

--- a/QUI_CDM/cdm/cdm_reanchor_boot.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_boot.lua
@@ -302,9 +302,9 @@ function CDMReanchorBoot.BuildRuntime(env)
             end
             return false
         end,
-        startPandemic = function(overlay)
+        startPandemic = function(overlay, entry)
             local OG = ns._OwnedGlows
-            if OG and OG.ApplyPandemicToOverlay then OG.ApplyPandemicToOverlay(overlay) end
+            if OG and OG.ApplyPandemicToOverlay then OG.ApplyPandemicToOverlay(overlay, entry) end
         end,
         stopPandemic = function(overlay)
             local OG = ns._OwnedGlows

--- a/QUI_CDM/cdm/cdm_reanchor_hooks.lua
+++ b/QUI_CDM/cdm/cdm_reanchor_hooks.lua
@@ -512,7 +512,7 @@ end
 
 local function PandemicLatchKey(entry)
     if not entry then return nil end
-    return entry.spellID or entry.id or entry
+    return tostring(entry.viewerType or "") .. ":" .. tostring(entry.spellID or entry.id or entry)
 end
 
 function CDMReanchorPandemic:_StopFor(frame)
@@ -540,7 +540,7 @@ function CDMReanchorPandemic:_OnShowPandemic(frame)
     if not (self._ensureOverlay and self._startPandemic) then return end
     local overlay = self._ensureOverlay(frame)
     if overlay then
-        self._startPandemic(overlay)
+        self._startPandemic(overlay, entry)
         self._active[frame] = PandemicLatchKey(entry)
     end
 end

--- a/QUI_CDM/cdm/settings/containers_page.lua
+++ b/QUI_CDM/cdm/settings/containers_page.lua
@@ -1909,6 +1909,10 @@ local function RenderEffectsSection(sectionHost, ctx)
         return nil
     end
 
+    local function RefreshGlowEligibility()
+        RefreshGlows(containerKey)
+    end
+
     if containerType == "auraBar" then
         return RenderInfoMessage(
             sectionHost,
@@ -1947,10 +1951,10 @@ local function RenderEffectsSection(sectionHost, ctx)
         local buffSwipeCheckbox = gui:CreateFormCheckbox(card.frame, nil, "showBuffIconSwipe", profile.cooldownSwipe, RefreshSwipe, {
             description = ns.L["Play a swipe animation on buff/debuff icons in this container to represent remaining duration."],
         })
-        local pandemicDebuffCheckbox = gui:CreateFormCheckbox(card.frame, nil, "buffPandemicDebuffEnabled", profile.customGlow, RefreshGlows, {
+        local pandemicDebuffCheckbox = gui:CreateFormCheckbox(card.frame, nil, "buffPandemicDebuffEnabled", profile.customGlow, RefreshGlowEligibility, {
             description = ns.L["Emit a refresh glow during the pandemic window (last ~30% remaining) of harmful auras like DoTs and debuffs."],
         })
-        local pandemicBuffCheckbox = gui:CreateFormCheckbox(card.frame, nil, "buffPandemicBuffEnabled", profile.customGlow, RefreshGlows, {
+        local pandemicBuffCheckbox = gui:CreateFormCheckbox(card.frame, nil, "buffPandemicBuffEnabled", profile.customGlow, RefreshGlowEligibility, {
             description = ns.L["Emit a refresh glow during the pandemic window (last ~30% remaining) of helpful auras like HoTs and self-buffs."],
         })
         card.AddRow(
@@ -2107,9 +2111,6 @@ local function RenderEffectsSection(sectionHost, ctx)
     local glowXOffsetKey = effectsCtx.glowPrefix .. "XOffset"
     local glowYOffsetKey = effectsCtx.glowPrefix .. "YOffset"
     local glowWidgets = {}
-    local function RefreshGlowEligibility()
-        RefreshGlows(containerKey)
-    end
     local function UpdateGlowWidgetStates()
         local enabled = effectsCtx.glowDB[glowEnabledKey] ~= false
         local glowType = effectsCtx.glowDB[glowTypeKey] or "Pixel Glow"
@@ -2150,12 +2151,12 @@ local function RenderEffectsSection(sectionHost, ctx)
         glowWidgets.pandemicBuffRow
     )
     local glowTypeDropdown = gui:CreateFormDropdown(glowCard.frame, nil, GLOW_TYPE_OPTIONS, glowTypeKey, effectsCtx.glowDB, function()
-        RefreshGlows()
+        RefreshGlowEligibility()
         UpdateGlowWidgetStates()
     end, {
         description = ns.L["Which LibCustomGlow style to render. Pixel/Autocast support line count and thickness; Button/Flash/Hammer ignore those controls."],
     })
-    local glowColorPicker = gui:CreateFormColorPicker(glowCard.frame, nil, glowColorKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowColorPicker = gui:CreateFormColorPicker(glowCard.frame, nil, glowColorKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["Color used for the custom glow effect."],
     })
     glowWidgets.typeRow = optionsAPI.BuildSettingRow(glowCard.frame, ns.L["Glow Type"], glowTypeDropdown)
@@ -2164,10 +2165,10 @@ local function RenderEffectsSection(sectionHost, ctx)
         glowWidgets.typeRow,
         glowWidgets.colorRow
     )
-    local glowLinesSlider = gui:CreateFormSlider(glowCard.frame, nil, 1, 30, 1, glowLinesKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowLinesSlider = gui:CreateFormSlider(glowCard.frame, nil, 1, 30, 1, glowLinesKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["Number of glow particles/lines. Only used by Pixel Glow and Autocast Shine."],
     })
-    local glowThicknessSlider = gui:CreateFormSlider(glowCard.frame, nil, 1, 10, 1, glowThicknessKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowThicknessSlider = gui:CreateFormSlider(glowCard.frame, nil, 1, 10, 1, glowThicknessKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["Thickness of each glow line. Only used by Pixel Glow."],
     })
     glowWidgets.linesRow = optionsAPI.BuildSettingRow(glowCard.frame, ns.L["Lines"], glowLinesSlider)
@@ -2176,10 +2177,10 @@ local function RenderEffectsSection(sectionHost, ctx)
         glowWidgets.linesRow,
         glowWidgets.thicknessRow
     )
-    local glowScaleSlider = gui:CreateFormSlider(glowCard.frame, nil, 0.5, 3.0, 0.1, glowScaleKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowScaleSlider = gui:CreateFormSlider(glowCard.frame, nil, 0.5, 3.0, 0.1, glowScaleKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["Size multiplier for the Autocast Shine glow."],
     })
-    local glowFrequencySlider = gui:CreateFormSlider(glowCard.frame, nil, 0.1, 2.0, 0.05, glowFrequencyKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowFrequencySlider = gui:CreateFormSlider(glowCard.frame, nil, 0.1, 2.0, 0.05, glowFrequencyKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["How fast the glow animates. Higher values rotate/pulse faster."],
     })
     glowWidgets.scaleRow = optionsAPI.BuildSettingRow(glowCard.frame, ns.L["Shine Scale"], glowScaleSlider)
@@ -2188,10 +2189,10 @@ local function RenderEffectsSection(sectionHost, ctx)
         glowWidgets.scaleRow,
         glowWidgets.frequencyRow
     )
-    local glowXOffsetSlider = gui:CreateFormSlider(glowCard.frame, nil, -20, 20, 1, glowXOffsetKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowXOffsetSlider = gui:CreateFormSlider(glowCard.frame, nil, -20, 20, 1, glowXOffsetKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["Horizontal pixel offset for the glow effect. Ignored by Button Glow and texture glows."],
     })
-    local glowYOffsetSlider = gui:CreateFormSlider(glowCard.frame, nil, -20, 20, 1, glowYOffsetKey, effectsCtx.glowDB, RefreshGlows, nil, {
+    local glowYOffsetSlider = gui:CreateFormSlider(glowCard.frame, nil, -20, 20, 1, glowYOffsetKey, effectsCtx.glowDB, RefreshGlowEligibility, nil, {
         description = ns.L["Vertical pixel offset for the glow effect. Ignored by Button Glow and texture glows."],
     })
     glowWidgets.xOffsetRow = optionsAPI.BuildSettingRow(glowCard.frame, ns.L["X Offset"], glowXOffsetSlider)

--- a/QUI_Chat/chat/message_format.lua
+++ b/QUI_Chat/chat/message_format.lua
@@ -737,7 +737,10 @@ local function BuildSecretSenderLink(typeKey, p)
     local guidSecret = IsSecret(guid)
     if not guidSecret and not guid then guid = p.guid end
     if not IsSecret(p.text) and not guidSecret and not guid then return nil end
-    local shown = string.format("[%s]", p.rawSender)
+    local mode = ShowRealmNames()
+        and (typeKey == "GUILD" and "guild" or "none")
+        or "short"
+    local shown = string.format("[%s]", _G.Ambiguate(p.rawSender, mode))
     shown = ColorizeSenderName(guid, p.sender, shown)
     return string.format("|Hplayer:%s|h%s|h", p.rawSender, shown)
 end

--- a/QUI_UnitFrames/unitframes/unitframe_auras.lua
+++ b/QUI_UnitFrames/unitframes/unitframe_auras.lua
@@ -147,6 +147,9 @@ QUI_UF.ApplyContainerConfig = ApplyContainerConfig
 
 local function UpdateAuras(frame)
     if not frame or not QUI_UF.GetFrameUnit(frame) then return end
+    for _, container in ipairs(frame._quiAuraContainers or {}) do
+        container:UpdateAllAuras()
+    end
     if InCombatLockdown() then
         local ok = ns.SafeCall("best-effort-style", ApplyElementPass, frame, true)
         if not ok then

--- a/core/aura_skin.lua
+++ b/core/aura_skin.lua
@@ -384,7 +384,7 @@ local function styleButton(button, profile)
     local pandemic = button._quiPandemic
     if pandemic then
         local glow = profile.pandemicGlow
-        if type(glow) == "table" and type(glow.color) == "table" then
+        if type(glow) == "table" and not glow.glowType and type(glow.color) == "table" then
             local c = glow.color
             if pandemic.SetVertexColor then pandemic:SetVertexColor(c[1] or 1, c[2] or 0.85, c[3] or 0.2, 1) end
             if pandemic.SetAlpha then pandemic:SetAlpha(c[4] or 1) end


### PR DESCRIPTION
Refresh native aura caches when target or focus identity changes so CDM mirrors and unit frames replace stale auras. Preserve focus-only refresh behavior without unrelated target range work.

Apply configured pandemic glow styles, colors, and offsets across native and reanchored CDM icons; refresh the affected container when glow settings change. Reuse unchanged pandemic styling during aura events, invalidate it for settings, entry, or size changes, and restore a disabled native glow when re-enabled within the same pandemic window. Restricted chat sender names now honor the realm-name setting while retaining the full clickable player identity.

Validation: all nine local gates passed, including 959 standalone unit files, strict taint analysis, Lua 5.1 compilation, lint, and generated-file checks. Regression tests landed in zol-wow/QUI-tests#178 and zol-wow/QUI-tests#179 and are pinned through the tests submodule. Live gameplay validation remains outstanding.
