### PR TITLE
release: v5.3.1-beta9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to QUI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v5.3.1-beta9 - 2026-09-12
+
+> ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and
+> will not load on the 12.0.x client.
+
+### Fixed
+
+- **Cooldown Manager buff rows avoid duplicate aura icons** during combat and
+  stay centered as the number of visible native and custom auras changes.
+- **Target and focus auras refresh when you switch units**, including built-in
+  and custom Cooldown Manager tracking.
+- **Pandemic glows follow the selected style and settings**, including changes
+  made during an active pandemic window.
+- **Chat sender names honor the realm-name setting** when WoW restricts sender
+  information.
+
 ## v5.3.1-beta8 - 2026-09-12
 
 > ⚠️ **WoW 12.1 ONLY.** This build targets patch 12.1 (interface 120100) and

--- a/QUI.toc
+++ b/QUI.toc
@@ -6,7 +6,7 @@
 ## AddonCompartmentFuncOnLeave: QUI_CompartmentOnLeave
 ## Notes: Comprehensive UI customization addon
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## SavedVariables: QUIDB, QUI_StorageDB
 ## LoadSavedVariablesFirst: 1

--- a/QUI_ActionBars/QUI_ActionBars.toc
+++ b/QUI_ActionBars/QUI_ActionBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Action Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Bags/QUI_Bags.toc
+++ b/QUI_Bags/QUI_Bags.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Bags
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_CDM/QUI_CDM.toc
+++ b/QUI_CDM/QUI_CDM.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Cooldown Manager
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Chat/QUI_Chat.toc
+++ b/QUI_Chat/QUI_Chat.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Chat
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_DamageMeter/QUI_DamageMeter.toc
+++ b/QUI_DamageMeter/QUI_DamageMeter.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Damage Meter
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_GroupFrames/QUI_GroupFrames.toc
+++ b/QUI_GroupFrames/QUI_GroupFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Group Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Nameplates/QUI_Nameplates.toc
+++ b/QUI_Nameplates/QUI_Nameplates.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Nameplates
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_Options/QUI_Options.toc
+++ b/QUI_Options/QUI_Options.toc
@@ -3,7 +3,7 @@
 ## IconTexture: Interface\AddOns\QUI\assets\QUI
 ## Notes: Configuration UI for QUI
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## RequiredDeps: QUI

--- a/QUI_Reminders/QUI_Reminders.toc
+++ b/QUI_Reminders/QUI_Reminders.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Reminders
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_ResourceBars/QUI_ResourceBars.toc
+++ b/QUI_ResourceBars/QUI_ResourceBars.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Resource Bars
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI

--- a/QUI_UnitFrames/QUI_UnitFrames.toc
+++ b/QUI_UnitFrames/QUI_UnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFQUI|r Unit Frames
 ## Notes: QUI module. Requires the QUI core addon.
 ## Author: Zol and Drew
-## Version: 5.3.1-beta8
+## Version: 5.3.1-beta9
 ## Category: User Interface
 ## Group: QUI
 ## Dependencies: QUI


### PR DESCRIPTION
Prepare v5.3.1-beta9 with consistent versions across all 12 shipped TOCs, release notes for the latest aura and chat fixes, and the landed beta9 documentation from QUI-docs #60.

Validation: all nine local gates passed, including 959 unit files; generators produced no shipped drift. The exact committed tree is also verified in an isolated checkout with both pinned sidecars. Independent release metadata review found no blockers; the workflow notes extractor selects the beta9 section.
